### PR TITLE
feat(trivy): optional server detection and scanner client (#96)

### DIFF
--- a/charts/kube9-operator/templates/deployment.yaml
+++ b/charts/kube9-operator/templates/deployment.yaml
@@ -69,6 +69,23 @@ spec:
         {{- end }}
         - name: ARGOCD_DETECTION_INTERVAL
           value: {{ .Values.argocd.detectionInterval | default 6 | quote }}
+        # Optional Trivy server detection
+        - name: TRIVY_AUTO_DETECT
+          value: {{ .Values.trivy.autoDetect | quote }}
+        {{- if kindIs "bool" .Values.trivy.enabled }}
+        - name: TRIVY_ENABLED
+          value: {{ .Values.trivy.enabled | quote }}
+        {{- end }}
+        {{- if .Values.trivy.serverUrl }}
+        - name: TRIVY_SERVER_URL
+          value: {{ .Values.trivy.serverUrl | quote }}
+        {{- end }}
+        - name: TRIVY_HEALTH_PATH
+          value: {{ .Values.trivy.healthPath | default "/healthz" | quote }}
+        - name: TRIVY_DETECTION_INTERVAL
+          value: {{ .Values.trivy.detectionInterval | default 6 | quote }}
+        - name: TRIVY_DETECTION_TIMEOUT_MS
+          value: {{ .Values.trivy.detectionTimeoutMs | default 10000 | quote }}
         # Event retention configuration
         - name: EVENT_RETENTION_INFO_WARNING_DAYS
           value: {{ .Values.events.retention.infoWarning | default 7 | quote }}

--- a/charts/kube9-operator/values.yaml
+++ b/charts/kube9-operator/values.yaml
@@ -53,6 +53,14 @@ argocd:
   # Detection check interval in hours (default: 6)
   detectionInterval: 6
 
+# Optional Trivy server detection (does not install Trivy; set serverUrl to probe)
+trivy:
+  autoDetect: true
+  # serverUrl: "http://trivy.trivy-system.svc.cluster.local:4954"
+  healthPath: "/healthz"
+  detectionInterval: 6
+  detectionTimeoutMs: 10000
+
 # Collection interval configuration (for testing/debugging)
 # The operator enforces minimum intervals to prevent abuse
 metrics:

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -20,6 +20,9 @@ import { logger } from './logging/logger.js';
 import { detectArgoCDWithTimeout, type ArgoCDDetectionConfig } from './argocd/detection.js';
 import { argocdStatusTracker } from './argocd/state.js';
 import { ArgoCDDetectionManager } from './argocd/detection-manager.js';
+import { detectTrivyWithTimeout, type TrivyDetectionConfig } from './trivy/detection.js';
+import { trivyStatusTracker } from './trivy/state.js';
+import { TrivyDetectionManager } from './trivy/detection-manager.js';
 import { SchemaManager } from './database/schema.js';
 import { KubernetesEventWatcher } from './events/kubernetes-event-watcher.js';
 import { EventQueueWorker } from './events/queue-worker.js';
@@ -29,6 +32,7 @@ import { registerEventWatcher } from './events/health.js';
 let statusWriterInstance: StatusWriter | null = null;
 let collectionSchedulerInstance: CollectionScheduler | null = null;
 let argoCDDetectionManagerInstance: ArgoCDDetectionManager | null = null;
+let trivyDetectionManagerInstance: TrivyDetectionManager | null = null;
 let eventWatcherInstance: KubernetesEventWatcher | null = null;
 let eventQueueWorkerInstance: EventQueueWorker | null = null;
 
@@ -87,6 +91,19 @@ function parseArgoCDConfig(): ArgoCDDetectionConfig {
   };
 }
 
+function parseTrivyConfig(): TrivyDetectionConfig {
+  const enabledEnv = process.env.TRIVY_ENABLED;
+  return {
+    autoDetect: process.env.TRIVY_AUTO_DETECT !== 'false',
+    enabled:
+      enabledEnv === 'true' ? true : enabledEnv === 'false' ? false : undefined,
+    serverUrl: process.env.TRIVY_SERVER_URL?.trim() || undefined,
+    healthPath: process.env.TRIVY_HEALTH_PATH || '/healthz',
+    detectionInterval: parseInt(process.env.TRIVY_DETECTION_INTERVAL || '6', 10),
+    detectionTimeoutMs: parseInt(process.env.TRIVY_DETECTION_TIMEOUT_MS || '10000', 10)
+  };
+}
+
 // Perform initial ArgoCD detection during startup
 async function performInitialArgoCDDetection(): Promise<void> {
   try {
@@ -110,6 +127,28 @@ async function performInitialArgoCDDetection(): Promise<void> {
     const errorMessage = error instanceof Error ? error.message : String(error);
     logger.warn('ArgoCD detection failed during startup', { error: errorMessage });
     // Continue with default status (not detected)
+  }
+}
+
+async function performInitialTrivyDetection(): Promise<void> {
+  try {
+    logger.info('Performing initial Trivy detection');
+    const trivyConfig = parseTrivyConfig();
+    const trivyStatus = await detectTrivyWithTimeout(trivyConfig);
+    trivyStatusTracker.setStatus(trivyStatus);
+
+    if (trivyStatus.detected) {
+      logger.info('Trivy detection completed', {
+        detected: true,
+        serverUrl: trivyStatus.serverUrl,
+        version: trivyStatus.version
+      });
+    } else {
+      logger.info('Trivy detection completed', { detected: false });
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.warn('Trivy detection failed during startup', { error: errorMessage });
   }
 }
 
@@ -158,6 +197,14 @@ export async function startOperator() {
     const argoCDDetectionManager = new ArgoCDDetectionManager();
     argoCDDetectionManager.start(kubernetesClient, argoCDConfig, initialArgoCDStatus);
     argoCDDetectionManagerInstance = argoCDDetectionManager;
+
+    await performInitialTrivyDetection();
+
+    const trivyConfig = parseTrivyConfig();
+    const initialTrivyStatus = trivyStatusTracker.getStatus();
+    const trivyDetectionManager = new TrivyDetectionManager();
+    trivyDetectionManager.start(trivyConfig, initialTrivyStatus);
+    trivyDetectionManagerInstance = trivyDetectionManager;
     
     // Start status writer for periodic ConfigMap updates
     logger.info('Starting status writer...');
@@ -313,6 +360,7 @@ export async function startOperator() {
           null,
           collectionSchedulerInstance,
           argoCDDetectionManagerInstance,
+          trivyDetectionManagerInstance,
           eventWatcherInstance,
           eventQueueWorkerInstance
         ).catch((error) => {
@@ -330,6 +378,7 @@ export async function startOperator() {
           null,
           collectionSchedulerInstance,
           argoCDDetectionManagerInstance,
+          trivyDetectionManagerInstance,
           eventWatcherInstance,
           eventQueueWorkerInstance
         ).catch((error) => {

--- a/src/shutdown/handler.ts
+++ b/src/shutdown/handler.ts
@@ -2,6 +2,7 @@ import type { StatusWriter } from '../status/writer.js';
 import type { RegistrationManager } from '../registration/manager.js';
 import type { CollectionScheduler } from '../collection/scheduler.js';
 import type { ArgoCDDetectionManager } from '../argocd/detection-manager.js';
+import type { TrivyDetectionManager } from '../trivy/detection-manager.js';
 import type { KubernetesEventWatcher } from '../events/kubernetes-event-watcher.js';
 import type { EventQueueWorker } from '../events/queue-worker.js';
 import { stopHealthServer } from '../health/server.js';
@@ -9,6 +10,7 @@ import type { OperatorStatus } from '../status/types.js';
 import { logger } from '../logging/logger.js';
 import { collectionStatsTracker } from '../collection/stats-tracker.js';
 import { argocdStatusTracker } from '../argocd/state.js';
+import { trivyStatusTracker } from '../trivy/state.js';
 
 /**
  * Operator version (semver)
@@ -40,6 +42,7 @@ let isShuttingDown = false;
  * @param registrationManager - Optional registration manager instance to stop
  * @param collectionScheduler - Optional collection scheduler instance to stop
  * @param argoCDDetectionManager - Optional ArgoCD detection manager instance to stop
+ * @param trivyDetectionManager - Optional Trivy detection manager instance to stop
  * @param eventWatcher - Optional event watcher instance to stop
  * @param eventQueueWorker - Optional event queue worker instance to stop
  */
@@ -48,6 +51,7 @@ export async function gracefulShutdown(
   registrationManager: RegistrationManager | null,
   collectionScheduler: CollectionScheduler | null,
   argoCDDetectionManager: ArgoCDDetectionManager | null,
+  trivyDetectionManager: TrivyDetectionManager | null,
   eventWatcher: KubernetesEventWatcher | null,
   eventQueueWorker: EventQueueWorker | null
 ): Promise<void> {
@@ -87,6 +91,10 @@ export async function gracefulShutdown(
       argoCDDetectionManager.stop();
     }
 
+    if (trivyDetectionManager) {
+      trivyDetectionManager.stop();
+    }
+
     // Stop status writer (clears interval)
     statusWriter.stop();
 
@@ -106,6 +114,7 @@ export async function gracefulShutdown(
     // Build final status indicating shutdown
     const collectionStats = collectionStatsTracker.getStats();
     const argocdStatus = argocdStatusTracker.getStatus();
+    const trivyStatus = trivyStatusTracker.getStatus();
     const finalStatus: OperatorStatus = {
       mode: "operated",
       tier: "free",
@@ -121,7 +130,8 @@ export async function gracefulShutdown(
         collectionsStoredCount: collectionStats.collectionsStoredCount,
         lastSuccessTime: collectionStats.lastSuccessTime
       },
-      argocd: argocdStatus
+      argocd: argocdStatus,
+      trivy: trivyStatus
     };
 
     // Include clusterId if registered

--- a/src/status/calculator.test.ts
+++ b/src/status/calculator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import type { RegistrationState, CollectionStats, ArgoCDStatus } from './types.js';
+import type { RegistrationState, CollectionStats, ArgoCDStatus, TrivyStatus } from './types.js';
 
 describe('calculateStatus', () => {
   let originalPodNamespace: string | undefined;
@@ -64,6 +64,7 @@ describe('calculateStatus', () => {
       expect(status.lastUpdate).toBeDefined();
       expect(status.collectionStats).toBeDefined();
       expect(status.argocd).toBeDefined();
+      expect(status.trivy).toBeDefined();
     });
 
     it('should return operated mode regardless config inputs', async () => {
@@ -371,6 +372,54 @@ describe('calculateStatus', () => {
 
       expect(status.argocd).toEqual(argocdStatus);
       expect(status.namespace).toBe('kube9-system');
+    });
+  });
+
+  describe('trivy status', () => {
+    it('should include Trivy status in operator status', async () => {
+      delete process.env.POD_NAMESPACE;
+
+      vi.resetModules();
+      const configLoader = await import('../config/loader.js');
+      vi.spyOn(configLoader, 'getConfig').mockReturnValue({
+        apiKey: null,
+        serverUrl: 'https://api.kube9.dev',
+        logLevel: 'info',
+        statusUpdateIntervalSeconds: 60,
+        reregistrationIntervalHours: 24,
+        clusterMetadataIntervalSeconds: 86400,
+        resourceInventoryIntervalSeconds: 21600,
+        resourceConfigurationPatternsIntervalSeconds: 43200,
+      } as any);
+
+      const calculatorModule = await import('./calculator.js');
+      const trivyStatus: TrivyStatus = {
+        detected: true,
+        serverUrl: 'http://trivy:4954',
+        version: '0.58.0',
+        lastChecked: '2025-01-01T00:00:00Z',
+      };
+
+      const status = calculatorModule.calculateStatus(
+        { isRegistered: false, consecutiveFailures: 0 },
+        null,
+        true,
+        {
+          totalSuccessCount: 0,
+          totalFailureCount: 0,
+          collectionsStoredCount: 0,
+          lastSuccessTime: null,
+        },
+        {
+          detected: false,
+          namespace: null,
+          version: null,
+          lastChecked: '2025-01-01T00:00:00Z',
+        },
+        trivyStatus
+      );
+
+      expect(status.trivy).toEqual(trivyStatus);
     });
   });
 

--- a/src/status/calculator.ts
+++ b/src/status/calculator.ts
@@ -1,4 +1,10 @@
-import type { OperatorStatus, RegistrationState, CollectionStats, ArgoCDStatus } from './types.js';
+import type {
+  OperatorStatus,
+  RegistrationState,
+  CollectionStats,
+  ArgoCDStatus,
+  TrivyStatus,
+} from './types.js';
 
 /**
  * Operator version (semver)
@@ -37,6 +43,13 @@ const DEFAULT_ARGOCD_STATUS: ArgoCDStatus = {
   lastChecked: new Date().toISOString(),
 };
 
+const DEFAULT_TRIVY_STATUS: TrivyStatus = {
+  detected: false,
+  serverUrl: null,
+  version: null,
+  lastChecked: new Date().toISOString(),
+};
+
 /**
  * Calculate the current operator status based on configuration and system state
  * 
@@ -45,6 +58,7 @@ const DEFAULT_ARGOCD_STATUS: ArgoCDStatus = {
  * @param canWriteConfigMap - Whether the operator can write to ConfigMap (defaults to true)
  * @param collectionStats - Optional collection statistics (defaults to zero stats)
  * @param argocdStatus - Optional ArgoCD detection status (defaults to not detected)
+ * @param trivyStatus - Optional Trivy detection status (defaults to unavailable)
  * @returns OperatorStatus object with current operator state
  */
 export function calculateStatus(
@@ -57,7 +71,8 @@ export function calculateStatus(
     collectionsStoredCount: 0,
     lastSuccessTime: null
   },
-  argocdStatus: ArgoCDStatus = DEFAULT_ARGOCD_STATUS
+  argocdStatus: ArgoCDStatus = DEFAULT_ARGOCD_STATUS,
+  trivyStatus: TrivyStatus = DEFAULT_TRIVY_STATUS
 ): OperatorStatus {
   const { isRegistered, clusterId, consecutiveFailures = 0 } = registrationState;
   
@@ -112,7 +127,8 @@ export function calculateStatus(
       collectionsStoredCount: collectionStats.collectionsStoredCount,
       lastSuccessTime: collectionStats.lastSuccessTime
     },
-    argocd: argocdStatus
+    argocd: argocdStatus,
+    trivy: trivyStatus
   };
   
   // Include clusterId only when registered (pro tier)

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -55,6 +55,31 @@ export interface ArgoCDStatus {
 }
 
 /**
+ * Optional Trivy server detection (remote HTTP health probe)
+ */
+export interface TrivyStatus {
+  /**
+   * Whether a Trivy server was reached at the configured URL
+   */
+  detected: boolean;
+
+  /**
+   * Base URL of the Trivy server when detected
+   */
+  serverUrl: string | null;
+
+  /**
+   * Server version when available (e.g. from /version)
+   */
+  version: string | null;
+
+  /**
+   * ISO 8601 timestamp of last detection check
+   */
+  lastChecked: string;
+}
+
+/**
  * Operator Status Model
  * Represents the current state and health of the kube9 operator
  */
@@ -130,6 +155,11 @@ export interface OperatorStatus {
    * Tracks whether ArgoCD is installed in the cluster
    */
   argocd: ArgoCDStatus;
+
+  /**
+   * Optional Trivy server awareness (does not install or manage Trivy)
+   */
+  trivy: TrivyStatus;
 }
 
 /**

--- a/src/status/writer.ts
+++ b/src/status/writer.ts
@@ -6,6 +6,7 @@ import type { RegistrationManager } from '../registration/manager.js';
 import { logger } from '../logging/logger.js';
 import { collectionStatsTracker } from '../collection/stats-tracker.js';
 import { argocdStatusTracker } from '../argocd/state.js';
+import { trivyStatusTracker } from '../trivy/state.js';
 
 /**
  * Default registration state when registration manager is not available
@@ -195,13 +196,15 @@ export class StatusWriter {
       
       // Get current ArgoCD status
       const argocdStatus = argocdStatusTracker.getStatus();
+      const trivyStatus = trivyStatusTracker.getStatus();
       
       const status = calculateStatus(
         registrationState,
         this.lastWriteError,
         canWriteConfigMap,
         collectionStats,
-        argocdStatus
+        argocdStatus,
+        trivyStatus
       );
 
       // Convert status to JSON string

--- a/src/trivy/detection-manager.ts
+++ b/src/trivy/detection-manager.ts
@@ -1,0 +1,67 @@
+/**
+ * Periodic Trivy server re-detection (presence may change after startup).
+ */
+
+import { logger } from '../logging/logger.js';
+import { detectTrivyWithTimeout, type TrivyDetectionConfig } from './detection.js';
+import { trivyStatusTracker } from './state.js';
+import type { TrivyStatus } from '../status/types.js';
+
+export class TrivyDetectionManager {
+  private intervalHandle: NodeJS.Timeout | null = null;
+  private currentStatus!: TrivyStatus;
+
+  start(config: TrivyDetectionConfig, initialStatus: TrivyStatus): void {
+    this.currentStatus = initialStatus;
+    const intervalMs = config.detectionInterval * 60 * 60 * 1000;
+
+    this.intervalHandle = setInterval(() => {
+      this.performPeriodicCheck(config).catch((err) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.error('Periodic Trivy detection failed', { error: msg });
+      });
+    }, intervalMs);
+
+    logger.info('Trivy periodic detection started', {
+      intervalHours: config.detectionInterval,
+    });
+  }
+
+  stop(): void {
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+      logger.info('Trivy periodic detection stopped');
+    }
+  }
+
+  private async performPeriodicCheck(config: TrivyDetectionConfig): Promise<void> {
+    logger.debug('Performing periodic Trivy detection');
+    const newStatus = await detectTrivyWithTimeout(config);
+
+    if (this.hasStatusChanged(newStatus)) {
+      logger.info('Trivy status changed', {
+        previous: {
+          detected: this.currentStatus.detected,
+          serverUrl: this.currentStatus.serverUrl,
+        },
+        current: {
+          detected: newStatus.detected,
+          serverUrl: newStatus.serverUrl,
+        },
+      });
+      this.currentStatus = newStatus;
+      trivyStatusTracker.setStatus(newStatus);
+    } else {
+      logger.debug('Trivy status unchanged, skipping tracker update');
+    }
+  }
+
+  private hasStatusChanged(newStatus: TrivyStatus): boolean {
+    return (
+      this.currentStatus.detected !== newStatus.detected ||
+      this.currentStatus.serverUrl !== newStatus.serverUrl ||
+      this.currentStatus.version !== newStatus.version
+    );
+  }
+}

--- a/src/trivy/detection.test.ts
+++ b/src/trivy/detection.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { detectTrivy, probeTrivyHealth, type TrivyDetectionConfig } from './detection.js';
+
+const baseConfig = (): TrivyDetectionConfig => ({
+  autoDetect: true,
+  healthPath: '/healthz',
+  detectionInterval: 6,
+  detectionTimeoutMs: 5000,
+  serverUrl: 'http://127.0.0.1:4954',
+});
+
+describe('probeTrivyHealth', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('returns true when health endpoint responds OK', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+    });
+
+    const ok = await probeTrivyHealth('http://127.0.0.1:4954', '/healthz', 5000);
+    expect(ok).toBe(true);
+    expect(globalThis.fetch).toHaveBeenCalled();
+  });
+
+  it('returns false on non-OK HTTP status', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+    });
+
+    const ok = await probeTrivyHealth('http://127.0.0.1:4954', '/healthz', 5000);
+    expect(ok).toBe(false);
+  });
+});
+
+describe('detectTrivy', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('reports not detected when autoDetect is false', async () => {
+    const status = await detectTrivy({
+      ...baseConfig(),
+      autoDetect: false,
+    });
+    expect(status.detected).toBe(false);
+    expect(status.serverUrl).toBeNull();
+  });
+
+  it('reports not detected when server URL is missing', async () => {
+    const status = await detectTrivy({
+      ...baseConfig(),
+      serverUrl: undefined,
+    });
+    expect(status.detected).toBe(false);
+  });
+
+  it('reports detected when health probe succeeds', async () => {
+    globalThis.fetch = vi
+      .fn()
+      // health
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+      // /version optional
+      .mockResolvedValueOnce({ ok: false, status: 404 });
+
+    const status = await detectTrivy(baseConfig());
+    expect(status.detected).toBe(true);
+    expect(status.serverUrl).toBe('http://127.0.0.1:4954');
+  });
+
+  it('parses JSON version from /version when available', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ Version: '0.58.0' }),
+      });
+
+    const status = await detectTrivy(baseConfig());
+    expect(status.detected).toBe(true);
+    expect(status.version).toBe('0.58.0');
+  });
+});

--- a/src/trivy/detection.ts
+++ b/src/trivy/detection.ts
@@ -1,0 +1,172 @@
+/**
+ * Optional Trivy server detection via HTTP health endpoint (e.g. GET /healthz).
+ */
+
+import { logger } from '../logging/logger.js';
+import type { TrivyStatus } from '../status/types.js';
+
+export interface TrivyDetectionConfig {
+  autoDetect: boolean;
+  enabled?: boolean;
+  /** Base URL of the Trivy server (e.g. http://trivy.trivy-system.svc:4954) */
+  serverUrl?: string;
+  /** Path for HTTP health probe (default /healthz) */
+  healthPath: string;
+  /** Re-check interval in hours */
+  detectionInterval: number;
+  /** Per-request timeout for the health probe */
+  detectionTimeoutMs: number;
+}
+
+function emptyStatus(lastChecked: string): TrivyStatus {
+  return {
+    detected: false,
+    serverUrl: null,
+    version: null,
+    lastChecked,
+  };
+}
+
+function normalizeBaseUrl(url: string): string {
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return '';
+  }
+  return trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed;
+}
+
+/**
+ * Probe Trivy HTTP health endpoint. Trivy server exposes GET /healthz (200, body "ok") by default.
+ */
+export async function probeTrivyHealth(
+  baseUrl: string,
+  healthPath: string,
+  timeoutMs: number
+): Promise<boolean> {
+  const root = normalizeBaseUrl(baseUrl);
+  if (!root) {
+    return false;
+  }
+  const path = healthPath.startsWith('/') ? healthPath : `/${healthPath}`;
+  const target = new URL(path, `${root}/`);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(target, {
+      method: 'GET',
+      signal: controller.signal,
+      headers: { accept: 'text/plain, */*' },
+    });
+    if (!res.ok) {
+      logger.debug('Trivy health probe returned non-OK status', {
+        status: res.status,
+        url: target.href,
+      });
+      return false;
+    }
+    return true;
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    logger.debug('Trivy health probe failed', { url: target.href, error: msg });
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Optionally fetch Trivy version from GET /version when present (non-fatal if missing).
+ */
+async function tryFetchVersion(baseUrl: string, timeoutMs: number): Promise<string | null> {
+  const root = normalizeBaseUrl(baseUrl);
+  if (!root) {
+    return null;
+  }
+  const target = new URL('/version', `${root}/`);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(target, {
+      method: 'GET',
+      signal: controller.signal,
+      headers: { accept: 'application/json, text/plain, */*' },
+    });
+    if (!res.ok) {
+      return null;
+    }
+    const text = (await res.text()).trim();
+    if (!text) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(text) as { Version?: string; version?: string };
+      return parsed.Version ?? parsed.version ?? null;
+    } catch {
+      return text.length > 64 ? `${text.slice(0, 61)}...` : text;
+    }
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Detect whether a Trivy server is reachable at the configured URL.
+ */
+export async function detectTrivy(config: TrivyDetectionConfig): Promise<TrivyStatus> {
+  const now = new Date().toISOString();
+
+  if (config.enabled === false || config.autoDetect === false) {
+    logger.debug('Trivy detection disabled via configuration');
+    return emptyStatus(now);
+  }
+
+  const serverUrl = config.serverUrl?.trim();
+  if (!serverUrl) {
+    logger.debug('Trivy server URL not set; reporting unavailable');
+    return emptyStatus(now);
+  }
+
+  if (config.enabled === true) {
+    logger.debug('Trivy explicitly enabled, probing configured server URL');
+  }
+
+  const ok = await probeTrivyHealth(serverUrl, config.healthPath, config.detectionTimeoutMs);
+  if (!ok) {
+    logger.info('Trivy not detected or unreachable', { serverUrl });
+    return {
+      detected: false,
+      serverUrl: null,
+      version: null,
+      lastChecked: now,
+    };
+  }
+
+  const version = await tryFetchVersion(serverUrl, config.detectionTimeoutMs);
+  logger.info('Trivy server detected', { serverUrl, version });
+  return {
+    detected: true,
+    serverUrl: normalizeBaseUrl(serverUrl),
+    version,
+    lastChecked: now,
+  };
+}
+
+export async function detectTrivyWithTimeout(
+  config: TrivyDetectionConfig,
+  timeoutMs?: number
+): Promise<TrivyStatus> {
+  const outer =
+    timeoutMs ?? Math.max(30000, config.detectionTimeoutMs + 2000);
+
+  const timeoutPromise = new Promise<TrivyStatus>((resolve) => {
+    setTimeout(() => {
+      logger.warn('Trivy detection timed out', { timeoutMs: outer });
+      resolve(emptyStatus(new Date().toISOString()));
+    }, outer);
+  });
+
+  return Promise.race([detectTrivy(config), timeoutPromise]);
+}

--- a/src/trivy/scanner.test.ts
+++ b/src/trivy/scanner.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { spawn as nodeSpawn } from 'node:child_process';
+import {
+  scanContainerImage,
+  TrivyScanFailure,
+} from './scanner.js';
+
+function fakeSpawnSuccess(json: object): typeof nodeSpawn {
+  return ((() => {
+    const proc = new EventEmitter();
+    const stdout = new EventEmitter();
+    const stderr = new EventEmitter();
+    (proc as any).stdout = stdout;
+    (proc as any).stderr = stderr;
+    (proc as any).kill = vi.fn();
+
+    queueMicrotask(() => {
+      stdout.emit('data', Buffer.from(JSON.stringify(json)));
+      proc.emit('close', 0);
+    });
+
+    return proc as any;
+  }) as unknown) as typeof nodeSpawn;
+}
+
+describe('scanContainerImage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('parses JSON report from trivy CLI stdout', async () => {
+    const report = await scanContainerImage('alpine:3', {
+      serverUrl: 'http://127.0.0.1:4954',
+      cliPath: 'trivy',
+      scanTimeoutMs: 5000,
+      maxAttempts: 1,
+      spawnImpl: fakeSpawnSuccess({ SchemaVersion: 2, ArtifactName: 'alpine:3' }),
+    });
+
+    expect(report.SchemaVersion).toBe(2);
+    expect(report.ArtifactName).toBe('alpine:3');
+  });
+
+  it('throws TrivyScanFailure on non-zero exit', async () => {
+    const spawnImpl = ((() => {
+      const proc = new EventEmitter();
+      const stdout = new EventEmitter();
+      const stderr = new EventEmitter();
+      (proc as any).stdout = stdout;
+      (proc as any).stderr = stderr;
+      (proc as any).kill = vi.fn();
+
+      queueMicrotask(() => {
+        stderr.emit('data', Buffer.from('scan failed'));
+        proc.emit('close', 1);
+      });
+
+      return proc as any;
+    }) as unknown) as typeof nodeSpawn;
+
+    await expect(
+      scanContainerImage('bad:image', {
+        serverUrl: 'http://127.0.0.1:4954',
+        maxAttempts: 1,
+        spawnImpl,
+      })
+    ).rejects.toMatchObject({
+      code: 'TRIVY_CLI_FAILED',
+    });
+  });
+
+  it('maps invalid JSON to TRIVY_SCAN_PARSE', async () => {
+    const spawnImpl = ((() => {
+      const proc = new EventEmitter();
+      const stdout = new EventEmitter();
+      const stderr = new EventEmitter();
+      (proc as any).stdout = stdout;
+      (proc as any).stderr = stderr;
+      (proc as any).kill = vi.fn();
+
+      queueMicrotask(() => {
+        stdout.emit('data', Buffer.from('not-json'));
+        proc.emit('close', 0);
+      });
+
+      return proc as any;
+    }) as unknown) as typeof nodeSpawn;
+
+    try {
+      await scanContainerImage('alpine:3', {
+        serverUrl: 'http://127.0.0.1:4954',
+        maxAttempts: 1,
+        spawnImpl,
+      });
+      expect.fail('expected throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(TrivyScanFailure);
+      expect((e as TrivyScanFailure).code).toBe('TRIVY_SCAN_PARSE');
+    }
+  });
+});

--- a/src/trivy/scanner.ts
+++ b/src/trivy/scanner.ts
@@ -1,0 +1,193 @@
+/**
+ * Trivy image scanner using the documented CLI client/server path:
+ * `trivy image --server <url> --format json <imageRef>`
+ */
+
+import { spawn } from 'node:child_process';
+import { logger } from '../logging/logger.js';
+import { trivyStatusTracker } from './state.js';
+import type { TrivyStatus } from '../status/types.js';
+
+/** Minimal shape of `trivy image -f json` output */
+export interface TrivyImageReport {
+  SchemaVersion?: number;
+  ArtifactName?: string;
+  Results?: unknown[];
+  [key: string]: unknown;
+}
+
+export type TrivyScanFailureCode =
+  | 'TRIVY_NOT_DETECTED'
+  | 'TRIVY_CLI_FAILED'
+  | 'TRIVY_SCAN_TIMEOUT'
+  | 'TRIVY_SCAN_PARSE';
+
+export class TrivyScanFailure extends Error {
+  readonly code: TrivyScanFailureCode;
+  readonly exitCode: number | null;
+
+  constructor(
+    code: TrivyScanFailureCode,
+    message: string,
+    options?: { exitCode?: number | null; cause?: unknown }
+  ) {
+    super(message, options?.cause ? { cause: options.cause } : undefined);
+    this.name = 'TrivyScanFailure';
+    this.code = code;
+    this.exitCode = options?.exitCode ?? null;
+  }
+}
+
+export interface TrivyScannerOptions {
+  /** Remote Trivy server URL (must match detection) */
+  serverUrl: string;
+  /** Path to trivy binary (default: trivy) */
+  cliPath?: string;
+  /** Total timeout for a single scan attempt */
+  scanTimeoutMs?: number;
+  /** Retries on spawn/timeout failures (not on non-zero exit with output) */
+  maxAttempts?: number;
+  /** Override `child_process.spawn` (for tests) */
+  spawnImpl?: typeof spawn;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function runTrivyOnce(
+  imageRef: string,
+  serverUrl: string,
+  cliPath: string,
+  timeoutMs: number,
+  spawnImpl: TrivyScannerOptions['spawnImpl']
+): Promise<string> {
+  const spawnFn = spawnImpl ?? spawn;
+  return new Promise((resolve, reject) => {
+    const proc = spawnFn(
+      cliPath,
+      ['image', '--server', serverUrl, '--format', 'json', '--quiet', imageRef],
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env },
+      }
+    );
+
+    let stdout = '';
+    let stderr = '';
+
+    const timer = setTimeout(() => {
+      proc.kill('SIGKILL');
+      reject(new TrivyScanFailure('TRIVY_SCAN_TIMEOUT', `Trivy scan timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    proc.stdout?.on('data', (d: Buffer) => {
+      stdout += d.toString();
+    });
+    proc.stderr?.on('data', (d: Buffer) => {
+      stderr += d.toString();
+    });
+
+    proc.on('error', (err) => {
+      clearTimeout(timer);
+      reject(
+        new TrivyScanFailure('TRIVY_CLI_FAILED', `Failed to spawn Trivy CLI: ${err.message}`, {
+          cause: err,
+        })
+      );
+    });
+
+    proc.on('close', (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(
+          new TrivyScanFailure(
+            'TRIVY_CLI_FAILED',
+            stderr.trim() || `trivy exited with code ${code}`,
+            { exitCode: code }
+          )
+        );
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+/**
+ * Scan a container image reference using the Trivy CLI against a remote server.
+ * Does not run unless the caller provides a server URL (typically after detection).
+ */
+export async function scanContainerImage(
+  imageRef: string,
+  options: TrivyScannerOptions
+): Promise<TrivyImageReport> {
+  const cliPath = options.cliPath ?? process.env.TRIVY_CLI_PATH ?? 'trivy';
+  const scanTimeoutMs = options.scanTimeoutMs ?? parseInt(process.env.TRIVY_SCAN_TIMEOUT_MS || '600000', 10);
+  const maxAttempts = options.maxAttempts ?? 3;
+  const spawnImpl = options.spawnImpl;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const raw = await runTrivyOnce(
+        imageRef,
+        options.serverUrl,
+        cliPath,
+        scanTimeoutMs,
+        spawnImpl
+      );
+      try {
+        return JSON.parse(raw) as TrivyImageReport;
+      } catch (err) {
+        throw new TrivyScanFailure('TRIVY_SCAN_PARSE', 'Failed to parse Trivy JSON output', {
+          cause: err,
+        });
+      }
+    } catch (err) {
+      lastError = err;
+      const retryable = err instanceof TrivyScanFailure && err.code === 'TRIVY_SCAN_TIMEOUT';
+
+      if (!retryable || attempt === maxAttempts) {
+        throw err;
+      }
+      const backoffMs = 1000 * 2 ** (attempt - 1);
+      logger.warn('Trivy scan attempt failed, retrying', {
+        attempt,
+        maxAttempts,
+        backoffMs,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      await sleep(backoffMs);
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new TrivyScanFailure('TRIVY_CLI_FAILED', String(lastError));
+}
+
+/**
+ * Runs a container image scan only when the tracker reports a detected Trivy server.
+ */
+export async function scanContainerImageWhenDetected(
+  imageRef: string,
+  options: Omit<TrivyScannerOptions, 'serverUrl'> & {
+    getStatus?: () => TrivyStatus;
+  }
+): Promise<TrivyImageReport> {
+  const status = options.getStatus?.() ?? trivyStatusTracker.getStatus();
+  if (!status.detected || !status.serverUrl) {
+    throw new TrivyScanFailure(
+      'TRIVY_NOT_DETECTED',
+      'Trivy server is not detected or unavailable; skipping scan'
+    );
+  }
+  return scanContainerImage(imageRef, {
+    cliPath: options.cliPath,
+    scanTimeoutMs: options.scanTimeoutMs,
+    maxAttempts: options.maxAttempts,
+    spawnImpl: options.spawnImpl,
+    serverUrl: status.serverUrl,
+  });
+}

--- a/src/trivy/state.ts
+++ b/src/trivy/state.ts
@@ -1,0 +1,30 @@
+/**
+ * In-memory Trivy detection status for operator status ConfigMap.
+ */
+
+import type { TrivyStatus } from '../status/types.js';
+
+const DEFAULT_TRIVY_STATUS: TrivyStatus = {
+  detected: false,
+  serverUrl: null,
+  version: null,
+  lastChecked: new Date().toISOString(),
+};
+
+export class TrivyStatusTracker {
+  private status: TrivyStatus = { ...DEFAULT_TRIVY_STATUS };
+
+  getStatus(): TrivyStatus {
+    return { ...this.status };
+  }
+
+  setStatus(status: TrivyStatus): void {
+    this.status = { ...status };
+  }
+
+  reset(): void {
+    this.status = { ...DEFAULT_TRIVY_STATUS };
+  }
+}
+
+export const trivyStatusTracker = new TrivyStatusTracker();


### PR DESCRIPTION
## Description

Implements optional Trivy server detection (HTTP health probe) and a scanner client using the documented CLI path `trivy image --server <url> --format json`. Detection status is published on `kube9-operator-status` under `status.trivy`. No scanning runs unless a server URL is configured and the health check succeeds; the operator does not install or bundle Trivy.

## Related issues

- Closes #96
- Part of #15 (parent epic)

## Motivation and Context

Delivers the scope for #96 under parent issue #15. Aligns with ArgoCD-style env configuration, timeouts, and periodic refresh.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tests added/updated
- [x] Integration tests (existing suite; all pass)
- [x] `npm run lint` and `npm test`

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter (`npm run lint`)