### PR TITLE
feat(argocd): add endpoint override configuration

### DIFF
--- a/.forge/runtime/configuration.md
+++ b/.forge/runtime/configuration.md
@@ -5,12 +5,13 @@
 - **LOG_LEVEL**: debug, info, warn, error
 - **PROMETHEUS_PORT**: Port for health server and metrics (default: 8080)
 - **PROMETHEUS_METRICS_PATH**: Path for Prometheus metrics endpoint (default: /metrics)
+- **ARGOCD_ENDPOINT_OVERRIDE**: Override ArgoCD API endpoint (full URL). When set, used for ArgoCD API access (M9). Detection continues to use namespace/selector for deployment lookup.
 
 ## Helm Values
 - image, resources, logLevel
 - statusUpdateIntervalSeconds (60)
 - events.retention, argocd.namespace
-- argocd.endpointOverride
+- argocd.endpointOverride: Override ArgoCD API endpoint (full URL). When set, used for ArgoCD API access (M9). Detection continues to use namespace/selector for deployment lookup.
 - prometheus.port (default: 8080), prometheus.metricsPath (default: /metrics)
 
 ## In-Cluster Config

--- a/charts/kube9-operator/README.md
+++ b/charts/kube9-operator/README.md
@@ -110,6 +110,11 @@ The following table lists the configurable parameters and their default values:
 | `serverUrl` | URL of the kube9-server API (Pro tier only) | `"https://api.kube9.dev"` |
 | `prometheus.port` | Port for Prometheus metrics and health endpoints (default: 8080) | `8080` |
 | `prometheus.metricsPath` | Path for Prometheus metrics scrape endpoint | `"/metrics"` |
+| `argocd.endpointOverride` | Override ArgoCD API endpoint (full URL). When set, used for ArgoCD API access (M9). Detection continues to use namespace/selector for deployment lookup. | `""` |
+| `argocd.autoDetect` | Enable automatic ArgoCD detection | `true` |
+| `argocd.namespace` | Custom namespace where ArgoCD is installed | `"argocd"` |
+| `argocd.selector` | Custom label selector for ArgoCD server deployment | `"app.kubernetes.io/name=argocd-server"` |
+| `argocd.detectionInterval` | Detection check interval in hours | `6` |
 
 ### Configuration Details
 
@@ -175,6 +180,16 @@ Override the default `:8080/metrics` endpoint when deploying in non-standard env
 - **metricsPath**: Path for the Prometheus metrics endpoint. Default: `/metrics`.
 
 The operator adds `prometheus.io/scrape`, `prometheus.io/port`, and `prometheus.io/path` annotations to the pod for auto-discovery.
+
+#### ArgoCD Configuration (`argocd.*`)
+
+- **endpointOverride**: Override the ArgoCD API endpoint (full URL). Use when ArgoCD is in a non-standard location or behind a custom URL. When set, used for ArgoCD API access (M9); detection continues to use namespace/selector for deployment lookup. Example: `https://argocd-server.my-ns.svc.cluster.local`
+- **autoDetect**: Enable automatic ArgoCD detection (default: true)
+- **namespace**: Custom namespace where ArgoCD is installed (default: argocd)
+- **selector**: Custom label selector for ArgoCD server deployment (default: app.kubernetes.io/name=argocd-server)
+- **detectionInterval**: How often to re-check ArgoCD presence (in hours, default: 6)
+
+Environment variable `ARGOCD_ENDPOINT_OVERRIDE` can be set directly instead of via Helm values.
 
 ## Examples
 
@@ -409,6 +424,11 @@ Complete reference of all configurable values:
 | `serverUrl` | kube9-server API URL (Pro tier) | `"https://api.kube9.dev"` |
 | `prometheus.port` | Port for Prometheus metrics and health endpoints | `8080` |
 | `prometheus.metricsPath` | Path for Prometheus metrics scrape endpoint | `"/metrics"` |
+| `argocd.endpointOverride` | Override ArgoCD API endpoint (full URL) | `""` |
+| `argocd.autoDetect` | Enable automatic ArgoCD detection | `true` |
+| `argocd.namespace` | Custom namespace where ArgoCD is installed | `"argocd"` |
+| `argocd.selector` | Custom label selector for ArgoCD server deployment | `"app.kubernetes.io/name=argocd-server"` |
+| `argocd.detectionInterval` | Detection check interval in hours | `6` |
 
 ## Additional Resources
 

--- a/charts/kube9-operator/templates/deployment.yaml
+++ b/charts/kube9-operator/templates/deployment.yaml
@@ -71,6 +71,10 @@ spec:
         - name: ARGOCD_SELECTOR
           value: {{ .Values.argocd.selector | quote }}
         {{- end }}
+        {{- if .Values.argocd.endpointOverride }}
+        - name: ARGOCD_ENDPOINT_OVERRIDE
+          value: {{ .Values.argocd.endpointOverride | quote }}
+        {{- end }}
         - name: ARGOCD_DETECTION_INTERVAL
           value: {{ .Values.argocd.detectionInterval | default 6 | quote }}
         # Event retention configuration

--- a/charts/kube9-operator/values.yaml
+++ b/charts/kube9-operator/values.yaml
@@ -56,6 +56,11 @@ argocd:
   # Custom label selector for ArgoCD server deployment (optional)
   # selector: "app.kubernetes.io/name=argocd-server"
   
+  # Override ArgoCD API endpoint (full URL). When set, used for ArgoCD API access (M9).
+  # Detection continues to use namespace/selector for deployment lookup.
+  # Example: "https://argocd-server.my-ns.svc.cluster.local"
+  # endpointOverride: ""
+  
   # Detection check interval in hours (default: 6)
   detectionInterval: 6
 

--- a/src/argocd/config.test.ts
+++ b/src/argocd/config.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { parseArgoCDConfig } from './config.js';
+
+describe('parseArgoCDConfig', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns default config when no ArgoCD env vars are set', () => {
+    delete process.env.ARGOCD_AUTO_DETECT;
+    delete process.env.ARGOCD_ENABLED;
+    delete process.env.ARGOCD_NAMESPACE;
+    delete process.env.ARGOCD_SELECTOR;
+    delete process.env.ARGOCD_ENDPOINT_OVERRIDE;
+    delete process.env.ARGOCD_DETECTION_INTERVAL;
+
+    const config = parseArgoCDConfig();
+
+    expect(config.autoDetect).toBe(true);
+    expect(config.enabled).toBeUndefined();
+    expect(config.namespace).toBe('argocd');
+    expect(config.selector).toBe('app.kubernetes.io/name=argocd-server');
+    expect(config.endpointOverride).toBeUndefined();
+    expect(config.detectionInterval).toBe(6);
+  });
+
+  it('parses ARGOCD_ENDPOINT_OVERRIDE from environment', () => {
+    process.env.ARGOCD_ENDPOINT_OVERRIDE =
+      'https://argocd-server.argocd.svc.cluster.local';
+
+    const config = parseArgoCDConfig();
+
+    expect(config.endpointOverride).toBe(
+      'https://argocd-server.argocd.svc.cluster.local'
+    );
+  });
+
+  it('parses ARGOCD_ENDPOINT_OVERRIDE with custom namespace URL', () => {
+    process.env.ARGOCD_ENDPOINT_OVERRIDE =
+      'https://argocd-server.my-ns.svc.cluster.local';
+
+    const config = parseArgoCDConfig();
+
+    expect(config.endpointOverride).toBe(
+      'https://argocd-server.my-ns.svc.cluster.local'
+    );
+  });
+
+  it('parses all ArgoCD env vars including endpoint override', () => {
+    process.env.ARGOCD_AUTO_DETECT = 'false';
+    process.env.ARGOCD_ENABLED = 'true';
+    process.env.ARGOCD_NAMESPACE = 'custom-argocd';
+    process.env.ARGOCD_SELECTOR = 'app=argocd';
+    process.env.ARGOCD_ENDPOINT_OVERRIDE = 'https://custom-argocd.example.com';
+    process.env.ARGOCD_DETECTION_INTERVAL = '12';
+
+    const config = parseArgoCDConfig();
+
+    expect(config.autoDetect).toBe(false);
+    expect(config.enabled).toBe(true);
+    expect(config.namespace).toBe('custom-argocd');
+    expect(config.selector).toBe('app=argocd');
+    expect(config.endpointOverride).toBe('https://custom-argocd.example.com');
+    expect(config.detectionInterval).toBe(12);
+  });
+
+  it('leaves endpointOverride undefined when ARGOCD_ENDPOINT_OVERRIDE is empty', () => {
+    process.env.ARGOCD_ENDPOINT_OVERRIDE = '';
+
+    const config = parseArgoCDConfig();
+
+    expect(config.endpointOverride).toBeUndefined();
+  });
+});

--- a/src/argocd/config.ts
+++ b/src/argocd/config.ts
@@ -1,0 +1,21 @@
+/**
+ * ArgoCD configuration parsing from environment variables
+ */
+
+import type { ArgoCDDetectionConfig } from './detection.js';
+
+/**
+ * Parse ArgoCD configuration from environment variables
+ *
+ * @returns ArgoCDDetectionConfig with values from env
+ */
+export function parseArgoCDConfig(): ArgoCDDetectionConfig {
+  return {
+    autoDetect: process.env.ARGOCD_AUTO_DETECT !== 'false',
+    enabled: process.env.ARGOCD_ENABLED === 'true' ? true : undefined,
+    namespace: process.env.ARGOCD_NAMESPACE || 'argocd',
+    selector: process.env.ARGOCD_SELECTOR || 'app.kubernetes.io/name=argocd-server',
+    endpointOverride: process.env.ARGOCD_ENDPOINT_OVERRIDE || undefined,
+    detectionInterval: parseInt(process.env.ARGOCD_DETECTION_INTERVAL || '6', 10),
+  };
+}

--- a/src/argocd/detection.ts
+++ b/src/argocd/detection.ts
@@ -41,6 +41,14 @@ export interface ArgoCDDetectionConfig {
   selector?: string;
   
   /**
+   * Override the ArgoCD API endpoint (full URL).
+   * When set, used for ArgoCD API access (M9); detection continues to use
+   * namespace and selector for deployment lookup.
+   * Example: https://argocd-server.my-ns.svc.cluster.local
+   */
+  endpointOverride?: string;
+  
+  /**
    * Detection check interval in hours
    * How often to re-check ArgoCD presence
    */

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -17,7 +17,8 @@ import { LocalStorage } from './collection/storage.js';
 import { recordCollection } from './collection/metrics.js';
 import { collectionStatsTracker } from './collection/stats-tracker.js';
 import { logger } from './logging/logger.js';
-import { detectArgoCDWithTimeout, type ArgoCDDetectionConfig } from './argocd/detection.js';
+import { detectArgoCDWithTimeout } from './argocd/detection.js';
+import { parseArgoCDConfig } from './argocd/config.js';
 import { argocdStatusTracker } from './argocd/state.js';
 import { ArgoCDDetectionManager } from './argocd/detection-manager.js';
 import { SchemaManager } from './database/schema.js';
@@ -74,17 +75,6 @@ async function testKubernetesClient() {
       note: 'This is expected if running outside a cluster. The operator will retry when deployed.',
     });
   }
-}
-
-// Parse ArgoCD configuration from environment variables
-function parseArgoCDConfig(): ArgoCDDetectionConfig {
-  return {
-    autoDetect: process.env.ARGOCD_AUTO_DETECT !== 'false',
-    enabled: process.env.ARGOCD_ENABLED === 'true' ? true : undefined,
-    namespace: process.env.ARGOCD_NAMESPACE || 'argocd',
-    selector: process.env.ARGOCD_SELECTOR || 'app.kubernetes.io/name=argocd-server',
-    detectionInterval: parseInt(process.env.ARGOCD_DETECTION_INTERVAL || '6', 10)
-  };
 }
 
 // Perform initial ArgoCD detection during startup


### PR DESCRIPTION
## Summary

Adds ArgoCD endpoint override configuration per #64.

## Changes

- **ArgoCDDetectionConfig** (`src/argocd/detection.ts`): Added optional `endpointOverride?: string` for full URL override (e.g. `https://argocd-server.my-ns.svc.cluster.local`). When set, used for API access (M9); detection continues to use namespace/selector for deployment lookup.
- **Config / env** (`src/argocd/config.ts`): Added `parseArgoCDConfig()` that reads `ARGOCD_ENDPOINT_OVERRIDE` from environment.
- **Helm values** (`charts/kube9-operator/values.yaml`): Added `argocd.endpointOverride` (optional string).
- **Deployment template** (`charts/kube9-operator/templates/deployment.yaml`): Added env var `ARGOCD_ENDPOINT_OVERRIDE` when `argocd.endpointOverride` is set.
- **Documentation**: Updated `charts/kube9-operator/README.md` and `.forge/runtime/configuration.md` with `argocd.endpointOverride` and `ARGOCD_ENDPOINT_OVERRIDE`.
- **Unit tests**: Added `src/argocd/config.test.ts` covering config parsing with override values.

## Acceptance Criteria

- [x] `argocd.endpointOverride` configurable via Helm values and `ARGOCD_ENDPOINT_OVERRIDE` env var
- [x] `ArgoCDDetectionConfig` includes `endpointOverride`; parsed and passed to detection manager
- [x] Auto-detection (default) works: no override means standard namespace-based detection
- [x] Configuration documented in Helm README and Forge runtime docs
- [x] Unit tests cover config parsing with override values

Closes #64