### PR TITLE
feat(database): SQLite image_scans and image_vulnerabilities (closes #98)

### DIFF
--- a/.forge/data/data_model.md
+++ b/.forge/data/data_model.md
@@ -134,7 +134,7 @@ Tracks database schema migrations.
 | applied_at | TEXT | NOT NULL | ISO 8601 timestamp when migration was applied |
 | description | TEXT | NULL | Migration description |
 
-### image_scans (planned, M3)
+### image_scans
 
 Records of vulnerability scan runs against a container image reference (digest or repo:tag as reported by the scanner).
 
@@ -149,9 +149,9 @@ Records of vulnerability scan runs against a container image reference (digest o
 | scanner | TEXT | NOT NULL | e.g. `trivy` |
 | error_message | TEXT | NULL | Populated when state is `failed` or scan was skipped due to missing scanner |
 
-**Indexes (planned):** `idx_image_scans_image_reference`, `idx_image_scans_completed_at DESC`, `idx_image_scans_state`.
+**Indexes:** `idx_image_scans_image_reference`, `idx_image_scans_completed_at DESC`, `idx_image_scans_state`.
 
-### image_vulnerabilities (planned, M3)
+### image_vulnerabilities
 
 Normalized vulnerability findings linked to a scan (and optionally to originating workload metadata via application logic).
 
@@ -167,6 +167,8 @@ Normalized vulnerability findings linked to a scan (and optionally to originatin
 | title | TEXT | NULL | Short title |
 | raw_metadata | TEXT | NULL | Optional JSON blob for scanner-specific fields |
 
-**Indexes (planned):** `idx_image_vulnerabilities_scan_id`, `idx_image_vulnerabilities_severity`, `idx_image_vulnerabilities_vulnerability_id`.
+**Indexes:** `idx_image_vulnerabilities_scan_id`, `idx_image_vulnerabilities_severity`, `idx_image_vulnerabilities_vulnerability_id`.
+
+**Retention:** Deleting a row in `image_scans` cascades to `image_vulnerabilities` (`ON DELETE CASCADE`). Optional time-based pruning is implemented in application code (`ImageScanRepository.deleteScansCompletedBefore`); there is no DB-level TTL trigger.
 
 **Note:** Collections and argocd_apps tables are planned for future milestones (M8/M9) but are not yet implemented in the current schema.

--- a/.forge/technical_concepts.json
+++ b/.forge/technical_concepts.json
@@ -22,7 +22,7 @@
     },
     {
       "title": "SQLite Storage",
-      "description": "better-sqlite3 at /data/kube9.db. Tables: assessments, assessment_history, events. argocd_apps and collections planned for M8/M9.",
+      "description": "better-sqlite3 at /data/kube9.db. Tables: assessments, assessment_history, events, image_scans, image_vulnerabilities. argocd_apps and collections planned for M8/M9.",
       "context_sources": [".forge/data/data_model.md", ".forge/data/persistence_abstractions.md"]
     },
     {

--- a/src/database/image-scan-contracts.ts
+++ b/src/database/image-scan-contracts.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+export const ImageScanStateSchema = z.enum([
+  'queued',
+  'running',
+  'completed',
+  'failed',
+  'skipped',
+]);
+
+export const ImageScanRecordSchema = z.object({
+  scan_id: z.string().min(1),
+  image_reference: z.string().min(1),
+  image_digest: z.string().min(1).optional().nullable(),
+  started_at: z.string().min(1),
+  completed_at: z.string().min(1).optional().nullable(),
+  state: ImageScanStateSchema,
+  scanner: z.string().min(1),
+  error_message: z.string().optional().nullable(),
+});
+
+export type ImageScanRecord = z.infer<typeof ImageScanRecordSchema>;
+
+export const ImageVulnerabilityInputSchema = z.object({
+  id: z.string().min(1),
+  scan_id: z.string().min(1),
+  vulnerability_id: z.string().min(1),
+  severity: z.string().min(1),
+  package_name: z.string().optional().nullable(),
+  installed_version: z.string().optional().nullable(),
+  fixed_version: z.string().optional().nullable(),
+  title: z.string().optional().nullable(),
+  raw_metadata: z.string().optional().nullable(),
+});
+
+export type ImageVulnerabilityInput = z.infer<typeof ImageVulnerabilityInputSchema>;

--- a/src/database/image-scan-repository.test.ts
+++ b/src/database/image-scan-repository.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { SchemaManager } from './schema.js';
+import { DatabaseManager } from './manager.js';
+import { ImageScanRepository } from './image-scan-repository.js';
+import { existsSync, rmSync, mkdirSync } from 'fs';
+import path from 'path';
+
+const testDbDir = path.join(process.cwd(), 'test-image-scan-temp');
+
+describe('ImageScanRepository', () => {
+  beforeAll(() => {
+    if (existsSync(testDbDir)) {
+      rmSync(testDbDir, { recursive: true, force: true });
+    }
+    mkdirSync(testDbDir, { recursive: true });
+    process.env.DB_PATH = testDbDir;
+  });
+
+  afterAll(() => {
+    DatabaseManager.reset();
+    if (existsSync(testDbDir)) {
+      rmSync(testDbDir, { recursive: true, force: true });
+    }
+    delete process.env.DB_PATH;
+  });
+
+  beforeEach(() => {
+    DatabaseManager.reset();
+    const dbPath = path.join(testDbDir, 'kube9.db');
+    if (existsSync(dbPath)) {
+      rmSync(dbPath);
+    }
+    const schema = new SchemaManager();
+    schema.initialize();
+  });
+
+  afterEach(() => {
+    DatabaseManager.reset();
+  });
+
+  it('stores and retrieves scans with filters', () => {
+    const repo = new ImageScanRepository();
+    const t0 = '2026-01-01T00:00:00.000Z';
+    const t1 = '2026-01-15T12:00:00.000Z';
+    repo.upsertScan({
+      scan_id: 'scan-a',
+      image_reference: 'docker.io/library/nginx:1.25',
+      started_at: t0,
+      completed_at: t1,
+      state: 'completed',
+      scanner: 'trivy',
+    });
+    repo.upsertScan({
+      scan_id: 'scan-b',
+      image_reference: 'gcr.io/foo/bar:v2',
+      started_at: '2026-02-01T00:00:00.000Z',
+      state: 'failed',
+      scanner: 'trivy',
+      error_message: 'timeout',
+    });
+
+    expect(repo.getScanById('scan-a')?.image_reference).toBe('docker.io/library/nginx:1.25');
+    const byRef = repo.queryScans({
+      filters: { image_reference: 'docker.io/library/nginx:1.25' },
+    });
+    expect(byRef).toHaveLength(1);
+
+    const contains = repo.queryScans({
+      filters: { image_reference_contains: 'nginx' },
+    });
+    expect(contains.map((s) => s.scan_id)).toContain('scan-a');
+
+    const inRange = repo.queryScans({
+      filters: { completed_from: '2026-01-10T00:00:00.000Z', completed_to: '2026-01-20T00:00:00.000Z' },
+    });
+    expect(inRange.map((s) => s.scan_id)).toEqual(['scan-a']);
+
+    expect(repo.countScans({ state: 'failed' })).toBe(1);
+  });
+
+  it('replaces vulnerabilities and filters by severity and time', () => {
+    const repo = new ImageScanRepository();
+    const started = '2026-03-01T10:00:00.000Z';
+    const completed = '2026-03-01T10:05:00.000Z';
+    repo.upsertScan({
+      scan_id: 'scan-1',
+      image_reference: 'alpine:3',
+      started_at: started,
+      completed_at: completed,
+      state: 'completed',
+      scanner: 'trivy',
+    });
+    repo.replaceVulnerabilitiesForScan('scan-1', [
+      {
+        id: 'v1',
+        scan_id: 'scan-1',
+        vulnerability_id: 'CVE-2024-1',
+        severity: 'HIGH',
+        title: 'test',
+      },
+      {
+        id: 'v2',
+        scan_id: 'scan-1',
+        vulnerability_id: 'CVE-2024-2',
+        severity: 'LOW',
+      },
+    ]);
+
+    expect(repo.countVulnerabilities({ scan_id: 'scan-1' })).toBe(2);
+    const highs = repo.queryVulnerabilities({
+      filters: { severity: 'HIGH', completed_from: '2026-03-01T00:00:00.000Z' },
+    });
+    expect(highs).toHaveLength(1);
+    expect(highs[0]?.vulnerability_id).toBe('CVE-2024-1');
+
+    repo.replaceVulnerabilitiesForScan('scan-1', [
+      {
+        id: 'v3',
+        scan_id: 'scan-1',
+        vulnerability_id: 'CVE-2024-3',
+        severity: 'CRITICAL',
+      },
+    ]);
+    expect(repo.countVulnerabilities({ scan_id: 'scan-1' })).toBe(1);
+  });
+
+  it('cascades deletes when removing a scan', () => {
+    const repo = new ImageScanRepository();
+    repo.upsertScan({
+      scan_id: 'scan-c',
+      image_reference: 'x:y',
+      started_at: new Date().toISOString(),
+      state: 'completed',
+      scanner: 'trivy',
+    });
+    repo.insertVulnerabilities([
+      {
+        id: 'row1',
+        scan_id: 'scan-c',
+        vulnerability_id: 'CVE-1',
+        severity: 'MEDIUM',
+      },
+    ]);
+    expect(repo.countVulnerabilities({ scan_id: 'scan-c' })).toBe(1);
+    repo.deleteScan('scan-c');
+    expect(repo.getScanById('scan-c')).toBeNull();
+    expect(repo.countVulnerabilities({ scan_id: 'scan-c' })).toBe(0);
+  });
+
+  it('deleteScansCompletedBefore removes old completed scans', () => {
+    const repo = new ImageScanRepository();
+    repo.upsertScan({
+      scan_id: 'old',
+      image_reference: 'a:b',
+      started_at: '2020-01-01T00:00:00.000Z',
+      completed_at: '2020-01-02T00:00:00.000Z',
+      state: 'completed',
+      scanner: 'trivy',
+    });
+    repo.upsertScan({
+      scan_id: 'new',
+      image_reference: 'c:d',
+      started_at: '2026-01-01T00:00:00.000Z',
+      completed_at: '2026-01-02T00:00:00.000Z',
+      state: 'completed',
+      scanner: 'trivy',
+    });
+    const n = repo.deleteScansCompletedBefore('2025-01-01T00:00:00.000Z');
+    expect(n).toBe(1);
+    expect(repo.getScanById('old')).toBeNull();
+    expect(repo.getScanById('new')).not.toBeNull();
+  });
+
+  it('empty repository returns no rows', () => {
+    const repo = new ImageScanRepository();
+    expect(repo.queryScans()).toEqual([]);
+    expect(repo.queryVulnerabilities()).toEqual([]);
+    expect(repo.countScans()).toBe(0);
+    expect(repo.countVulnerabilities()).toBe(0);
+  });
+});

--- a/src/database/image-scan-repository.ts
+++ b/src/database/image-scan-repository.ts
@@ -1,0 +1,381 @@
+/**
+ * Persistence for Trivy (or other) image scans and normalized vulnerability rows.
+ */
+
+import { DatabaseManager } from './manager.js';
+import Database from 'better-sqlite3';
+import {
+  ImageScanRecord,
+  ImageScanRecordSchema,
+  ImageVulnerabilityInput,
+  ImageVulnerabilityInputSchema,
+} from './image-scan-contracts.js';
+
+export interface ImageScanRow {
+  scan_id: string;
+  image_reference: string;
+  image_digest: string | null;
+  started_at: string;
+  completed_at: string | null;
+  state: string;
+  scanner: string;
+  error_message: string | null;
+}
+
+export interface ImageVulnerabilityRow {
+  id: string;
+  scan_id: string;
+  vulnerability_id: string;
+  severity: string;
+  package_name: string | null;
+  installed_version: string | null;
+  fixed_version: string | null;
+  title: string | null;
+  raw_metadata: string | null;
+}
+
+export interface ImageScanFilters {
+  state?: string;
+  image_reference?: string;
+  /** Match image_reference with SQL LIKE '%' || value || '%' */
+  image_reference_contains?: string;
+  started_from?: string;
+  started_to?: string;
+  completed_from?: string;
+  completed_to?: string;
+}
+
+export interface ImageScanQueryOptions {
+  filters?: ImageScanFilters;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ImageVulnerabilityFilters {
+  scan_id?: string;
+  severity?: string | string[];
+  vulnerability_id?: string;
+  image_reference?: string;
+  /** Time range on parent scan completed_at (ISO 8601), inclusive */
+  completed_from?: string;
+  completed_to?: string;
+}
+
+export interface ImageVulnerabilityQueryOptions {
+  filters?: ImageVulnerabilityFilters;
+  limit?: number;
+  offset?: number;
+}
+
+export class ImageScanRepository {
+  private db: Database.Database;
+
+  constructor() {
+    const manager = DatabaseManager.getInstance();
+    this.db = manager.getDatabase();
+  }
+
+  public upsertScan(record: ImageScanRecord): void {
+    const v = ImageScanRecordSchema.parse(record);
+    const stmt = this.db.prepare(`
+      INSERT INTO image_scans (
+        scan_id, image_reference, image_digest, started_at, completed_at,
+        state, scanner, error_message
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(scan_id) DO UPDATE SET
+        image_reference = excluded.image_reference,
+        image_digest = excluded.image_digest,
+        started_at = excluded.started_at,
+        completed_at = COALESCE(excluded.completed_at, completed_at),
+        state = excluded.state,
+        scanner = excluded.scanner,
+        error_message = excluded.error_message
+    `);
+    stmt.run(
+      v.scan_id,
+      v.image_reference,
+      v.image_digest ?? null,
+      v.started_at,
+      v.completed_at ?? null,
+      v.state,
+      v.scanner,
+      v.error_message ?? null
+    );
+  }
+
+  public getScanById(scanId: string): ImageScanRecord | null {
+    const row = this.db
+      .prepare('SELECT * FROM image_scans WHERE scan_id = ?')
+      .get(scanId) as ImageScanRow | undefined;
+    if (!row) return null;
+    return this.rowToScanRecord(row);
+  }
+
+  public queryScans(options: ImageScanQueryOptions = {}): ImageScanRecord[] {
+    const { filters = {}, limit = 100, offset = 0 } = options;
+    const conditions: string[] = [];
+    const params: (string | number)[] = [];
+
+    if (filters.state) {
+      conditions.push('state = ?');
+      params.push(filters.state);
+    }
+    if (filters.image_reference) {
+      conditions.push('image_reference = ?');
+      params.push(filters.image_reference);
+    }
+    if (filters.image_reference_contains) {
+      conditions.push('image_reference LIKE ?');
+      params.push(`%${filters.image_reference_contains}%`);
+    }
+    if (filters.started_from) {
+      conditions.push('started_at >= ?');
+      params.push(filters.started_from);
+    }
+    if (filters.started_to) {
+      conditions.push('started_at <= ?');
+      params.push(filters.started_to);
+    }
+    if (filters.completed_from) {
+      conditions.push('completed_at IS NOT NULL AND completed_at >= ?');
+      params.push(filters.completed_from);
+    }
+    if (filters.completed_to) {
+      conditions.push('completed_at IS NOT NULL AND completed_at <= ?');
+      params.push(filters.completed_to);
+    }
+
+    let query = 'SELECT * FROM image_scans';
+    if (conditions.length > 0) {
+      query += ' WHERE ' + conditions.join(' AND ');
+    }
+    query += ' ORDER BY started_at DESC LIMIT ? OFFSET ?';
+    params.push(limit, offset);
+
+    const rows = this.db.prepare(query).all(...params) as ImageScanRow[];
+    return rows.map((r) => this.rowToScanRecord(r));
+  }
+
+  public countScans(filters: ImageScanFilters = {}): number {
+    const conditions: string[] = [];
+    const params: string[] = [];
+
+    if (filters.state) {
+      conditions.push('state = ?');
+      params.push(filters.state);
+    }
+    if (filters.image_reference) {
+      conditions.push('image_reference = ?');
+      params.push(filters.image_reference);
+    }
+    if (filters.image_reference_contains) {
+      conditions.push('image_reference LIKE ?');
+      params.push(`%${filters.image_reference_contains}%`);
+    }
+    if (filters.started_from) {
+      conditions.push('started_at >= ?');
+      params.push(filters.started_from);
+    }
+    if (filters.started_to) {
+      conditions.push('started_at <= ?');
+      params.push(filters.started_to);
+    }
+    if (filters.completed_from) {
+      conditions.push('completed_at IS NOT NULL AND completed_at >= ?');
+      params.push(filters.completed_from);
+    }
+    if (filters.completed_to) {
+      conditions.push('completed_at IS NOT NULL AND completed_at <= ?');
+      params.push(filters.completed_to);
+    }
+
+    let query = 'SELECT COUNT(*) as count FROM image_scans';
+    if (conditions.length > 0) {
+      query += ' WHERE ' + conditions.join(' AND ');
+    }
+    const result = this.db.prepare(query).get(...params) as { count: number };
+    return result.count;
+  }
+
+  /**
+   * Replace all vulnerability rows for a scan (idempotent completion write).
+   */
+  public replaceVulnerabilitiesForScan(
+    scanId: string,
+    rows: ImageVulnerabilityInput[]
+  ): void {
+    const validated = rows.map((r) => ImageVulnerabilityInputSchema.parse(r));
+    const del = this.db.prepare('DELETE FROM image_vulnerabilities WHERE scan_id = ?');
+    const ins = this.db.prepare(`
+      INSERT INTO image_vulnerabilities (
+        id, scan_id, vulnerability_id, severity, package_name,
+        installed_version, fixed_version, title, raw_metadata
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    const run = this.db.transaction(() => {
+      del.run(scanId);
+      for (const row of validated) {
+        ins.run(
+          row.id,
+          row.scan_id,
+          row.vulnerability_id,
+          row.severity,
+          row.package_name ?? null,
+          row.installed_version ?? null,
+          row.fixed_version ?? null,
+          row.title ?? null,
+          row.raw_metadata ?? null
+        );
+      }
+    });
+    run();
+  }
+
+  public insertVulnerabilities(rows: ImageVulnerabilityInput[]): void {
+    if (rows.length === 0) return;
+    const validated = rows.map((r) => ImageVulnerabilityInputSchema.parse(r));
+    const ins = this.db.prepare(`
+      INSERT INTO image_vulnerabilities (
+        id, scan_id, vulnerability_id, severity, package_name,
+        installed_version, fixed_version, title, raw_metadata
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    const run = this.db.transaction(() => {
+      for (const row of validated) {
+        ins.run(
+          row.id,
+          row.scan_id,
+          row.vulnerability_id,
+          row.severity,
+          row.package_name ?? null,
+          row.installed_version ?? null,
+          row.fixed_version ?? null,
+          row.title ?? null,
+          row.raw_metadata ?? null
+        );
+      }
+    });
+    run();
+  }
+
+  public queryVulnerabilities(
+    options: ImageVulnerabilityQueryOptions = {}
+  ): ImageVulnerabilityRow[] {
+    const { filters = {}, limit = 500, offset = 0 } = options;
+    const conditions: string[] = [];
+    const params: (string | number)[] = [];
+
+    if (filters.scan_id) {
+      conditions.push('v.scan_id = ?');
+      params.push(filters.scan_id);
+    }
+    if (filters.vulnerability_id) {
+      conditions.push('v.vulnerability_id = ?');
+      params.push(filters.vulnerability_id);
+    }
+    if (filters.image_reference) {
+      conditions.push('s.image_reference = ?');
+      params.push(filters.image_reference);
+    }
+    if (filters.severity) {
+      const sev = Array.isArray(filters.severity) ? filters.severity : [filters.severity];
+      conditions.push(`v.severity IN (${sev.map(() => '?').join(',')})`);
+      params.push(...sev);
+    }
+    if (filters.completed_from) {
+      conditions.push('s.completed_at IS NOT NULL AND s.completed_at >= ?');
+      params.push(filters.completed_from);
+    }
+    if (filters.completed_to) {
+      conditions.push('s.completed_at IS NOT NULL AND s.completed_at <= ?');
+      params.push(filters.completed_to);
+    }
+
+    let query = `
+      SELECT v.id, v.scan_id, v.vulnerability_id, v.severity, v.package_name,
+             v.installed_version, v.fixed_version, v.title, v.raw_metadata
+      FROM image_vulnerabilities v
+      INNER JOIN image_scans s ON s.scan_id = v.scan_id
+    `;
+    if (conditions.length > 0) {
+      query += ' WHERE ' + conditions.join(' AND ');
+    }
+    query += ' ORDER BY v.severity DESC, v.vulnerability_id ASC LIMIT ? OFFSET ?';
+    params.push(limit, offset);
+
+    return this.db.prepare(query).all(...params) as ImageVulnerabilityRow[];
+  }
+
+  public countVulnerabilities(filters: ImageVulnerabilityFilters = {}): number {
+    const conditions: string[] = [];
+    const params: string[] = [];
+
+    if (filters.scan_id) {
+      conditions.push('v.scan_id = ?');
+      params.push(filters.scan_id);
+    }
+    if (filters.vulnerability_id) {
+      conditions.push('v.vulnerability_id = ?');
+      params.push(filters.vulnerability_id);
+    }
+    if (filters.image_reference) {
+      conditions.push('s.image_reference = ?');
+      params.push(filters.image_reference);
+    }
+    if (filters.severity) {
+      const sev = Array.isArray(filters.severity) ? filters.severity : [filters.severity];
+      conditions.push(`v.severity IN (${sev.map(() => '?').join(',')})`);
+      params.push(...sev);
+    }
+    if (filters.completed_from) {
+      conditions.push('s.completed_at IS NOT NULL AND s.completed_at >= ?');
+      params.push(filters.completed_from);
+    }
+    if (filters.completed_to) {
+      conditions.push('s.completed_at IS NOT NULL AND s.completed_at <= ?');
+      params.push(filters.completed_to);
+    }
+
+    let query = `
+      SELECT COUNT(*) as count
+      FROM image_vulnerabilities v
+      INNER JOIN image_scans s ON s.scan_id = v.scan_id
+    `;
+    if (conditions.length > 0) {
+      query += ' WHERE ' + conditions.join(' AND ');
+    }
+    const result = this.db.prepare(query).get(...params) as { count: number };
+    return result.count;
+  }
+
+  public deleteScan(scanId: string): number {
+    const r = this.db.prepare('DELETE FROM image_scans WHERE scan_id = ?').run(scanId);
+    return r.changes;
+  }
+
+  /**
+   * Retention helper: remove completed scans (and cascaded vulnerabilities) older than cutoff.
+   */
+  public deleteScansCompletedBefore(isoTimestamp: string): number {
+    const r = this.db
+      .prepare(
+        `DELETE FROM image_scans WHERE completed_at IS NOT NULL AND completed_at < ?`
+      )
+      .run(isoTimestamp);
+    return r.changes;
+  }
+
+  private rowToScanRecord(row: ImageScanRow): ImageScanRecord {
+    return ImageScanRecordSchema.parse({
+      scan_id: row.scan_id,
+      image_reference: row.image_reference,
+      image_digest: row.image_digest ?? undefined,
+      started_at: row.started_at,
+      completed_at: row.completed_at ?? undefined,
+      state: row.state,
+      scanner: row.scanner,
+      error_message: row.error_message ?? undefined,
+    });
+  }
+}

--- a/src/database/schema.test.ts
+++ b/src/database/schema.test.ts
@@ -116,7 +116,7 @@ describe('SchemaManager', () => {
     
     expect(versions.length).toBeGreaterThanOrEqual(1);
     expect(versions[0]?.version).toBe(1);
-    expect(schema.getVersion()).toBeGreaterThanOrEqual(2);
+    expect(schema.getVersion()).toBeGreaterThanOrEqual(3);
   });
 
   it('schema version has correct fields', () => {
@@ -256,7 +256,33 @@ describe('SchemaManager', () => {
     const versionAfter = schema.getVersion();
     
     expect(versionBefore).toBe(versionAfter);
-    expect(versionAfter).toBeGreaterThanOrEqual(2);
+    expect(versionAfter).toBeGreaterThanOrEqual(3);
+  });
+
+  it('creates image_scans and image_vulnerabilities when migrating to v3', () => {
+    const schema = new SchemaManager();
+    schema.initialize();
+
+    const manager = DatabaseManager.getInstance();
+    const db = manager.getDatabase();
+
+    const scans = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='image_scans'`)
+      .get() as { name: string } | undefined;
+    expect(scans?.name).toBe('image_scans');
+
+    const vulns = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='image_vulnerabilities'`)
+      .get() as { name: string } | undefined;
+    expect(vulns?.name).toBe('image_vulnerabilities');
+
+    const fk = db.prepare(`PRAGMA foreign_key_list(image_vulnerabilities)`).all() as Array<{
+      table: string;
+      from: string;
+      to: string;
+    }>;
+    const scanFk = fk.find((x) => x.from === 'scan_id' && x.table === 'image_scans');
+    expect(scanFk?.to).toBe('scan_id');
   });
 
   it('migration runs cleanly on fresh database', () => {
@@ -264,7 +290,7 @@ describe('SchemaManager', () => {
     const schema = new SchemaManager();
     schema.initialize();
     
-    expect(schema.getVersion()).toBeGreaterThanOrEqual(1);
+    expect(schema.getVersion()).toBeGreaterThanOrEqual(3);
     
     const manager = DatabaseManager.getInstance();
     const db = manager.getDatabase();

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -7,7 +7,7 @@ import Database from 'better-sqlite3';
 import { logger } from '../logging/logger.js';
 
 /** Latest schema version - bump when adding migrations */
-const LATEST_SCHEMA_VERSION = 2;
+const LATEST_SCHEMA_VERSION = 3;
 
 /**
  * SchemaManager handles database schema initialization and migrations
@@ -49,6 +49,10 @@ export class SchemaManager {
       {
         version: 2,
         apply: () => this.migrateToV2(),
+      },
+      {
+        version: 3,
+        apply: () => this.migrateToV3(),
       },
     ];
 
@@ -111,6 +115,47 @@ export class SchemaManager {
       CREATE INDEX IF NOT EXISTS idx_assessment_history_status ON assessment_history(status);
       CREATE INDEX IF NOT EXISTS idx_assessment_history_assessed_at ON assessment_history(assessed_at DESC);
       CREATE INDEX IF NOT EXISTS idx_assessment_history_run_pillar ON assessment_history(run_id, pillar);
+    `);
+  }
+
+  /**
+   * Migration v3: image vulnerability scan storage (M3 Security).
+   * Retention: child rows use ON DELETE CASCADE from image_scans; optional
+   * time-based pruning is left to application code (see ImageScanRepository.deleteScansCompletedBefore).
+   */
+  private migrateToV3(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS image_scans (
+        scan_id TEXT PRIMARY KEY,
+        image_reference TEXT NOT NULL,
+        image_digest TEXT,
+        started_at TEXT NOT NULL,
+        completed_at TEXT,
+        state TEXT NOT NULL CHECK (state IN ('queued', 'running', 'completed', 'failed', 'skipped')),
+        scanner TEXT NOT NULL,
+        error_message TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_image_scans_image_reference ON image_scans(image_reference);
+      CREATE INDEX IF NOT EXISTS idx_image_scans_completed_at ON image_scans(completed_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_image_scans_state ON image_scans(state);
+
+      CREATE TABLE IF NOT EXISTS image_vulnerabilities (
+        id TEXT PRIMARY KEY,
+        scan_id TEXT NOT NULL,
+        vulnerability_id TEXT NOT NULL,
+        severity TEXT NOT NULL,
+        package_name TEXT,
+        installed_version TEXT,
+        fixed_version TEXT,
+        title TEXT,
+        raw_metadata TEXT,
+        FOREIGN KEY (scan_id) REFERENCES image_scans(scan_id) ON DELETE CASCADE
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_image_vulnerabilities_scan_id ON image_vulnerabilities(scan_id);
+      CREATE INDEX IF NOT EXISTS idx_image_vulnerabilities_severity ON image_vulnerabilities(severity);
+      CREATE INDEX IF NOT EXISTS idx_image_vulnerabilities_vulnerability_id ON image_vulnerabilities(vulnerability_id);
     `);
   }
 


### PR DESCRIPTION
## Summary

Implements [issue #98](https://github.com/alto9/kube9-operator/issues/98) (parent [#15](https://github.com/alto9/kube9-operator/issues/15)): SQLite schema v3 and persistence APIs for image vulnerability scans.

**Base branch:** `feature/issue-15` (parent epic), not `main`.

## Changes

- **Migration v3** (`schema.ts`): `image_scans` and `image_vulnerabilities` per `.forge/data/data_model.md`, with indexes and `FOREIGN KEY ... ON DELETE CASCADE` from vulnerabilities to scans.
- **`ImageScanRepository`**: upsert scans, replace/insert findings, query with filters (severity, image reference, completed time range), `deleteScan`, `deleteScansCompletedBefore` for optional retention.
- **Docs**: data model updated (tables no longer “planned”), retention note; `technical_concepts.json` SQLite blurb updated.
- **Tests**: `schema.test.ts` (v3 tables + FK), `image-scan-repository.test.ts` (filters, cascade, retention, empty DB).

## Acceptance

- Migrations apply on existing DBs (version &lt; 3 runs `migrateToV3` once; idempotent `CREATE IF NOT EXISTS`).
- Repository APIs covered by unit tests.
- Empty DB / no-scan path unchanged (no required scan data).

Closes #98