### PR TITLE
feat(cli): add assessment CLI commands and output formatters

### DIFF
--- a/src/cli/commands/assess.test.ts
+++ b/src/cli/commands/assess.test.ts
@@ -1,0 +1,87 @@
+/**
+ * CLI Assess Commands - Unit tests for command structure and parsing
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createAssessCommands } from '../index.js';
+
+describe('createAssessCommands', () => {
+  it('returns Command instance named assess', () => {
+    const assessCmd = createAssessCommands();
+    expect(assessCmd).toBeTruthy();
+    expect(assessCmd.name()).toBe('assess');
+  });
+
+  it('has correct description', () => {
+    const assessCmd = createAssessCommands();
+    expect(assessCmd.description()).toContain('Well-Architected');
+    expect(assessCmd.description()).toContain('assessment');
+  });
+
+  it('has run subcommand', () => {
+    const assessCmd = createAssessCommands();
+    const runCmd = assessCmd.commands.find((c) => c.name() === 'run');
+    expect(runCmd).toBeTruthy();
+    expect(runCmd?.description()).toContain('Run');
+  });
+
+  it('has list subcommand', () => {
+    const assessCmd = createAssessCommands();
+    const listCmd = assessCmd.commands.find((c) => c.name() === 'list');
+    expect(listCmd).toBeTruthy();
+    expect(listCmd?.description()).toContain('List');
+  });
+
+  it('has get subcommand', () => {
+    const assessCmd = createAssessCommands();
+    const getCmd = assessCmd.commands.find((c) => c.name() === 'get');
+    expect(getCmd).toBeTruthy();
+    expect(getCmd?.description()).toContain('Get');
+  });
+
+  it('has summary subcommand', () => {
+    const assessCmd = createAssessCommands();
+    const summaryCmd = assessCmd.commands.find((c) => c.name() === 'summary');
+    expect(summaryCmd).toBeTruthy();
+    expect(summaryCmd?.description()).toContain('summary');
+  });
+
+  it('has history subcommand', () => {
+    const assessCmd = createAssessCommands();
+    const historyCmd = assessCmd.commands.find((c) => c.name() === 'history');
+    expect(historyCmd).toBeTruthy();
+    expect(historyCmd?.description()).toContain('history');
+  });
+
+  it('run command has expected options', () => {
+    const assessCmd = createAssessCommands();
+    const runCmd = assessCmd.commands.find((c) => c.name() === 'run');
+    expect(runCmd).toBeTruthy();
+    const optionNames = runCmd!.options.map((o) => o.long);
+    expect(optionNames).toContain('--mode');
+    expect(optionNames).toContain('--pillar');
+    expect(optionNames).toContain('--check-id');
+    expect(optionNames).toContain('--format');
+  });
+
+  it('list command has filter options', () => {
+    const assessCmd = createAssessCommands();
+    const listCmd = assessCmd.commands.find((c) => c.name() === 'list');
+    expect(listCmd).toBeTruthy();
+    const optionNames = listCmd!.options.map((o) => o.long);
+    expect(optionNames).toContain('--state');
+    expect(optionNames).toContain('--limit');
+    expect(optionNames).toContain('--since');
+  });
+
+  it('history command has filter options', () => {
+    const assessCmd = createAssessCommands();
+    const historyCmd = assessCmd.commands.find((c) => c.name() === 'history');
+    expect(historyCmd).toBeTruthy();
+    const optionNames = historyCmd!.options.map((o) => o.long);
+    expect(optionNames).toContain('--pillar');
+    expect(optionNames).toContain('--result');
+    expect(optionNames).toContain('--limit');
+    expect(optionNames).toContain('--since');
+  });
+});

--- a/src/cli/commands/assess.ts
+++ b/src/cli/commands/assess.ts
@@ -1,0 +1,367 @@
+/**
+ * CLI Assessment Commands - Well-Architected Framework assessment operations
+ */
+
+import { z } from 'zod';
+import { DatabaseManager } from '../../database/manager.js';
+import { SchemaManager } from '../../database/schema.js';
+import { AssessmentRepository } from '../../database/assessment-repository.js';
+import type { AssessmentFilters, AssessmentQueryOptions } from '../../database/assessment-repository.js';
+import type { AssessmentHistoryRow } from '../../database/assessment-repository.js';
+import { formatOutput } from '../formatters.js';
+import { AssessmentRunner } from '../../assessment/runner.js';
+import { bootstrapAssessmentRegistry } from '../../assessment/bootstrap.js';
+import { AssessmentRunMode, Pillar, PILLAR_VALUES } from '../../assessment/types.js';
+import { kubernetesClient } from '../../kubernetes/client.js';
+import { loadConfig, setConfig } from '../../config/loader.js';
+import { logger } from '../../logging/logger.js';
+
+const PILLAR_OPTIONS = PILLAR_VALUES.join(', ');
+
+const ListOptionsSchema = z.object({
+  state: z.enum(['queued', 'running', 'completed', 'failed', 'partial']).optional(),
+  limit: z
+    .string()
+    .default('50')
+    .transform(Number)
+    .pipe(z.number().int().positive().max(1000)),
+  since: z.string().datetime().optional(),
+  format: z.enum(['json', 'yaml', 'table', 'compact']).default('json'),
+});
+
+const GetOptionsSchema = z.object({
+  format: z.enum(['json', 'yaml', 'table', 'compact']).default('json'),
+});
+
+const SummaryOptionsSchema = z.object({
+  since: z.string().datetime().optional(),
+  limit: z
+    .string()
+    .default('50')
+    .transform(Number)
+    .pipe(z.number().int().positive().max(100)),
+  format: z.enum(['json', 'yaml', 'table', 'compact']).default('json'),
+});
+
+const HistoryOptionsSchema = z.object({
+  pillar: z.enum(PILLAR_VALUES as [string, ...string[]]).optional(),
+  result: z.enum(['passing', 'failing', 'warning', 'skipped', 'error', 'timeout']).optional(),
+  severity: z.enum(['critical', 'high', 'medium', 'low', 'info']).optional(),
+  limit: z
+    .string()
+    .default('100')
+    .transform(Number)
+    .pipe(z.number().int().positive().max(1000)),
+  since: z.string().datetime().optional(),
+  format: z.enum(['json', 'yaml', 'table', 'compact']).default('json'),
+});
+
+const RunOptionsSchema = z.object({
+  mode: z.enum(['full', 'pillar', 'single-check']).default('full'),
+  pillar: z.string().optional(),
+  checkId: z.string().optional(),
+  timeoutMs: z
+    .string()
+    .default('30000')
+    .transform(Number)
+    .pipe(z.number().int().positive().max(300000)),
+  format: z.enum(['json', 'yaml', 'table', 'compact']).default('json'),
+});
+
+function writeError(message: string, details?: string) {
+  const err = details ? { error: message, details } : { error: message };
+  console.error(JSON.stringify(err));
+  process.exit(1);
+}
+
+function ensureDb() {
+  DatabaseManager.getInstance();
+  const schema = new SchemaManager();
+  schema.initialize();
+}
+
+function toApiRecord(record: {
+  run_id: string;
+  mode: string;
+  state: string;
+  requested_at: string;
+  started_at?: string | null;
+  completed_at?: string | null;
+  total_checks: number;
+  completed_checks: number;
+  passed_checks: number;
+  failed_checks: number;
+  warning_checks: number;
+  skipped_checks: number;
+  error_checks: number;
+  timeout_checks: number;
+  failure_reason?: string | null;
+}) {
+  return {
+    run_id: record.run_id,
+    mode: record.mode,
+    state: record.state,
+    requested_at: record.requested_at,
+    started_at: record.started_at ?? undefined,
+    completed_at: record.completed_at ?? undefined,
+    total_checks: record.total_checks,
+    completed_checks: record.completed_checks,
+    passed_checks: record.passed_checks,
+    failed_checks: record.failed_checks,
+    warning_checks: record.warning_checks,
+    skipped_checks: record.skipped_checks,
+    error_checks: record.error_checks,
+    timeout_checks: record.timeout_checks,
+    failure_reason: record.failure_reason ?? undefined,
+  };
+}
+
+function toApiHistoryRow(row: AssessmentHistoryRow) {
+  return {
+    id: row.id,
+    run_id: row.run_id,
+    check_id: row.check_id,
+    pillar: row.pillar,
+    check_name: row.check_name ?? undefined,
+    status: row.status,
+    message: row.message ?? undefined,
+    remediation: row.remediation ?? undefined,
+    assessed_at: row.assessed_at,
+    duration_ms: row.duration_ms ?? undefined,
+    error_code: row.error_code ?? undefined,
+  };
+}
+
+export async function assessRun(options: Record<string, unknown>) {
+  try {
+    const validated = RunOptionsSchema.parse(options);
+
+    if (validated.mode === 'pillar' && !validated.pillar) {
+      writeError('--pillar is required when --mode is pillar', `Valid pillars: ${PILLAR_OPTIONS}`);
+    }
+    if (validated.mode === 'single-check' && !validated.checkId) {
+      writeError('--check-id is required when --mode is single-check');
+    }
+    if (validated.pillar && !PILLAR_VALUES.includes(validated.pillar)) {
+      writeError('Invalid pillar', `Valid pillars: ${PILLAR_OPTIONS}`);
+    }
+
+    ensureDb();
+    bootstrapAssessmentRegistry();
+
+    if (!process.env.SERVER_URL) {
+      process.env.SERVER_URL = 'https://api.kube9.io';
+    }
+    const config = await loadConfig();
+    setConfig(config);
+
+    const runner = new AssessmentRunner({
+      kubernetes: kubernetesClient,
+      config,
+      logger,
+    });
+
+    const mode = validated.mode as AssessmentRunMode;
+    const input = {
+      mode,
+      pillarFilter: validated.pillar ? (validated.pillar as Pillar) : undefined,
+      checkIdFilter: validated.checkId,
+      timeoutMs: validated.timeoutMs,
+    };
+
+    const record = await runner.run(input);
+    const apiRecord = toApiRecord(record);
+
+    const output = formatOutput(apiRecord, validated.format);
+    console.log(output);
+    process.exit(0);
+  } catch (err: unknown) {
+    if (err instanceof z.ZodError) {
+      const first = err.errors[0];
+      const path = first.path.join('.');
+      writeError(
+        'Invalid arguments',
+        path ? `${path}: ${first.message}` : first.message
+      );
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    writeError('Failed to run assessment', msg);
+  }
+}
+
+export async function assessList(options: Record<string, unknown>) {
+  try {
+    const validated = ListOptionsSchema.parse(options);
+    ensureDb();
+
+    const filters: AssessmentFilters = {
+      state: validated.state,
+      since: validated.since,
+    };
+
+    const opts: AssessmentQueryOptions = {
+      filters,
+      limit: validated.limit,
+      offset: 0,
+    };
+
+    const repo = new AssessmentRepository();
+    const assessments = repo.queryAssessments(opts);
+    const total = repo.countAssessments(filters);
+
+    const result = {
+      assessments: assessments.map(toApiRecord),
+      pagination: {
+        total,
+        limit: validated.limit,
+        offset: 0,
+        returned: assessments.length,
+      },
+    };
+
+    const output = formatOutput(result, validated.format);
+    console.log(output);
+    process.exit(0);
+  } catch (err: unknown) {
+    if (err instanceof z.ZodError) {
+      const first = err.errors[0];
+      const path = first.path.join('.');
+      writeError(
+        'Invalid arguments',
+        path ? `${path}: ${first.message}` : first.message
+      );
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    writeError('Failed to list assessments', msg);
+  }
+}
+
+export async function assessGet(assessmentId: string, options: Record<string, unknown>) {
+  try {
+    if (!assessmentId || assessmentId.trim() === '') {
+      writeError('Assessment ID is required');
+    }
+
+    const validated = GetOptionsSchema.parse(options);
+    ensureDb();
+
+    const repo = new AssessmentRepository();
+    const record = repo.getAssessmentById(assessmentId.trim());
+    if (!record) {
+      writeError('Assessment not found', `run_id: ${assessmentId}`);
+    }
+    const apiRecord = toApiRecord(record!);
+    const output = formatOutput(apiRecord, validated.format);
+    console.log(output);
+    process.exit(0);
+  } catch (err: unknown) {
+    if (err instanceof z.ZodError) {
+      const first = err.errors[0];
+      writeError('Invalid arguments', first.message);
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    writeError('Failed to get assessment', msg);
+  }
+}
+
+export async function assessSummary(options: Record<string, unknown>) {
+  try {
+    const validated = SummaryOptionsSchema.parse(options);
+    ensureDb();
+
+    const filters: AssessmentFilters = { since: validated.since };
+    const repo = new AssessmentRepository();
+    const assessments = repo.queryAssessments({
+      filters,
+      limit: validated.limit,
+      offset: 0,
+    });
+
+    const total = repo.countAssessments(filters);
+
+    const summary = {
+      total_runs: total,
+      recent_runs: assessments.length,
+      by_state: {} as Record<string, number>,
+      by_mode: {} as Record<string, number>,
+      totals: {
+        passed_checks: 0,
+        failed_checks: 0,
+        warning_checks: 0,
+        skipped_checks: 0,
+        error_checks: 0,
+        timeout_checks: 0,
+      },
+    };
+
+    for (const a of assessments) {
+      summary.by_state[a.state] = (summary.by_state[a.state] ?? 0) + 1;
+      summary.by_mode[a.mode] = (summary.by_mode[a.mode] ?? 0) + 1;
+      summary.totals.passed_checks += a.passed_checks;
+      summary.totals.failed_checks += a.failed_checks;
+      summary.totals.warning_checks += a.warning_checks;
+      summary.totals.skipped_checks += a.skipped_checks;
+      summary.totals.error_checks += a.error_checks;
+      summary.totals.timeout_checks += a.timeout_checks;
+    }
+
+    const output = formatOutput(summary, validated.format);
+    console.log(output);
+    process.exit(0);
+  } catch (err: unknown) {
+    if (err instanceof z.ZodError) {
+      const first = err.errors[0];
+      writeError('Invalid arguments', first.message);
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    writeError('Failed to get assessment summary', msg);
+  }
+}
+
+export async function assessHistory(options: Record<string, unknown>) {
+  try {
+    const validated = HistoryOptionsSchema.parse(options);
+    ensureDb();
+
+    const filters: AssessmentFilters = {
+      pillar: validated.pillar,
+      status: validated.result,
+      since: validated.since,
+    };
+
+    const opts: AssessmentQueryOptions = {
+      filters,
+      limit: validated.limit,
+      offset: 0,
+    };
+
+    const repo = new AssessmentRepository();
+    const history = repo.queryHistory(opts);
+    const total = repo.countHistory(filters);
+
+    const result = {
+      history: history.map(toApiHistoryRow),
+      pagination: {
+        total,
+        limit: validated.limit,
+        offset: 0,
+        returned: history.length,
+      },
+    };
+
+    const output = formatOutput(result, validated.format);
+    console.log(output);
+    process.exit(0);
+  } catch (err: unknown) {
+    if (err instanceof z.ZodError) {
+      const first = err.errors[0];
+      const path = first.path.join('.');
+      writeError(
+        'Invalid arguments',
+        path ? `${path}: ${first.message}` : first.message
+      );
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    writeError('Failed to list assessment history', msg);
+  }
+}

--- a/src/cli/formatters.test.ts
+++ b/src/cli/formatters.test.ts
@@ -137,8 +137,92 @@ describe('formatOutput', () => {
     const yaml = await import('js-yaml');
     const data = { key: 'value', number: 123 };
     const result = formatOutput(data, 'yaml');
-    
+
     const parsed = yaml.load(result);
     expect(parsed).toEqual(data);
+  });
+
+  it('formats assessments list as table', () => {
+    const data = {
+      assessments: [
+        {
+          run_id: 'run-1',
+          mode: 'full',
+          state: 'completed',
+          total_checks: 10,
+          passed_checks: 8,
+          failed_checks: 2,
+          requested_at: '2025-01-01T10:00:00Z',
+        },
+      ],
+    };
+
+    const result = formatOutput(data, 'table');
+
+    expect(result).toContain('RUN_ID');
+    expect(result).toContain('MODE');
+    expect(result).toContain('STATE');
+    expect(result).toContain('run-1');
+    expect(result).toContain('full');
+    expect(result).toContain('completed');
+  });
+
+  it('formats assessment history as table', () => {
+    const data = {
+      history: [
+        {
+          id: 'hist-1',
+          run_id: 'run-1',
+          check_id: 'security.pod-security',
+          pillar: 'security',
+          status: 'passing',
+          assessed_at: '2025-01-01T10:00:00Z',
+        },
+      ],
+    };
+
+    const result = formatOutput(data, 'table');
+
+    expect(result).toContain('CHECK_ID');
+    expect(result).toContain('PILLAR');
+    expect(result).toContain('STATUS');
+    expect(result).toContain('security');
+    expect(result).toContain('passing');
+  });
+
+  it('supports compact format', () => {
+    const data = {
+      assessments: [
+        {
+          run_id: 'run-1',
+          mode: 'full',
+          state: 'completed',
+          total_checks: 5,
+          passed_checks: 5,
+          failed_checks: 0,
+          requested_at: '2025-01-01T10:00:00Z',
+        },
+      ],
+    };
+
+    const result = formatOutput(data, 'compact');
+
+    expect(result).toContain('RUN_ID');
+    expect(result).toContain('run-1');
+    expect(result).toContain('completed');
+  });
+
+  it('handles empty assessments array', () => {
+    const data = { assessments: [] };
+    const result = formatOutput(data, 'table');
+
+    expect(result).toBe('No results found');
+  });
+
+  it('handles empty history array', () => {
+    const data = { history: [] };
+    const result = formatOutput(data, 'table');
+
+    expect(result).toBe('No results found');
   });
 });

--- a/src/cli/formatters.ts
+++ b/src/cli/formatters.ts
@@ -8,67 +8,103 @@ export function formatOutput(data: any, format: string): string {
   switch (format) {
     case 'json':
       return JSON.stringify(data, null, 2);
-    
+
     case 'yaml':
       return yaml.dump(data, { indent: 2, lineWidth: 120 });
-    
+
     case 'table':
-      return formatTable(data);
-    
+    case 'compact':
+      return formatTable(data, format);
+
     default:
       throw new Error(`Unsupported format: ${format}`);
   }
 }
 
-function formatTable(data: any): string {
+function formatTable(data: any, format: string = 'table'): string {
+  const isCompact = format === 'compact';
+
   // Handle events list
   if (data.events && Array.isArray(data.events)) {
     const headers = ['ID', 'TYPE', 'SEVERITY', 'TITLE', 'CREATED'];
     const rows = data.events.map((event: any) => [
-      truncate(event.id, 28),
+      truncate(event.id, isCompact ? 20 : 28),
       event.event_type,
       event.severity,
-      truncate(event.title, 40),
+      truncate(event.title, isCompact ? 30 : 40),
       formatDate(event.created_at),
     ]);
-    
-    return renderTable(headers, rows);
+    return renderTable(headers, rows, isCompact);
   }
-  
-  // Handle single event or status
+
+  // Handle assessments list
+  if (data.assessments && Array.isArray(data.assessments)) {
+    const headers = ['RUN_ID', 'MODE', 'STATE', 'TOTAL', 'PASSED', 'FAILED', 'REQUESTED'];
+    const rows = data.assessments.map((a: any) => [
+      truncate(a.run_id, isCompact ? 20 : 36),
+      a.mode,
+      a.state,
+      String(a.total_checks),
+      String(a.passed_checks),
+      String(a.failed_checks),
+      formatDate(a.requested_at),
+    ]);
+    return renderTable(headers, rows, isCompact);
+  }
+
+  // Handle assessment history list
+  if (data.history && Array.isArray(data.history)) {
+    const headers = ['ID', 'RUN_ID', 'CHECK_ID', 'PILLAR', 'STATUS', 'ASSESSED'];
+    const rows = data.history.map((h: any) => [
+      truncate(h.id, isCompact ? 24 : 36),
+      truncate(h.run_id, isCompact ? 20 : 36),
+      truncate(h.check_id, isCompact ? 24 : 40),
+      h.pillar,
+      h.status,
+      formatDate(h.assessed_at),
+    ]);
+    return renderTable(headers, rows, isCompact);
+  }
+
+  // Handle single event, status, or assessment record
   if (typeof data === 'object' && !Array.isArray(data)) {
     return renderKeyValueTable(data);
   }
-  
+
   // Fallback to JSON
   return JSON.stringify(data, null, 2);
 }
 
-function renderTable(headers: string[], rows: string[][]): string {
+function renderTable(headers: string[], rows: string[][], compact: boolean = false): string {
   if (rows.length === 0) {
     return 'No results found';
   }
-  
-  // Calculate column widths
-  const columnWidths = headers.map((h, i) => 
-    Math.max(h.length, ...rows.map(r => r[i]?.length || 0))
-  );
-  
+
+  // Calculate column widths (cap in compact mode)
+  const columnWidths = headers.map((h, i) => {
+    const max = Math.max(h.length, ...rows.map(r => r[i]?.length || 0));
+    return compact ? Math.min(max, 24) : max;
+  });
+
   // Format header row
   const headerRow = headers
-    .map((h, i) => h.padEnd(columnWidths[i]))
-    .join('  ');
-  
+    .map((h, i) => truncate(h, columnWidths[i]).padEnd(columnWidths[i]))
+    .join(compact ? ' ' : '  ');
+
   // Format separator
   const separator = columnWidths
     .map(w => '-'.repeat(w))
-    .join('--');
-  
+    .join(compact ? '-' : '--');
+
   // Format data rows
   const dataRows = rows
-    .map(row => row.map((cell, i) => cell.padEnd(columnWidths[i])).join('  '))
+    .map(row =>
+      row
+        .map((cell, i) => truncate(String(cell), columnWidths[i]).padEnd(columnWidths[i]))
+        .join(compact ? ' ' : '  ')
+    )
     .join('\n');
-  
+
   return `${headerRow}\n${separator}\n${dataRows}`;
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,72 @@
 import { Command } from 'commander';
 import { queryStatus } from './commands/status.js';
 import { listEvents, getEvent } from './commands/events.js';
+import {
+  assessRun,
+  assessList,
+  assessGet,
+  assessSummary,
+  assessHistory,
+} from './commands/assess.js';
+
+/**
+ * Create the assess command structure
+ */
+export function createAssessCommands(): Command {
+  const assess = new Command('assess')
+    .description('Well-Architected Framework assessment commands');
+
+  // assess run
+  assess
+    .command('run')
+    .description('Run an assessment')
+    .option('--mode <mode>', 'Run mode: full, pillar, single-check', 'full')
+    .option('--pillar <pillar>', 'Pillar filter (required when mode=pillar)')
+    .option('--check-id <id>', 'Check ID filter (required when mode=single-check)')
+    .option('--timeout-ms <ms>', 'Per-check timeout in milliseconds', '30000')
+    .option('--format <format>', 'Output format (json|yaml|table|compact)', 'json')
+    .action(assessRun);
+
+  // assess list
+  assess
+    .command('list')
+    .description('List assessment runs')
+    .option('--state <state>', 'Filter by state: queued, running, completed, failed, partial')
+    .option('--limit <number>', 'Limit number of results', '50')
+    .option('--since <date>', 'Filter since date (ISO 8601)')
+    .option('--format <format>', 'Output format (json|yaml|table|compact)', 'json')
+    .action(assessList);
+
+  // assess get
+  assess
+    .command('get <assessmentId>')
+    .description('Get single assessment by run ID')
+    .option('--format <format>', 'Output format (json|yaml|table|compact)', 'json')
+    .action(assessGet);
+
+  // assess summary
+  assess
+    .command('summary')
+    .description('Get assessment summary')
+    .option('--since <date>', 'Filter since date (ISO 8601)')
+    .option('--limit <number>', 'Number of recent runs to aggregate', '50')
+    .option('--format <format>', 'Output format (json|yaml|table|compact)', 'json')
+    .action(assessSummary);
+
+  // assess history
+  assess
+    .command('history')
+    .description('List assessment check history')
+    .option('--pillar <pillar>', 'Filter by pillar')
+    .option('--result <result>', `Filter by result: passing, failing, warning, skipped, error, timeout`)
+    .option('--severity <severity>', 'Filter by severity')
+    .option('--limit <number>', 'Limit number of results', '100')
+    .option('--since <date>', 'Filter since date (ISO 8601)')
+    .option('--format <format>', 'Output format (json|yaml|table|compact)', 'json')
+    .action(assessHistory);
+
+  return assess;
+}
 
 /**
  * Create the query command structure

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { program } from 'commander';
-import { createQueryCommands } from './cli/index.js';
+import { createQueryCommands, createAssessCommands } from './cli/index.js';
 import { getConfig } from './config/loader.js';
 import type { Config } from './config/types.js';
 
@@ -24,8 +24,11 @@ program
     await startOperator();
   });
 
-// Query command - CLI queries (subcommands added in later stories)
+// Query command - CLI queries
 program.addCommand(createQueryCommands());
+
+// Assess command - Well-Architected Framework assessment
+program.addCommand(createAssessCommands());
 
 program.parse(process.argv);
 


### PR DESCRIPTION
## Summary

Adds the `assess` CLI command group for Well-Architected Framework assessment operations.

## Changes

- Add assess command group with run, list, get, summary, history subcommands
- Implement filter flags (state, pillar, result, limit, since)
- Add table, compact, and JSON output formatters for assessments
- Add command validation and actionable error messages
- Add unit tests for command structure and output rendering

## Commits

- `feat(cli): add assessment CLI commands and output formatters`

Closes #36

Made with [Cursor](https://cursor.com)