### PR TITLE
feat(config): add Prometheus endpoint override configuration

### DIFF
--- a/.forge/runtime/configuration.md
+++ b/.forge/runtime/configuration.md
@@ -3,12 +3,15 @@
 ## Environment Variables
 - **POD_NAMESPACE**: Operator namespace (from downward API)
 - **LOG_LEVEL**: debug, info, warn, error
+- **PROMETHEUS_PORT**: Port for health server and metrics (default: 8080)
+- **PROMETHEUS_METRICS_PATH**: Path for Prometheus metrics endpoint (default: /metrics)
 
 ## Helm Values
 - image, resources, logLevel
 - statusUpdateIntervalSeconds (60)
 - events.retention, argocd.namespace
-- argocd.endpointOverride, prometheus.endpointOverride (M1)
+- argocd.endpointOverride
+- prometheus.port (default: 8080), prometheus.metricsPath (default: /metrics)
 
 ## In-Cluster Config
 - Service account token for Kubernetes API

--- a/charts/kube9-operator/README.md
+++ b/charts/kube9-operator/README.md
@@ -108,6 +108,8 @@ The following table lists the configurable parameters and their default values:
 | `statusUpdateIntervalSeconds` | How often the operator updates the status ConfigMap (in seconds) | `60` |
 | `reregistrationIntervalHours` | How often the operator re-registers with kube9-server (in hours, Pro tier only) | `24` |
 | `serverUrl` | URL of the kube9-server API (Pro tier only) | `"https://api.kube9.dev"` |
+| `prometheus.port` | Port for Prometheus metrics and health endpoints (default: 8080) | `8080` |
+| `prometheus.metricsPath` | Path for Prometheus metrics scrape endpoint | `"/metrics"` |
 
 ### Configuration Details
 
@@ -164,6 +166,15 @@ The operator uses Guaranteed QoS for stable performance:
 
 - **reregistrationIntervalHours**: How often to re-register with kube9-server (default: 24 hours)
 - **serverUrl**: The kube9-server API endpoint (default: https://api.kube9.dev)
+
+#### Prometheus Metrics (`prometheus.*`)
+
+Override the default `:8080/metrics` endpoint when deploying in non-standard environments (e.g. custom ports, proxies, or different scrape paths):
+
+- **port**: Port for the health server (liveness, readiness, metrics). Default: 8080.
+- **metricsPath**: Path for the Prometheus metrics endpoint. Default: `/metrics`.
+
+The operator adds `prometheus.io/scrape`, `prometheus.io/port`, and `prometheus.io/path` annotations to the pod for auto-discovery.
 
 ## Examples
 
@@ -396,6 +407,8 @@ Complete reference of all configurable values:
 | `statusUpdateIntervalSeconds` | Status ConfigMap update interval (seconds) | `60` |
 | `reregistrationIntervalHours` | Re-registration interval with kube9-server (hours, Pro tier) | `24` |
 | `serverUrl` | kube9-server API URL (Pro tier) | `"https://api.kube9.dev"` |
+| `prometheus.port` | Port for Prometheus metrics and health endpoints | `8080` |
+| `prometheus.metricsPath` | Path for Prometheus metrics scrape endpoint | `"/metrics"` |
 
 ## Additional Resources
 

--- a/charts/kube9-operator/templates/deployment.yaml
+++ b/charts/kube9-operator/templates/deployment.yaml
@@ -14,6 +14,10 @@ spec:
       {{- include "kube9-operator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.prometheus.port | default 8080 | quote }}
+        prometheus.io/path: {{ .Values.prometheus.metricsPath | default "/metrics" | quote }}
       labels:
         {{- include "kube9-operator.selectorLabels" . | nindent 8 }}
     spec:
@@ -74,20 +78,25 @@ spec:
           value: {{ .Values.events.retention.infoWarning | default 7 | quote }}
         - name: EVENT_RETENTION_ERROR_CRITICAL_DAYS
           value: {{ .Values.events.retention.errorCritical | default 30 | quote }}
+        # Prometheus metrics endpoint configuration
+        - name: PROMETHEUS_PORT
+          value: {{ .Values.prometheus.port | default 8080 | quote }}
+        - name: PROMETHEUS_METRICS_PATH
+          value: {{ .Values.prometheus.metricsPath | default "/metrics" | quote }}
         ports:
         - name: http
-          containerPort: 8080
+          containerPort: {{ .Values.prometheus.port | default 8080 }}
           protocol: TCP
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8080
+            port: {{ .Values.prometheus.port | default 8080 }}
           initialDelaySeconds: 30
           periodSeconds: 10
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 8080
+            port: {{ .Values.prometheus.port | default 8080 }}
           initialDelaySeconds: 10
           periodSeconds: 5
         resources:

--- a/charts/kube9-operator/values.yaml
+++ b/charts/kube9-operator/values.yaml
@@ -36,6 +36,12 @@ reregistrationIntervalHours: 24
 # kube9-server URL (for pro tier)
 serverUrl: "https://api.kube9.io"
 
+# Prometheus metrics endpoint configuration
+# Override when the default :8080/metrics is not suitable (e.g. custom ports, proxies)
+prometheus:
+  port: 8080
+  metricsPath: "/metrics"
+
 # ArgoCD integration configuration
 argocd:
   # Enable automatic ArgoCD detection (default: true)

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { loadConfig } from './loader.js';
+
+describe('loadConfig', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.SERVER_URL = 'https://api.kube9.dev';
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('loads default prometheus port and path when not overridden', async () => {
+    delete process.env.PROMETHEUS_PORT;
+    delete process.env.PROMETHEUS_METRICS_PATH;
+
+    const config = await loadConfig();
+
+    expect(config.prometheus).toEqual({
+      port: 8080,
+      metricsPath: '/metrics',
+    });
+  });
+
+  it('loads PROMETHEUS_PORT override from environment', async () => {
+    process.env.PROMETHEUS_PORT = '9090';
+
+    const config = await loadConfig();
+
+    expect(config.prometheus.port).toBe(9090);
+    expect(config.prometheus.metricsPath).toBe('/metrics');
+  });
+
+  it('loads PROMETHEUS_METRICS_PATH override from environment', async () => {
+    process.env.PROMETHEUS_METRICS_PATH = '/custom-metrics';
+
+    const config = await loadConfig();
+
+    expect(config.prometheus.port).toBe(8080);
+    expect(config.prometheus.metricsPath).toBe('/custom-metrics');
+  });
+
+  it('loads both PROMETHEUS_PORT and PROMETHEUS_METRICS_PATH overrides', async () => {
+    process.env.PROMETHEUS_PORT = '9090';
+    process.env.PROMETHEUS_METRICS_PATH = '/custom-metrics';
+
+    const config = await loadConfig();
+
+    expect(config.prometheus).toEqual({
+      port: 9090,
+      metricsPath: '/custom-metrics',
+    });
+  });
+});

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -39,6 +39,9 @@ export async function loadConfig(): Promise<Config> {
     process.env.EVENT_RETENTION_ERROR_CRITICAL_DAYS || '30',
     10
   );
+  const prometheusPort = parseInt(process.env.PROMETHEUS_PORT || '8080', 10);
+  const prometheusMetricsPath =
+    process.env.PROMETHEUS_METRICS_PATH || '/metrics';
 
   // Validate required environment variables
   if (!serverUrl) {
@@ -55,6 +58,10 @@ export async function loadConfig(): Promise<Config> {
     resourceConfigurationPatternsIntervalSeconds,
     eventRetentionInfoWarningDays,
     eventRetentionErrorCriticalDays,
+    prometheus: {
+      port: prometheusPort,
+      metricsPath: prometheusMetricsPath,
+    },
   };
 
   // Log configured intervals (and any overrides)

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -51,5 +51,14 @@ export interface Config {
    * Default: 30 days
    */
   eventRetentionErrorCriticalDays: number;
+
+  /**
+   * Prometheus metrics endpoint configuration
+   * Default: port 8080, path /metrics
+   */
+  prometheus: {
+    port: number;
+    metricsPath: string;
+  };
 }
 

--- a/src/health/server.ts
+++ b/src/health/server.ts
@@ -9,18 +9,35 @@ import { logger } from '../logging/logger.js';
 let server: ReturnType<Express['listen']> | null = null;
 
 /**
+ * Options for the health server
+ */
+export interface HealthServerOptions {
+  /** Port number to listen on (default: 8080) */
+  port: number;
+  /** Path for Prometheus metrics endpoint (default: /metrics) */
+  metricsPath?: string;
+}
+
+/**
  * Start the health check HTTP server
- * 
+ *
  * Sets up Express server with /healthz (liveness) and /readyz (readiness) endpoints.
  * Server starts listening without blocking the main thread.
- * 
- * @param port - Port number to listen on (default: 8080)
+ *
+ * @param portOrOptions - Port number (default: 8080) or options object
  */
-export function startHealthServer(port: number = 8080): void {
+export function startHealthServer(portOrOptions: number | HealthServerOptions = 8080): void {
   if (server !== null) {
     logger.warn('Health server is already running');
     return;
   }
+
+  const port =
+    typeof portOrOptions === 'number' ? portOrOptions : portOrOptions.port;
+  const metricsPath =
+    typeof portOrOptions === 'object' && portOrOptions.metricsPath
+      ? portOrOptions.metricsPath
+      : '/metrics';
 
   const app = express();
 
@@ -55,7 +72,7 @@ export function startHealthServer(port: number = 8080): void {
   });
 
   // Prometheus metrics endpoint
-  app.get('/metrics', async (req, res) => {
+  app.get(metricsPath, async (req, res) => {
     try {
       const metrics = await getMetrics();
       res.set('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -124,7 +124,10 @@ export async function startOperator() {
     const config = await initializeConfig();
     
     // Start health server early so probes are available during initialization
-    startHealthServer(8080);
+    startHealthServer({
+      port: config.prometheus.port,
+      metricsPath: config.prometheus.metricsPath,
+    });
     
     // Initialize database schema for events
     logger.info('Initializing database schema...');

--- a/src/registration/manager.test.ts
+++ b/src/registration/manager.test.ts
@@ -23,6 +23,7 @@ function createMockConfig(): Config {
     resourceConfigurationPatternsIntervalSeconds: 43200,
     eventRetentionInfoWarningDays: 7,
     eventRetentionErrorCriticalDays: 30,
+    prometheus: { port: 8080, metricsPath: '/metrics' },
   };
 }
 


### PR DESCRIPTION
## Summary

Implements [issue #63](https://github.com/alto9/kube9-operator/issues/63): Add Prometheus Endpoint Override Configuration.

## Changes

### Config & Loader
- **Config types** (`src/config/types.ts`): Added `prometheus.port` and `prometheus.metricsPath` to `Config` interface
- **Config loader** (`src/config/loader.ts`): Reads `PROMETHEUS_PORT` and `PROMETHEUS_METRICS_PATH` from environment; defaults: port 8080, path `/metrics`

### Health Server
- **Health server** (`src/health/server.ts`): Accepts `HealthServerOptions` with `port` and `metricsPath`; mounts metrics at configurable path
- **Operator** (`src/operator.ts`): Passes `config.prometheus` to `startHealthServer`

### Helm
- **values.yaml**: Added `prometheus` section with `port` (default 8080) and `metricsPath` (default `/metrics`)
- **deployment.yaml**: 
  - Env vars: `PROMETHEUS_PORT`, `PROMETHEUS_METRICS_PATH`
  - Container port and probes use configured port
  - Annotations: `prometheus.io/scrape: "true"`, `prometheus.io/port`, `prometheus.io/path`

### Documentation
- **charts/kube9-operator/README.md**: Added `prometheus.port` and `prometheus.metricsPath` to configuration tables and Prometheus Metrics section
- **.forge/runtime/configuration.md**: Documented env vars and Helm values

### Tests
- **src/config/loader.test.ts**: Unit tests for config loading with default and override values

## Acceptance Criteria

- [x] `prometheus.port` (and optionally `prometheus.metricsPath`) configurable via Helm values and environment variables
- [x] Health server uses configured port; default remains 8080
- [x] Auto-detection (default) works: no override means standard `:8080/metrics`
- [x] Configuration documented in Helm README and Forge runtime docs
- [x] Unit tests cover config loading with override values

## How to Test

```bash
# Unit tests
npm run test:unit

# Manual: custom port
PROMETHEUS_PORT=9090 SERVER_URL=https://api.kube9.io npm run dev
# Verify health server listens on 9090 and /metrics returns Prometheus output

# Helm override
helm install kube9-operator ./charts/kube9-operator --set prometheus.port=9090
# Verify pod annotations and container port match
```

Closes #63