### PR TITLE
feat(security): implement secret management audit checks (#75)

### DIFF
--- a/charts/kube9-operator/templates/clusterrole.yaml
+++ b/charts/kube9-operator/templates/clusterrole.yaml
@@ -11,7 +11,7 @@ rules:
   nonResourceURLs: ["/version"]
 # Read cluster metadata and resources (for data collection: cluster metadata and resource inventory)
 - apiGroups: [""]
-  resources: ["nodes", "namespaces", "pods"]
+  resources: ["nodes", "namespaces", "pods", "configmaps"]
   verbs: ["get", "list", "watch"]
 # Read Kubernetes events (for event monitoring and recording)
 - apiGroups: [""]

--- a/src/assessment/bootstrap.ts
+++ b/src/assessment/bootstrap.ts
@@ -13,6 +13,9 @@ import {
   capabilitiesValidationCheck,
   rbacWildcardPermissionsCheck,
   rbacClusterAdminMisuseCheck,
+  secretsInConfigMapsCheck,
+  externalSecretsUsageCheck,
+  hardcodedSecretsCheck,
 } from './checks/security/index.js';
 
 /** Built-in checks to register at bootstrap (extend as checks are implemented) */
@@ -22,6 +25,9 @@ const BUILT_IN_CHECKS: AssessmentCheck[] = [
   capabilitiesValidationCheck,
   rbacWildcardPermissionsCheck,
   rbacClusterAdminMisuseCheck,
+  secretsInConfigMapsCheck,
+  externalSecretsUsageCheck,
+  hardcodedSecretsCheck,
 ];
 
 /**

--- a/src/assessment/checks/security/external-secrets-usage.test.ts
+++ b/src/assessment/checks/security/external-secrets-usage.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { externalSecretsUsageCheck } from './external-secrets-usage.js';
+import { Pillar, CheckStatus } from '../../types.js';
+import type { AssessmentRunContext } from '../../types.js';
+
+function createMockContext(overrides: Partial<{
+  readCustomResourceDefinition: (opts: { name: string }) => Promise<unknown>;
+}>): AssessmentRunContext {
+  return {
+    kubernetes: {
+      apiextensionsApi: {
+        readCustomResourceDefinition:
+          overrides.readCustomResourceDefinition ??
+          vi.fn().mockResolvedValue({ metadata: { name: 'externalsecrets.external-secrets.io' } }),
+      },
+    } as never,
+    config: {} as never,
+    timeoutMs: 30000,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+    runId: 'test',
+    mode: 'full' as never,
+  };
+}
+
+describe('externalSecretsUsageCheck', () => {
+  it('has correct metadata', () => {
+    expect(externalSecretsUsageCheck.id).toBe('security.external-secrets-usage');
+    expect(externalSecretsUsageCheck.name).toBe('External Secrets Usage');
+    expect(externalSecretsUsageCheck.pillar).toBe(Pillar.Security);
+  });
+
+  it('returns Passing when ExternalSecret CRD exists', async () => {
+    const ctx = createMockContext({
+      readCustomResourceDefinition: async () => ({ metadata: { name: 'externalsecrets.external-secrets.io' } }),
+    });
+
+    const result = await externalSecretsUsageCheck.run(ctx);
+    expect(result.status).toBe(CheckStatus.Passing);
+    expect(result.message).toContain('external-secrets operator is installed');
+  });
+
+  it('returns Warning when ExternalSecret CRD does not exist (404)', async () => {
+    const err = new Error('Not Found');
+    (err as { response?: { statusCode?: number } }).response = { statusCode: 404 };
+
+    const ctx = createMockContext({
+      readCustomResourceDefinition: async () => {
+        throw err;
+      },
+    });
+
+    const result = await externalSecretsUsageCheck.run(ctx);
+    expect(result.status).toBe(CheckStatus.Warning);
+    expect(result.message).toContain('external-secrets operator not detected');
+  });
+
+  it('throws when CRD read fails with non-404', async () => {
+    const ctx = createMockContext({
+      readCustomResourceDefinition: async () => {
+        throw new Error('Server error');
+      },
+    });
+
+    await expect(externalSecretsUsageCheck.run(ctx)).rejects.toThrow('Server error');
+  });
+});

--- a/src/assessment/checks/security/external-secrets-usage.ts
+++ b/src/assessment/checks/security/external-secrets-usage.ts
@@ -1,0 +1,54 @@
+/**
+ * Security check: Detect external-secrets operator usage.
+ *
+ * external-secrets provides secure secret management from external stores
+ * (Vault, AWS Secrets Manager, etc.). This check verifies the operator is
+ * installed by detecting the ExternalSecret CRD.
+ */
+
+import type { AssessmentCheck, AssessmentRunContext, AssessmentCheckResult } from '../../types.js';
+import { Pillar, CheckStatus, Severity } from '../../types.js';
+
+const EXTERNAL_SECRETS_CRD = 'externalsecrets.external-secrets.io';
+const REMEDIATION =
+  'Consider installing external-secrets operator for secure secret management from Vault, AWS Secrets Manager, etc.';
+
+export const externalSecretsUsageCheck: AssessmentCheck = {
+  id: 'security.external-secrets-usage',
+  name: 'External Secrets Usage',
+  pillar: Pillar.Security,
+  description: 'Detects whether external-secrets operator is installed for secret management',
+  defaultSeverity: Severity.Medium,
+
+  async run(ctx: AssessmentRunContext): Promise<AssessmentCheckResult> {
+    try {
+      await ctx.kubernetes.apiextensionsApi.readCustomResourceDefinition({
+        name: EXTERNAL_SECRETS_CRD,
+      });
+
+      return {
+        checkId: 'security.external-secrets-usage',
+        checkName: 'External Secrets Usage',
+        pillar: Pillar.Security,
+        status: CheckStatus.Passing,
+        message: 'external-secrets operator is installed (ExternalSecret CRD detected).',
+        remediation: REMEDIATION,
+      };
+    } catch (err: unknown) {
+      const statusCode = (err as { response?: { statusCode?: number } })?.response?.statusCode;
+      if (statusCode === 404) {
+        return {
+          checkId: 'security.external-secrets-usage',
+          checkName: 'External Secrets Usage',
+          pillar: Pillar.Security,
+          status: CheckStatus.Warning,
+          severity: Severity.Medium,
+          message:
+            'external-secrets operator not detected. Consider using it for secure secret management.',
+          remediation: REMEDIATION,
+        };
+      }
+      throw err;
+    }
+  },
+};

--- a/src/assessment/checks/security/hardcoded-secrets.test.ts
+++ b/src/assessment/checks/security/hardcoded-secrets.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from 'vitest';
+import { hardcodedSecretsCheck } from './hardcoded-secrets.js';
+import { Pillar, CheckStatus } from '../../types.js';
+import type { AssessmentRunContext } from '../../types.js';
+
+function createMockContext(overrides: Partial<{
+  listDeploymentForAllNamespaces: () => Promise<unknown>;
+  listStatefulSetForAllNamespaces: () => Promise<unknown>;
+}>): AssessmentRunContext {
+  return {
+    kubernetes: {
+      appsApi: {
+        listDeploymentForAllNamespaces:
+          overrides.listDeploymentForAllNamespaces ?? vi.fn().mockResolvedValue({ items: [] }),
+        listStatefulSetForAllNamespaces:
+          overrides.listStatefulSetForAllNamespaces ?? vi.fn().mockResolvedValue({ items: [] }),
+      },
+    } as never,
+    config: {} as never,
+    timeoutMs: 30000,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+    runId: 'test',
+    mode: 'full' as never,
+  };
+}
+
+describe('hardcodedSecretsCheck', () => {
+  it('has correct metadata', () => {
+    expect(hardcodedSecretsCheck.id).toBe('security.hardcoded-secrets');
+    expect(hardcodedSecretsCheck.name).toBe('Hardcoded Secrets in Workloads');
+    expect(hardcodedSecretsCheck.pillar).toBe(Pillar.Security);
+  });
+
+  it('returns Passing when no workloads have hardcoded secrets', async () => {
+    const ctx = createMockContext({
+      listDeploymentForAllNamespaces: async () => ({
+        items: [
+          {
+            metadata: { namespace: 'default', name: 'app' },
+            spec: {
+              template: {
+                spec: {
+                  containers: [
+                    {
+                      name: 'app',
+                      env: [
+                        { name: 'HOST', value: 'localhost' },
+                        { name: 'password', value: 'changeme' },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      }),
+      listStatefulSetForAllNamespaces: async () => ({ items: [] }),
+    });
+
+    const result = await hardcodedSecretsCheck.run(ctx);
+    expect(result.status).toBe(CheckStatus.Passing);
+  });
+
+  it('returns Failing when Deployment has hardcoded secret in env', async () => {
+    const ctx = createMockContext({
+      listDeploymentForAllNamespaces: async () => ({
+        items: [
+          {
+            metadata: { namespace: 'prod', name: 'api' },
+            spec: {
+              template: {
+                spec: {
+                  containers: [
+                    {
+                      name: 'api',
+                      env: [
+                        { name: 'API_TOKEN', value: 'sk-abc123xyz456789' },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      }),
+      listStatefulSetForAllNamespaces: async () => ({ items: [] }),
+    });
+
+    const result = await hardcodedSecretsCheck.run(ctx);
+    expect(result.status).toBe(CheckStatus.Failing);
+    expect(result.message).toContain('prod/api');
+    expect(result.remediation).toBeDefined();
+  });
+
+  it('returns Passing when env uses valueFrom (secretKeyRef)', async () => {
+    const ctx = createMockContext({
+      listDeploymentForAllNamespaces: async () => ({
+        items: [
+          {
+            metadata: { namespace: 'default', name: 'app' },
+            spec: {
+              template: {
+                spec: {
+                  containers: [
+                    {
+                      name: 'app',
+                      env: [
+                        {
+                          name: 'PASSWORD',
+                          valueFrom: { secretKeyRef: { name: 'db-secret', key: 'password' } },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      }),
+      listStatefulSetForAllNamespaces: async () => ({ items: [] }),
+    });
+
+    const result = await hardcodedSecretsCheck.run(ctx);
+    expect(result.status).toBe(CheckStatus.Passing);
+  });
+});

--- a/src/assessment/checks/security/hardcoded-secrets.ts
+++ b/src/assessment/checks/security/hardcoded-secrets.ts
@@ -1,0 +1,101 @@
+/**
+ * Security check: Detect hardcoded secrets in workload env vars.
+ *
+ * Scans Deployments and StatefulSets for env vars with `value:` (not valueFrom)
+ * that look like secrets (e.g. password=..., token=...).
+ */
+
+import type { V1Deployment, V1StatefulSet, V1EnvVar } from '@kubernetes/client-node';
+import type { AssessmentCheck, AssessmentRunContext, AssessmentCheckResult } from '../../types.js';
+import { Pillar, CheckStatus, Severity } from '../../types.js';
+import { looksLikeHardcodedSecret } from './heuristics.js';
+
+const REMEDIATION =
+  'Use Secrets, external-secrets, or valueFrom.secretKeyRef instead of hardcoded env values.';
+
+function getItems<T>(response: { body?: { items?: T[] }; items?: T[] }): T[] {
+  return response.body?.items ?? response.items ?? [];
+}
+
+interface Violation {
+  namespace: string;
+  workload: string;
+  kind: string;
+  container: string;
+}
+
+function scanWorkloadEnv(
+  workload: { metadata?: { namespace?: string; name?: string }; spec?: { template?: { spec?: { containers?: Array<{ name?: string; env?: V1EnvVar[] }> } } } },
+  kind: string,
+  violations: Violation[]
+): void {
+  const ns = workload.metadata?.namespace ?? 'default';
+  const name = workload.metadata?.name ?? 'unknown';
+  const containers = workload.spec?.template?.spec?.containers ?? [];
+
+  for (const container of containers) {
+    const containerName = container.name ?? 'unknown';
+    const envVars = container.env ?? [];
+
+    for (const env of envVars) {
+      if (env.value !== undefined && env.value !== null && env.name) {
+        if (looksLikeHardcodedSecret(env.name, String(env.value))) {
+          violations.push({ namespace: ns, workload: name, kind, container: containerName });
+          break; // One violation per container is enough
+        }
+      }
+    }
+  }
+}
+
+export const hardcodedSecretsCheck: AssessmentCheck = {
+  id: 'security.hardcoded-secrets',
+  name: 'Hardcoded Secrets in Workloads',
+  pillar: Pillar.Security,
+  description: 'Detects hardcoded secrets in Deployment/StatefulSet env vars',
+  defaultSeverity: Severity.High,
+
+  async run(ctx: AssessmentRunContext): Promise<AssessmentCheckResult> {
+    const violations: Violation[] = [];
+
+    const deploymentResponse = await ctx.kubernetes.appsApi.listDeploymentForAllNamespaces();
+    const deployments = getItems<V1Deployment>(deploymentResponse as { body?: { items?: V1Deployment[] }; items?: V1Deployment[] });
+
+    for (const d of deployments) {
+      scanWorkloadEnv(d, 'Deployment', violations);
+    }
+
+    const statefulSetResponse = await ctx.kubernetes.appsApi.listStatefulSetForAllNamespaces();
+    const statefulSets = getItems<V1StatefulSet>(statefulSetResponse as { body?: { items?: V1StatefulSet[] }; items?: V1StatefulSet[] });
+
+    for (const s of statefulSets) {
+      scanWorkloadEnv(s, 'StatefulSet', violations);
+    }
+
+    if (violations.length > 0) {
+      const summary = violations
+        .map((v) => `${v.namespace}/${v.workload} (${v.container})`)
+        .join(', ');
+
+      return {
+        checkId: 'security.hardcoded-secrets',
+        checkName: 'Hardcoded Secrets in Workloads',
+        pillar: Pillar.Security,
+        status: CheckStatus.Failing,
+        severity: Severity.High,
+        objectKind: 'Deployment',
+        message: `Found ${violations.length} workload(s) with likely hardcoded secrets: ${summary}`,
+        remediation: REMEDIATION,
+      };
+    }
+
+    return {
+      checkId: 'security.hardcoded-secrets',
+      checkName: 'Hardcoded Secrets in Workloads',
+      pillar: Pillar.Security,
+      status: CheckStatus.Passing,
+      message: 'No hardcoded secrets detected in workload env vars.',
+      remediation: REMEDIATION,
+    };
+  },
+};

--- a/src/assessment/checks/security/heuristics.test.ts
+++ b/src/assessment/checks/security/heuristics.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isSensitiveKey,
+  isPlaceholderValue,
+  looksLikeSecretValue,
+  base64LooksLikeSecret,
+  looksLikeHardcodedSecret,
+} from './heuristics.js';
+
+describe('heuristics', () => {
+  describe('isSensitiveKey', () => {
+    it('returns true for password', () => {
+      expect(isSensitiveKey('password')).toBe(true);
+      expect(isSensitiveKey('PASSWORD')).toBe(true);
+      expect(isSensitiveKey('db_password')).toBe(true);
+    });
+
+    it('returns true for token', () => {
+      expect(isSensitiveKey('token')).toBe(true);
+      expect(isSensitiveKey('API_TOKEN')).toBe(true);
+    });
+
+    it('returns true for api_key, credentials, etc.', () => {
+      expect(isSensitiveKey('api_key')).toBe(true);
+      expect(isSensitiveKey('credentials')).toBe(true);
+      expect(isSensitiveKey('private_key')).toBe(true);
+    });
+
+    it('returns false for non-sensitive keys', () => {
+      expect(isSensitiveKey('host')).toBe(false);
+      expect(isSensitiveKey('port')).toBe(false);
+      expect(isSensitiveKey('database')).toBe(false);
+    });
+  });
+
+  describe('isPlaceholderValue', () => {
+    it('returns true for common placeholders', () => {
+      expect(isPlaceholderValue('changeme')).toBe(true);
+      expect(isPlaceholderValue('placeholder')).toBe(true);
+      expect(isPlaceholderValue('xxx')).toBe(true);
+      expect(isPlaceholderValue('your-secret-here')).toBe(true);
+      expect(isPlaceholderValue('')).toBe(true);
+    });
+
+    it('returns false for non-placeholder values', () => {
+      expect(isPlaceholderValue('myActualSecret123')).toBe(false);
+      expect(isPlaceholderValue('sk-abc123xyz')).toBe(false);
+    });
+  });
+
+  describe('looksLikeSecretValue', () => {
+    it('returns false for short or empty values', () => {
+      expect(looksLikeSecretValue('')).toBe(false);
+      expect(looksLikeSecretValue('abc')).toBe(false);
+    });
+
+    it('returns false for placeholders', () => {
+      expect(looksLikeSecretValue('changeme')).toBe(false);
+      expect(looksLikeSecretValue('placeholder')).toBe(false);
+    });
+
+    it('returns true for non-placeholder values', () => {
+      expect(looksLikeSecretValue('mySecretValue123')).toBe(true);
+    });
+  });
+
+  describe('base64LooksLikeSecret', () => {
+    it('returns false for placeholder base64', () => {
+      expect(base64LooksLikeSecret(Buffer.from('changeme', 'utf-8').toString('base64'))).toBe(false);
+    });
+
+    it('returns true for non-placeholder base64', () => {
+      expect(base64LooksLikeSecret(Buffer.from('realSecret123', 'utf-8').toString('base64'))).toBe(true);
+    });
+  });
+
+  describe('looksLikeHardcodedSecret', () => {
+    it('returns true for sensitive key with non-placeholder value', () => {
+      expect(looksLikeHardcodedSecret('password', 'mySecurePass123')).toBe(true);
+      expect(looksLikeHardcodedSecret('API_TOKEN', 'sk-abc123xyz456')).toBe(true);
+    });
+
+    it('returns false for sensitive key with placeholder', () => {
+      expect(looksLikeHardcodedSecret('password', 'changeme')).toBe(false);
+    });
+
+    it('returns false for short values', () => {
+      expect(looksLikeHardcodedSecret('password', 'short')).toBe(false);
+    });
+
+    it('returns false for non-sensitive key', () => {
+      expect(looksLikeHardcodedSecret('HOST', 'mySecurePass123')).toBe(false);
+    });
+  });
+});

--- a/src/assessment/checks/security/heuristics.ts
+++ b/src/assessment/checks/security/heuristics.ts
@@ -1,0 +1,118 @@
+/**
+ * Secret detection heuristics for security audit checks.
+ *
+ * Used by secrets-in-configmaps, hardcoded-secrets, and related checks.
+ * Avoids false positives by excluding common placeholder values.
+ */
+
+/** Case-insensitive key patterns that suggest sensitive data */
+const SENSITIVE_KEY_PATTERNS = [
+  'password',
+  'passwd',
+  'token',
+  'secret',
+  'api_key',
+  'apikey',
+  'auth',
+  'credentials',
+  'private_key',
+  'privatekey',
+] as const;
+
+/** Placeholder values that should NOT be flagged as secrets (avoid false positives) */
+const PLACEHOLDER_VALUES = new Set([
+  '',
+  'changeme',
+  'change_me',
+  'change-me',
+  'placeholder',
+  'xxx',
+  'yyy',
+  'secret',
+  '<secret>',
+  'your-secret-here',
+  'your_password_here',
+  'replace-me',
+  'replace_me',
+  'tbd',
+  'todo',
+  'none',
+  'null',
+  'test',
+  'dummy',
+  'sample',
+  'example',
+  'default',
+]);
+
+/**
+ * Check if a key name suggests sensitive data (case-insensitive).
+ */
+export function isSensitiveKey(key: string): boolean {
+  const lower = key.toLowerCase();
+  return SENSITIVE_KEY_PATTERNS.some((pattern) => lower.includes(pattern));
+}
+
+/**
+ * Check if a value is a known placeholder (should not be flagged as secret).
+ */
+export function isPlaceholderValue(value: string): boolean {
+  const trimmed = value.trim().toLowerCase();
+  if (PLACEHOLDER_VALUES.has(trimmed)) {
+    return true;
+  }
+  if (trimmed.length <= 3 && /^[x*._-]+$/.test(trimmed)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Check if a value looks like a real secret (non-placeholder).
+ * Used for ConfigMap data and binaryData values.
+ */
+export function looksLikeSecretValue(value: string): boolean {
+  if (!value || value.length < 4) {
+    return false;
+  }
+  if (isPlaceholderValue(value)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Check if a base64-encoded value decodes to something that looks like a secret.
+ * Returns true if decode succeeds and decoded content looks non-placeholder.
+ */
+export function base64LooksLikeSecret(encoded: string): boolean {
+  try {
+    const decoded = Buffer.from(encoded, 'base64').toString('utf-8');
+    if (!decoded || decoded.length < 4) {
+      return false;
+    }
+    if (isPlaceholderValue(decoded)) {
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if an env var value looks like a hardcoded secret.
+ * Requires: key is sensitive, value is set (not valueFrom), value is non-placeholder.
+ */
+export function looksLikeHardcodedSecret(key: string, value: string): boolean {
+  if (!isSensitiveKey(key)) {
+    return false;
+  }
+  if (!value || value.length < 8) {
+    return false;
+  }
+  if (isPlaceholderValue(value)) {
+    return false;
+  }
+  return true;
+}

--- a/src/assessment/checks/security/index.ts
+++ b/src/assessment/checks/security/index.ts
@@ -7,3 +7,6 @@ export { privilegedContainersCheck } from './privileged-containers.js';
 export { capabilitiesValidationCheck } from './capabilities-validation.js';
 export { rbacWildcardPermissionsCheck } from './rbac-wildcard-permissions.js';
 export { rbacClusterAdminMisuseCheck } from './rbac-cluster-admin-misuse.js';
+export { secretsInConfigMapsCheck } from './secrets-in-configmaps.js';
+export { externalSecretsUsageCheck } from './external-secrets-usage.js';
+export { hardcodedSecretsCheck } from './hardcoded-secrets.js';

--- a/src/assessment/checks/security/secrets-in-configmaps.test.ts
+++ b/src/assessment/checks/security/secrets-in-configmaps.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { secretsInConfigMapsCheck } from './secrets-in-configmaps.js';
+import { Pillar, CheckStatus } from '../../types.js';
+import type { AssessmentRunContext } from '../../types.js';
+
+function createMockContext(overrides: Partial<{
+  listConfigMapForAllNamespaces: () => Promise<unknown>;
+}>): AssessmentRunContext {
+  return {
+    kubernetes: {
+      coreApi: {
+        listConfigMapForAllNamespaces: overrides.listConfigMapForAllNamespaces ?? vi.fn().mockResolvedValue({ items: [] }),
+      },
+    } as never,
+    config: {} as never,
+    timeoutMs: 30000,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+    runId: 'test',
+    mode: 'full' as never,
+  };
+}
+
+describe('secretsInConfigMapsCheck', () => {
+  it('has correct metadata', () => {
+    expect(secretsInConfigMapsCheck.id).toBe('security.secrets-in-configmaps');
+    expect(secretsInConfigMapsCheck.name).toBe('Secrets in ConfigMaps');
+    expect(secretsInConfigMapsCheck.pillar).toBe(Pillar.Security);
+  });
+
+  it('returns Passing when no ConfigMaps have secrets', async () => {
+    const ctx = createMockContext({
+      listConfigMapForAllNamespaces: async () => ({
+        items: [
+          { metadata: { namespace: 'default', name: 'app-config' }, data: { HOST: 'localhost', PORT: '8080' } },
+        ],
+      }),
+    });
+
+    const result = await secretsInConfigMapsCheck.run(ctx);
+    expect(result.status).toBe(CheckStatus.Passing);
+    expect(result.message).toContain('No ConfigMaps');
+  });
+
+  it('returns Passing when ConfigMap has placeholder in sensitive key', async () => {
+    const ctx = createMockContext({
+      listConfigMapForAllNamespaces: async () => ({
+        items: [
+          { metadata: { namespace: 'default', name: 'app-config' }, data: { password: 'changeme' } },
+        ],
+      }),
+    });
+
+    const result = await secretsInConfigMapsCheck.run(ctx);
+    expect(result.status).toBe(CheckStatus.Passing);
+  });
+
+  it('returns Failing when ConfigMap has likely secret in sensitive key', async () => {
+    const ctx = createMockContext({
+      listConfigMapForAllNamespaces: async () => ({
+        items: [
+          {
+            metadata: { namespace: 'prod', name: 'db-config' },
+            data: { password: 'myActualSecretPassword123' },
+          },
+        ],
+      }),
+    });
+
+    const result = await secretsInConfigMapsCheck.run(ctx);
+    expect(result.status).toBe(CheckStatus.Failing);
+    expect(result.message).toContain('prod/db-config');
+    expect(result.remediation).toBeDefined();
+  });
+});

--- a/src/assessment/checks/security/secrets-in-configmaps.ts
+++ b/src/assessment/checks/security/secrets-in-configmaps.ts
@@ -1,0 +1,91 @@
+/**
+ * Security check: Detect secrets stored in ConfigMaps.
+ *
+ * ConfigMaps are not suitable for sensitive data. This check flags ConfigMaps
+ * that contain keys/values resembling secrets (e.g. password, token, api_key).
+ */
+
+import type { V1ConfigMap } from '@kubernetes/client-node';
+import type { AssessmentCheck, AssessmentRunContext, AssessmentCheckResult } from '../../types.js';
+import { Pillar, CheckStatus, Severity } from '../../types.js';
+import {
+  isSensitiveKey,
+  looksLikeSecretValue,
+  base64LooksLikeSecret,
+} from './heuristics.js';
+
+const REMEDIATION =
+  'Move secrets to Kubernetes Secrets or external-secrets; avoid storing secrets in ConfigMaps.';
+
+function getConfigMapItems(response: { body?: { items?: V1ConfigMap[] }; items?: V1ConfigMap[] }): V1ConfigMap[] {
+  return response.body?.items ?? response.items ?? [];
+}
+
+function configMapHasSecrets(cm: V1ConfigMap): boolean {
+  const ns = cm.metadata?.namespace ?? '';
+  const name = cm.metadata?.name ?? '';
+
+  if (cm.data) {
+    for (const [key, value] of Object.entries(cm.data)) {
+      if (typeof value !== 'string') continue;
+      if (isSensitiveKey(key) && looksLikeSecretValue(value)) {
+        return true;
+      }
+    }
+  }
+
+  if (cm.binaryData) {
+    for (const [key, value] of Object.entries(cm.binaryData)) {
+      if (typeof value !== 'string') continue;
+      if (isSensitiveKey(key) && base64LooksLikeSecret(value)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+export const secretsInConfigMapsCheck: AssessmentCheck = {
+  id: 'security.secrets-in-configmaps',
+  name: 'Secrets in ConfigMaps',
+  pillar: Pillar.Security,
+  description: 'Detects ConfigMaps containing likely secret data (passwords, tokens, etc.)',
+  defaultSeverity: Severity.High,
+
+  async run(ctx: AssessmentRunContext): Promise<AssessmentCheckResult> {
+    const response = await ctx.kubernetes.coreApi.listConfigMapForAllNamespaces();
+    const items = getConfigMapItems(response as { body?: { items?: V1ConfigMap[] }; items?: V1ConfigMap[] });
+
+    const violations: string[] = [];
+    for (const cm of items) {
+      if (configMapHasSecrets(cm)) {
+        const ns = cm.metadata?.namespace ?? 'default';
+        const name = cm.metadata?.name ?? 'unknown';
+        violations.push(`${ns}/${name}`);
+      }
+    }
+
+    if (violations.length > 0) {
+      return {
+        checkId: 'security.secrets-in-configmaps',
+        checkName: 'Secrets in ConfigMaps',
+        pillar: Pillar.Security,
+        status: CheckStatus.Failing,
+        severity: Severity.High,
+        objectKind: 'ConfigMap',
+        message: `Found ${violations.length} ConfigMap(s) with likely secret data: ${violations.join(', ')}`,
+        remediation: REMEDIATION,
+      };
+    }
+
+    return {
+      checkId: 'security.secrets-in-configmaps',
+      checkName: 'Secrets in ConfigMaps',
+      pillar: Pillar.Security,
+      status: CheckStatus.Passing,
+      message: 'No ConfigMaps with likely secret data found.',
+      remediation: REMEDIATION,
+    };
+  },
+};


### PR DESCRIPTION
## Summary

Implements [Issue #75](https://github.com/alto9/kube9-operator/issues/75): Secret Management Audit Checks.

## Changes

- **security.secrets-in-configmaps**: Flags ConfigMaps containing likely secret data (passwords, tokens, etc.) in `data` or `binaryData`
- **security.external-secrets-usage**: Detects external-secrets operator via ExternalSecret CRD; Passing when present, Warning when absent
- **security.hardcoded-secrets**: Scans Deployments and StatefulSets for hardcoded env values in sensitive keys

## Implementation Details

- Shared `heuristics.ts` with placeholder exclusions to avoid false positives (changeme, placeholder, etc.)
- Added ConfigMap read permissions to ClusterRole for secrets-in-configmaps check
- Unit tests for each check with mock Kubernetes fixtures

## Acceptance Criteria

- [x] ConfigMaps with likely secret data are flagged
- [x] external-secrets operator usage is detected when present
- [x] Hardcoded secrets in workload specs are flagged
- [x] Checks avoid false positives via documented heuristics

## Testing

```
npm run build
npm run test:unit
npm run test:integration
helm lint charts/kube9-operator
```

All pass.