### PR TITLE
[#15] Collect workload container image references (#97)

### DIFF
--- a/charts/kube9-operator/templates/deployment.yaml
+++ b/charts/kube9-operator/templates/deployment.yaml
@@ -86,6 +86,10 @@ spec:
           value: {{ .Values.trivy.detectionInterval | default 6 | quote }}
         - name: TRIVY_DETECTION_TIMEOUT_MS
           value: {{ .Values.trivy.detectionTimeoutMs | default 10000 | quote }}
+        - name: TRIVY_MAX_SCANS_PER_CYCLE
+          value: {{ .Values.trivy.maxScansPerCycle | default 100 | quote }}
+        - name: WORKLOAD_IMAGE_SCAN_INTERVAL_SECONDS
+          value: {{ .Values.metrics.intervals.workloadImageScan | default 86400 | quote }}
         # Event retention configuration
         - name: EVENT_RETENTION_INFO_WARNING_DAYS
           value: {{ .Values.events.retention.infoWarning | default 7 | quote }}

--- a/charts/kube9-operator/values.schema.json
+++ b/charts/kube9-operator/values.schema.json
@@ -53,6 +53,12 @@
               "description": "Resource configuration patterns collection interval in seconds. Default: 43200 (12 hours). Minimum: 3600 (1 hour). Configurable for testing/debugging purposes.",
               "minimum": 3600,
               "default": 43200
+            },
+            "workloadImageScan": {
+              "type": "integer",
+              "description": "Workload image collection and optional Trivy scan cycle interval in seconds. Default: 86400 (24 hours). Minimum: 3600 (1 hour).",
+              "minimum": 3600,
+              "default": 86400
             }
           },
           "additionalProperties": false

--- a/charts/kube9-operator/values.yaml
+++ b/charts/kube9-operator/values.yaml
@@ -60,6 +60,8 @@ trivy:
   healthPath: "/healthz"
   detectionInterval: 6
   detectionTimeoutMs: 10000
+  # Cap on Trivy image scans per workload-image cycle (after collection)
+  maxScansPerCycle: 100
 
 # Collection interval configuration (for testing/debugging)
 # The operator enforces minimum intervals to prevent abuse
@@ -74,6 +76,9 @@ metrics:
     # Resource configuration patterns collection interval in seconds (default: 43200 = 12 hours)
     # Minimum: 3600 seconds (1 hour)
     resourceConfigurationPatterns: 43200
+    # Workload image collection + optional Trivy scan cycle (default: 86400 = 24 hours)
+    # Minimum: 3600 seconds (1 hour)
+    workloadImageScan: 86400
 
 # Event storage configuration
 events:

--- a/src/assessment/runner.integration.test.ts
+++ b/src/assessment/runner.integration.test.ts
@@ -76,6 +76,7 @@ const mockConfig = {
   clusterMetadataIntervalSeconds: 86400,
   resourceInventoryIntervalSeconds: 21600,
   resourceConfigurationPatternsIntervalSeconds: 43200,
+  workloadImageScanIntervalSeconds: 86400,
   eventRetentionInfoWarningDays: 7,
   eventRetentionErrorCriticalDays: 30,
 } as never;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -31,6 +31,10 @@ export async function loadConfig(): Promise<Config> {
     process.env.RESOURCE_CONFIGURATION_PATTERNS_INTERVAL_SECONDS || '43200',
     10
   );
+  const workloadImageScanIntervalSeconds = parseInt(
+    process.env.WORKLOAD_IMAGE_SCAN_INTERVAL_SECONDS || '86400',
+    10
+  );
   const eventRetentionInfoWarningDays = parseInt(
     process.env.EVENT_RETENTION_INFO_WARNING_DAYS || '7',
     10
@@ -53,6 +57,7 @@ export async function loadConfig(): Promise<Config> {
     clusterMetadataIntervalSeconds,
     resourceInventoryIntervalSeconds,
     resourceConfigurationPatternsIntervalSeconds,
+    workloadImageScanIntervalSeconds,
     eventRetentionInfoWarningDays,
     eventRetentionErrorCriticalDays,
   };
@@ -65,6 +70,8 @@ export async function loadConfig(): Promise<Config> {
     clusterMetadataOverridden: process.env.CLUSTER_METADATA_INTERVAL_SECONDS !== undefined,
     resourceInventoryOverridden: process.env.RESOURCE_INVENTORY_INTERVAL_SECONDS !== undefined,
     resourceConfigurationPatternsOverridden: process.env.RESOURCE_CONFIGURATION_PATTERNS_INTERVAL_SECONDS !== undefined,
+    workloadImageScanIntervalSeconds: config.workloadImageScanIntervalSeconds,
+    workloadImageScanOverridden: process.env.WORKLOAD_IMAGE_SCAN_INTERVAL_SECONDS !== undefined,
   });
 
   return config;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -41,6 +41,13 @@ export interface Config {
   resourceConfigurationPatternsIntervalSeconds: number;
 
   /**
+   * Workload container image collection / scan cycle interval in seconds
+   * (collects from Pods, Deployments, StatefulSets; Trivy scans only when Trivy is active).
+   * Default: 86400 (24 hours), Minimum: 3600 (1 hour)
+   */
+  workloadImageScanIntervalSeconds: number;
+
+  /**
    * Event retention for info/warning severity (days)
    * Default: 7 days
    */

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -23,6 +23,7 @@ import { ArgoCDDetectionManager } from './argocd/detection-manager.js';
 import { detectTrivyWithTimeout, type TrivyDetectionConfig } from './trivy/detection.js';
 import { trivyStatusTracker } from './trivy/state.js';
 import { TrivyDetectionManager } from './trivy/detection-manager.js';
+import { runWorkloadImageScanCycle } from './trivy/workload-scan-cycle.js';
 import { SchemaManager } from './database/schema.js';
 import { KubernetesEventWatcher } from './events/kubernetes-event-watcher.js';
 import { EventQueueWorker } from './events/queue-worker.js';
@@ -335,6 +336,31 @@ export async function startOperator() {
           recordCollection('resource-configuration-patterns', 'failed', durationSeconds);
           collectionStatsTracker.recordFailure('resource-configuration-patterns');
           // Don't throw - scheduler will retry on next interval
+        }
+      }
+    );
+
+    collectionScheduler.register(
+      'workload-image-scan',
+      config.workloadImageScanIntervalSeconds,
+      3600, // 1 hour minimum interval
+      3600, // 0-1 hour random offset range
+      async () => {
+        const startTime = Date.now();
+        try {
+          await runWorkloadImageScanCycle({
+            kubernetesClient,
+            getTrivyStatus: () => trivyStatusTracker.getStatus(),
+          });
+          const durationSeconds = (Date.now() - startTime) / 1000;
+          recordCollection('workload-image-scan', 'success', durationSeconds);
+          collectionStatsTracker.recordSuccess('workload-image-scan');
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          logger.error('Workload image collection or scan cycle failed', { error: errorMessage });
+          const durationSeconds = (Date.now() - startTime) / 1000;
+          recordCollection('workload-image-scan', 'failed', durationSeconds);
+          collectionStatsTracker.recordFailure('workload-image-scan');
         }
       }
     );

--- a/src/registration/manager.test.ts
+++ b/src/registration/manager.test.ts
@@ -21,6 +21,7 @@ function createMockConfig(): Config {
     clusterMetadataIntervalSeconds: 86400,
     resourceInventoryIntervalSeconds: 21600,
     resourceConfigurationPatternsIntervalSeconds: 43200,
+    workloadImageScanIntervalSeconds: 86400,
     eventRetentionInfoWarningDays: 7,
     eventRetentionErrorCriticalDays: 30,
   };

--- a/src/status/calculator.test.ts
+++ b/src/status/calculator.test.ts
@@ -38,6 +38,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -81,6 +82,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -104,6 +106,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -137,6 +140,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -159,6 +163,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -181,6 +186,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -226,6 +232,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -254,6 +261,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -281,6 +289,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -310,6 +319,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -347,6 +357,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -390,6 +401,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -438,6 +450,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -466,6 +479,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');

--- a/src/trivy/collect-workload-images.test.ts
+++ b/src/trivy/collect-workload-images.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { collectImagesFromListResponses } from './collect-workload-images.js';
+import type * as k8s from '@kubernetes/client-node';
+
+describe('collectImagesFromListResponses', () => {
+  it('dedupes across pods, deployments, and statefulsets', () => {
+    const pods: k8s.V1PodList = {
+      apiVersion: 'v1',
+      kind: 'PodList',
+      items: [
+        {
+          metadata: { name: 'p', namespace: 'ns' },
+          spec: {
+            containers: [{ name: 'c', image: 'shared:1' }],
+            initContainers: [{ name: 'i', image: 'init:1' }],
+          },
+        },
+      ],
+    };
+    const deployments: k8s.V1DeploymentList = {
+      apiVersion: 'apps/v1',
+      kind: 'DeploymentList',
+      items: [
+        {
+          metadata: { name: 'd', namespace: 'ns' },
+          spec: {
+            selector: { matchLabels: { app: 'd' } },
+            template: {
+              metadata: { labels: { app: 'd' } },
+              spec: {
+                containers: [{ name: 'c', image: 'shared:1' }],
+                initContainers: [{ name: 'i', image: 'init:1' }],
+              },
+            },
+          },
+        },
+      ],
+    };
+    const statefulSets: k8s.V1StatefulSetList = {
+      apiVersion: 'apps/v1',
+      kind: 'StatefulSetList',
+      items: [
+        {
+          metadata: { name: 's', namespace: 'ns' },
+          spec: {
+            selector: { matchLabels: { app: 's' } },
+            template: {
+              metadata: { labels: { app: 's' } },
+              spec: {
+                containers: [{ name: 'c', image: 'sts:1' }],
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    const { images, truncated } = collectImagesFromListResponses({
+      pods,
+      deployments,
+      statefulSets,
+    });
+    expect(truncated).toBe(false);
+    expect(images).toEqual(['init:1', 'shared:1', 'sts:1']);
+  });
+});

--- a/src/trivy/collect-workload-images.ts
+++ b/src/trivy/collect-workload-images.ts
@@ -1,0 +1,82 @@
+/**
+ * Lists Pods, Deployments, and StatefulSets and collects distinct normalized container image references.
+ * Uses existing read-only workload RBAC; does not invoke Trivy.
+ */
+
+import type * as k8s from '@kubernetes/client-node';
+import type { KubernetesClient } from '../kubernetes/client.js';
+import {
+  DEFAULT_MAX_UNIQUE_WORKLOAD_IMAGES,
+  addPodSpecImagesInto,
+} from './workload-images.js';
+
+export interface CollectWorkloadImagesResult {
+  /** Sorted unique normalized image references */
+  images: string[];
+  /** True if the unique cap was reached while still finding new references */
+  truncated: boolean;
+}
+
+/**
+ * Collect distinct container image references from all Pods, Deployments, and StatefulSets cluster-wide.
+ * ReplicaSets are not listed separately; their images are covered by Pods and Deployment templates.
+ */
+export async function collectWorkloadImageReferences(
+  client: KubernetesClient,
+  options?: { maxUniqueImages?: number }
+): Promise<CollectWorkloadImagesResult> {
+  const maxUnique = options?.maxUniqueImages ?? DEFAULT_MAX_UNIQUE_WORKLOAD_IMAGES;
+  const unique = new Set<string>();
+  let truncated = false;
+  const onTruncated = (): void => {
+    truncated = true;
+  };
+
+  const [podsRes, deploymentsRes, statefulSetsRes] = await Promise.all([
+    client.coreApi.listPodForAllNamespaces(),
+    client.appsApi.listDeploymentForAllNamespaces(),
+    client.appsApi.listStatefulSetForAllNamespaces(),
+  ]);
+
+  for (const pod of podsRes.items ?? []) {
+    addPodSpecImagesInto(unique, pod.spec, maxUnique, onTruncated);
+  }
+
+  for (const d of deploymentsRes.items ?? []) {
+    addPodSpecImagesInto(unique, d.spec?.template?.spec, maxUnique, onTruncated);
+  }
+
+  for (const s of statefulSetsRes.items ?? []) {
+    addPodSpecImagesInto(unique, s.spec?.template?.spec, maxUnique, onTruncated);
+  }
+
+  const images = Array.from(unique).sort((a, b) => a.localeCompare(b));
+  return { images, truncated };
+}
+
+/** @internal Exported for tests that build mock list responses */
+export function collectImagesFromListResponses(responses: {
+  pods: k8s.V1PodList;
+  deployments: k8s.V1DeploymentList;
+  statefulSets: k8s.V1StatefulSetList;
+}): CollectWorkloadImagesResult {
+  const maxUnique = DEFAULT_MAX_UNIQUE_WORKLOAD_IMAGES;
+  const unique = new Set<string>();
+  let truncated = false;
+  const onTruncated = (): void => {
+    truncated = true;
+  };
+
+  for (const pod of responses.pods.items ?? []) {
+    addPodSpecImagesInto(unique, pod.spec, maxUnique, onTruncated);
+  }
+  for (const d of responses.deployments.items ?? []) {
+    addPodSpecImagesInto(unique, d.spec?.template?.spec, maxUnique, onTruncated);
+  }
+  for (const s of responses.statefulSets.items ?? []) {
+    addPodSpecImagesInto(unique, s.spec?.template?.spec, maxUnique, onTruncated);
+  }
+
+  const images = Array.from(unique).sort((a, b) => a.localeCompare(b));
+  return { images, truncated };
+}

--- a/src/trivy/workload-images.test.ts
+++ b/src/trivy/workload-images.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeContainerImageRef,
+  extractImagesFromPodSpec,
+} from './workload-images.js';
+import type * as k8s from '@kubernetes/client-node';
+
+describe('normalizeContainerImageRef', () => {
+  it('trims whitespace and rejects empty', () => {
+    expect(normalizeContainerImageRef('  alpine:3.20  ')).toBe('alpine:3.20');
+    expect(normalizeContainerImageRef('')).toBeNull();
+    expect(normalizeContainerImageRef('   ')).toBeNull();
+  });
+
+  it('preserves digest and tag forms as reported by Kubernetes', () => {
+    expect(normalizeContainerImageRef('repo.io/ns/app:v1@sha256:abc')).toBe(
+      'repo.io/ns/app:v1@sha256:abc'
+    );
+    expect(normalizeContainerImageRef('busybox:latest')).toBe('busybox:latest');
+  });
+});
+
+describe('extractImagesFromPodSpec', () => {
+  it('collects containers, initContainers, and ephemeralContainers', () => {
+    const spec: k8s.V1PodSpec = {
+      containers: [{ name: 'a', image: 'img:a' }],
+      initContainers: [{ name: 'i', image: 'img:b' }],
+      ephemeralContainers: [{ name: 'e', image: 'img:a' }],
+    };
+    const { images, truncated } = extractImagesFromPodSpec(spec);
+    expect(truncated).toBe(false);
+    expect(images).toEqual(['img:a', 'img:b']);
+  });
+
+  it('dedupes within the spec and sorts', () => {
+    const spec: k8s.V1PodSpec = {
+      containers: [
+        { name: 'x', image: 'z:1' },
+        { name: 'y', image: 'a:1' },
+      ],
+    };
+    expect(extractImagesFromPodSpec(spec).images).toEqual(['a:1', 'z:1']);
+  });
+
+  it('respects maxUnique for a single spec', () => {
+    const spec: k8s.V1PodSpec = {
+      containers: [
+        { name: 'a', image: 'one:1' },
+        { name: 'b', image: 'two:2' },
+        { name: 'c', image: 'three:3' },
+      ],
+    };
+    const { images, truncated } = extractImagesFromPodSpec(spec, { maxUnique: 2 });
+    expect(truncated).toBe(true);
+    expect(images.length).toBeLessThanOrEqual(2);
+  });
+});

--- a/src/trivy/workload-images.ts
+++ b/src/trivy/workload-images.ts
@@ -1,0 +1,99 @@
+/**
+ * Container image references from workload API objects (Pods, Deployments, StatefulSets).
+ *
+ * Normalization for Trivy scanner input:
+ * - Leading and trailing whitespace is stripped; empty values are ignored.
+ * - References are passed through as Kubernetes reports them (tag and/or digest).
+ * - When a digest is present (`repo@sha256:...` or `:tag@sha256:...`), that immutable
+ *   form is preferred for scanning; tag-only refs are unchanged.
+ *
+ * This module does not call Trivy or any scanner; it only shapes strings from the API.
+ */
+
+import type * as k8s from '@kubernetes/client-node';
+
+/** Default cap on distinct normalized references collected per pass (deterministic truncation). */
+export const DEFAULT_MAX_UNIQUE_WORKLOAD_IMAGES = 10_000;
+
+/**
+ * Normalize a raw container image field from the API for deduplication and scanner input.
+ */
+export function normalizeContainerImageRef(raw: string): string | null {
+  const s = raw.trim();
+  if (!s.length) {
+    return null;
+  }
+  return s;
+}
+
+function addImagesFromContainers(
+  containers: k8s.V1Container[] | undefined,
+  into: Set<string>,
+  maxUnique: number,
+  onTruncated: () => void
+): void {
+  if (!containers?.length) {
+    return;
+  }
+  for (const c of containers) {
+    tryAddNormalized(into, c.image, maxUnique, onTruncated);
+  }
+}
+
+function tryAddNormalized(
+  into: Set<string>,
+  raw: string | undefined,
+  maxUnique: number,
+  onTruncated: () => void
+): void {
+  const n = normalizeContainerImageRef(raw ?? '');
+  if (!n) {
+    return;
+  }
+  if (into.has(n)) {
+    return;
+  }
+  if (into.size >= maxUnique) {
+    onTruncated();
+    return;
+  }
+  into.add(n);
+}
+
+/**
+ * Add all image references from a Pod spec into a shared set (for cross-resource collection with one cap).
+ */
+export function addPodSpecImagesInto(
+  into: Set<string>,
+  spec: k8s.V1PodSpec | undefined,
+  maxUnique: number,
+  onTruncated: () => void
+): void {
+  addImagesFromContainers(spec?.containers, into, maxUnique, onTruncated);
+  addImagesFromContainers(spec?.initContainers, into, maxUnique, onTruncated);
+  if (spec?.ephemeralContainers?.length) {
+    for (const ec of spec.ephemeralContainers) {
+      tryAddNormalized(into, ec.image, maxUnique, onTruncated);
+    }
+  }
+}
+
+/**
+ * Extract normalized image references from a Pod spec (containers, init, ephemeral).
+ */
+export function extractImagesFromPodSpec(
+  spec: k8s.V1PodSpec | undefined,
+  options?: { maxUnique?: number }
+): { images: string[]; truncated: boolean } {
+  const maxUnique = options?.maxUnique ?? DEFAULT_MAX_UNIQUE_WORKLOAD_IMAGES;
+  const into = new Set<string>();
+  let truncated = false;
+  const onTruncated = (): void => {
+    truncated = true;
+  };
+
+  addPodSpecImagesInto(into, spec, maxUnique, onTruncated);
+
+  const images = Array.from(into).sort((a, b) => a.localeCompare(b));
+  return { images, truncated };
+}

--- a/src/trivy/workload-scan-cycle.test.ts
+++ b/src/trivy/workload-scan-cycle.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { runWorkloadImageScanCycle } from './workload-scan-cycle.js';
+import type { KubernetesClient } from '../kubernetes/client.js';
+import type { TrivyStatus } from '../status/types.js';
+import * as collectMod from './collect-workload-images.js';
+import * as scannerMod from './scanner.js';
+
+describe('runWorkloadImageScanCycle', () => {
+  const client = {} as KubernetesClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.TRIVY_MAX_SCANS_PER_CYCLE;
+  });
+
+  it('collects but skips scans when Trivy is not detected', async () => {
+    vi.spyOn(collectMod, 'collectWorkloadImageReferences').mockResolvedValue({
+      images: ['a:1'],
+      truncated: false,
+    });
+    const scanSpy = vi.spyOn(scannerMod, 'scanContainerImageWhenDetected');
+
+    const getTrivyStatus = (): TrivyStatus => ({
+      detected: false,
+      serverUrl: null,
+      version: null,
+      lastChecked: new Date().toISOString(),
+    });
+
+    const r = await runWorkloadImageScanCycle({ kubernetesClient: client, getTrivyStatus });
+    expect(r.scansSkippedDueToTrivy).toBe(true);
+    expect(r.uniqueImagesCollected).toBe(1);
+    expect(scanSpy).not.toHaveBeenCalled();
+  });
+
+  it('collects and scans when Trivy is detected', async () => {
+    vi.spyOn(collectMod, 'collectWorkloadImageReferences').mockResolvedValue({
+      images: ['alpine:3', 'busybox:1'],
+      truncated: false,
+    });
+    const scanSpy = vi.spyOn(scannerMod, 'scanContainerImageWhenDetected').mockResolvedValue({});
+
+    const getTrivyStatus = (): TrivyStatus => ({
+      detected: true,
+      serverUrl: 'http://trivy:4954',
+      version: '1',
+      lastChecked: new Date().toISOString(),
+    });
+
+    const r = await runWorkloadImageScanCycle({
+      kubernetesClient: client,
+      getTrivyStatus,
+      maxScansPerCycle: 10,
+    });
+
+    expect(r.scansSkippedDueToTrivy).toBe(false);
+    expect(r.uniqueImagesCollected).toBe(2);
+    expect(r.scansAttempted).toBe(2);
+    expect(r.scansSucceeded).toBe(2);
+    expect(scanSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('continues after a failed scan', async () => {
+    vi.spyOn(collectMod, 'collectWorkloadImageReferences').mockResolvedValue({
+      images: ['a:1', 'b:2'],
+      truncated: false,
+    });
+    const scanSpy = vi
+      .spyOn(scannerMod, 'scanContainerImageWhenDetected')
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce({});
+
+    const getTrivyStatus = (): TrivyStatus => ({
+      detected: true,
+      serverUrl: 'http://trivy:4954',
+      version: '1',
+      lastChecked: new Date().toISOString(),
+    });
+
+    const r = await runWorkloadImageScanCycle({
+      kubernetesClient: client,
+      getTrivyStatus,
+      maxScansPerCycle: 10,
+    });
+
+    expect(r.scansFailed).toBe(1);
+    expect(r.scansSucceeded).toBe(1);
+    expect(scanSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/trivy/workload-scan-cycle.ts
+++ b/src/trivy/workload-scan-cycle.ts
@@ -1,0 +1,119 @@
+/**
+ * One pass: collect workload image references from the API, then optionally
+ * run Trivy scans for each reference when Trivy integration is active.
+ */
+
+import type { KubernetesClient } from '../kubernetes/client.js';
+import type { TrivyStatus } from '../status/types.js';
+import { logger } from '../logging/logger.js';
+import { collectWorkloadImageReferences } from './collect-workload-images.js';
+import { scanContainerImageWhenDetected } from './scanner.js';
+import { DEFAULT_MAX_UNIQUE_WORKLOAD_IMAGES } from './workload-images.js';
+
+export interface WorkloadScanCycleOptions {
+  kubernetesClient: KubernetesClient;
+  getTrivyStatus: () => TrivyStatus;
+  /** Max distinct normalized refs to collect (default: 10_000) */
+  maxUniqueImages?: number;
+  /** Max scans to run per cycle (default: 100) */
+  maxScansPerCycle?: number;
+}
+
+export interface WorkloadScanCycleResult {
+  /** True when Trivy was not active, so no scans were run (collection may still have run) */
+  scansSkippedDueToTrivy: boolean;
+  uniqueImagesCollected: number;
+  truncated: boolean;
+  scansAttempted: number;
+  scansSucceeded: number;
+  scansFailed: number;
+}
+
+function parseMaxScansPerCycle(): number {
+  const raw = process.env.TRIVY_MAX_SCANS_PER_CYCLE;
+  if (raw === undefined || raw === '') {
+    return 100;
+  }
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : 100;
+}
+
+/**
+ * Collects workload images from the API (no Trivy dependency), then feeds the list
+ * into the Trivy CLI scan path only when Trivy is detected and available.
+ */
+export async function runWorkloadImageScanCycle(
+  options: WorkloadScanCycleOptions
+): Promise<WorkloadScanCycleResult> {
+  const maxUnique = options.maxUniqueImages ?? DEFAULT_MAX_UNIQUE_WORKLOAD_IMAGES;
+  const maxScans = options.maxScansPerCycle ?? parseMaxScansPerCycle();
+
+  const { images, truncated } = await collectWorkloadImageReferences(options.kubernetesClient, {
+    maxUniqueImages: maxUnique,
+  });
+
+  const status = options.getTrivyStatus();
+  if (!status.detected || !status.serverUrl) {
+    logger.info('Workload images collected; skipping Trivy scans (integration not active)', {
+      uniqueImagesCollected: images.length,
+      truncated,
+    });
+    return {
+      scansSkippedDueToTrivy: true,
+      uniqueImagesCollected: images.length,
+      truncated,
+      scansAttempted: 0,
+      scansSucceeded: 0,
+      scansFailed: 0,
+    };
+  }
+
+  const toScan = images.slice(0, maxScans);
+  if (images.length > maxScans) {
+    logger.info('Workload image scan cycle limiting scans per cycle', {
+      totalUnique: images.length,
+      maxScansPerCycle: maxScans,
+    });
+  }
+
+  let scansSucceeded = 0;
+  let scansFailed = 0;
+
+  for (const imageRef of toScan) {
+    try {
+      await scanContainerImageWhenDetected(imageRef, {
+        getStatus: options.getTrivyStatus,
+      });
+      scansSucceeded++;
+    } catch (err) {
+      scansFailed++;
+      logger.warn('Trivy scan failed for workload image', {
+        imageRef,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  if (truncated) {
+    logger.warn('Workload image collection hit unique image cap', {
+      maxUniqueImages: maxUnique,
+    });
+  }
+
+  logger.info('Workload image scan cycle completed', {
+    uniqueImagesCollected: images.length,
+    truncated,
+    scansAttempted: toScan.length,
+    scansSucceeded,
+    scansFailed,
+  });
+
+  return {
+    scansSkippedDueToTrivy: false,
+    uniqueImagesCollected: images.length,
+    truncated,
+    scansAttempted: toScan.length,
+    scansSucceeded,
+    scansFailed,
+  };
+}


### PR DESCRIPTION
## Description

Implements deterministic, bounded collection of normalized container image references from **Pods**, **Deployments**, and **StatefulSets** using existing read-only workload RBAC. ReplicaSets are not listed separately; their images appear via Pods and higher-level templates.

- **`workload-images.ts`**: Trims and normalizes image strings; documents digest vs tag policy for Trivy input; extracts from `containers`, `initContainers`, and `ephemeralContainers` with a configurable cap on distinct refs (default 10,000).
- **`collect-workload-images.ts`**: Lists cluster-wide Pods, Deployments, and StatefulSets in parallel and merges unique sorted refs.
- **`workload-scan-cycle.ts`**: Runs collection on every cycle (no Trivy dependency). Feeds refs into `scanContainerImageWhenDetected` **only when** Trivy is detected; caps scans per cycle via `TRIVY_MAX_SCANS_PER_CYCLE` (default 100).
- **Operator**: Registers scheduler task `workload-image-scan` with `config.workloadImageScanIntervalSeconds` (env `WORKLOAD_IMAGE_SCAN_INTERVAL_SECONDS`, default 86400).
- **Helm**: `metrics.intervals.workloadImageScan`, `trivy.maxScansPerCycle`, and deployment env vars.

## Motivation and Context

Fixes [#97](https://github.com/alto9/kube9-operator/issues/97) (parent [#15](https://github.com/alto9/kube9-operator/issues/15)).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tests added/updated (`workload-images`, `collect-workload-images`, `workload-scan-cycle`)
- [x] All existing tests pass (`npm run lint`, `npm test`, `npm run test:integration`)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter (`npm run lint`)

Fixes #97