### PR TITLE
test(cli): add severity filter option to history command test

### DIFF
--- a/src/cli/commands/assess.test.ts
+++ b/src/cli/commands/assess.test.ts
@@ -81,6 +81,7 @@ describe('createAssessCommands', () => {
     const optionNames = historyCmd!.options.map((o) => o.long);
     expect(optionNames).toContain('--pillar');
     expect(optionNames).toContain('--result');
+    expect(optionNames).toContain('--severity');
     expect(optionNames).toContain('--limit');
     expect(optionNames).toContain('--since');
   });


### PR DESCRIPTION
## Summary

Adds test coverage for the `--severity` filter option on the `assess history` command.

## Changes

- **test(cli)**: add severity filter option to history command test

Ensures the `assess history` command exposes the `--severity` flag as specified in issue #36 (filter flags: pillar, result, severity, limit, since).

## Related

- Closes #36
- Parent: #14

Made with [Cursor](https://cursor.com)