### PR TITLE
[#99] Assessment checks, CLI queries, and Prometheus metrics for vulnerabilities

### DIFF
--- a/src/assessment/bootstrap.ts
+++ b/src/assessment/bootstrap.ts
@@ -16,6 +16,7 @@ import {
   secretsInConfigMapsCheck,
   externalSecretsUsageCheck,
   hardcodedSecretsCheck,
+  storedVulnerabilityThresholdsCheck,
 } from './checks/security/index.js';
 import {
   replicaCountsCheck,
@@ -43,6 +44,7 @@ const BUILT_IN_CHECKS: AssessmentCheck[] = [
   secretsInConfigMapsCheck,
   externalSecretsUsageCheck,
   hardcodedSecretsCheck,
+  storedVulnerabilityThresholdsCheck,
   replicaCountsCheck,
   spreadAntiAffinityCheck,
   podDisruptionBudgetsCheck,

--- a/src/assessment/checks/security/index.ts
+++ b/src/assessment/checks/security/index.ts
@@ -10,3 +10,4 @@ export { rbacClusterAdminMisuseCheck } from './rbac-cluster-admin-misuse.js';
 export { secretsInConfigMapsCheck } from './secrets-in-configmaps.js';
 export { externalSecretsUsageCheck } from './external-secrets-usage.js';
 export { hardcodedSecretsCheck } from './hardcoded-secrets.js';
+export { storedVulnerabilityThresholdsCheck } from './stored-vulnerability-thresholds.js';

--- a/src/assessment/checks/security/stored-vulnerability-thresholds.test.ts
+++ b/src/assessment/checks/security/stored-vulnerability-thresholds.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { storedVulnerabilityThresholdsCheck } from './stored-vulnerability-thresholds.js';
+import type { AssessmentRunContext } from '../../types.js';
+import { AssessmentRunMode } from '../../types.js';
+
+function buildCtx(partial: Partial<AssessmentRunContext>): AssessmentRunContext {
+  return {
+    kubernetes: {} as AssessmentRunContext['kubernetes'],
+    config: {} as AssessmentRunContext['config'],
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as AssessmentRunContext['logger'],
+    timeoutMs: 30000,
+    runId: 'r1',
+    mode: AssessmentRunMode.Full,
+    ...partial,
+  } as AssessmentRunContext;
+}
+
+describe('storedVulnerabilityThresholdsCheck', () => {
+  afterEach(() => {
+    delete process.env.VULN_MAX_CRITICAL;
+    delete process.env.VULN_MAX_HIGH;
+    delete process.env.VULN_MAX_MEDIUM;
+  });
+
+  it('skips when getTrivyStatus reports not detected', async () => {
+    const r = await storedVulnerabilityThresholdsCheck.run(
+      buildCtx({
+        getTrivyStatus: () => ({
+          detected: false,
+          serverUrl: null,
+          version: null,
+          lastChecked: new Date().toISOString(),
+        }),
+      })
+    );
+    expect(r.status).toBe('skipped');
+  });
+
+  it('passes when under thresholds', async () => {
+    const r = await storedVulnerabilityThresholdsCheck.run(
+      buildCtx({
+        imageScanRepository: {
+          countVulnerabilitiesGroupedBySeverity: () => ({ critical: 0, high: 0, medium: 0 }),
+        } as unknown as AssessmentRunContext['imageScanRepository'],
+      })
+    );
+    expect(r.status).toBe('passing');
+  });
+
+  it('fails when critical exceeds max', async () => {
+    process.env.VULN_MAX_CRITICAL = '0';
+    const r = await storedVulnerabilityThresholdsCheck.run(
+      buildCtx({
+        imageScanRepository: {
+          countVulnerabilitiesGroupedBySeverity: () => ({ critical: 2 }),
+        } as unknown as AssessmentRunContext['imageScanRepository'],
+      })
+    );
+    expect(r.status).toBe('failing');
+  });
+});

--- a/src/assessment/checks/security/stored-vulnerability-thresholds.ts
+++ b/src/assessment/checks/security/stored-vulnerability-thresholds.ts
@@ -1,0 +1,99 @@
+/**
+ * Security Check: Stored vulnerability thresholds
+ *
+ * Evaluates counts persisted from Trivy (or other scanners) against optional
+ * maxima. When getTrivyStatus is provided and Trivy is not detected, the check
+ * is skipped so the operator does not fail solely due to missing scanning.
+ */
+
+import type { AssessmentCheck, AssessmentCheckResult, AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus, Severity } from '../../types.js';
+import { ImageScanRepository } from '../../../database/image-scan-repository.js';
+
+const CHECK_ID = 'security.stored-vulnerability-thresholds';
+const CHECK_NAME = 'Stored vulnerability severity thresholds';
+
+function maxAllowed(envName: string, defaultValue: number): number {
+  const raw = process.env[envName];
+  if (raw === undefined || raw === '') {
+    return defaultValue;
+  }
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : defaultValue;
+}
+
+export const storedVulnerabilityThresholdsCheck: AssessmentCheck = {
+  id: CHECK_ID,
+  name: CHECK_NAME,
+  pillar: Pillar.Security,
+  description:
+    'Compares stored vulnerability counts by severity to VULN_MAX_CRITICAL, VULN_MAX_HIGH, and VULN_MAX_MEDIUM',
+  defaultSeverity: Severity.High,
+
+  async run(ctx: AssessmentRunContext): Promise<AssessmentCheckResult> {
+    const getTrivy = ctx.getTrivyStatus;
+    if (getTrivy) {
+      const st = getTrivy();
+      if (!st.detected || !st.serverUrl) {
+        return {
+          checkId: CHECK_ID,
+          checkName: CHECK_NAME,
+          pillar: Pillar.Security,
+          status: CheckStatus.Skipped,
+          severity: Severity.Medium,
+          message:
+            'Vulnerability scanning is unavailable (Trivy not detected or unreachable); threshold check skipped.',
+        };
+      }
+    }
+
+    const repo = ctx.imageScanRepository ?? new ImageScanRepository();
+    const grouped = repo.countVulnerabilitiesGroupedBySeverity();
+
+    const critical = grouped.critical ?? 0;
+    const high = grouped.high ?? 0;
+    const medium = grouped.medium ?? 0;
+
+    const maxCritical = maxAllowed('VULN_MAX_CRITICAL', 0);
+    const maxHigh = maxAllowed('VULN_MAX_HIGH', 1_000_000);
+    const maxMedium = maxAllowed('VULN_MAX_MEDIUM', 1_000_000);
+
+    const parts: string[] = [];
+    let failing = false;
+
+    if (critical > maxCritical) {
+      failing = true;
+      parts.push(`critical ${critical} exceeds max ${maxCritical}`);
+    }
+    if (high > maxHigh) {
+      failing = true;
+      parts.push(`high ${high} exceeds max ${maxHigh}`);
+    }
+    if (medium > maxMedium) {
+      failing = true;
+      parts.push(`medium ${medium} exceeds max ${maxMedium}`);
+    }
+
+    if (failing) {
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.Security,
+        status: CheckStatus.Failing,
+        severity: Severity.High,
+        message: `Stored vulnerability thresholds exceeded: ${parts.join('; ')}`,
+        remediation:
+          'Remediate findings, adjust workload images, or raise VULN_MAX_* only with explicit risk acceptance.',
+      };
+    }
+
+    return {
+      checkId: CHECK_ID,
+      checkName: CHECK_NAME,
+      pillar: Pillar.Security,
+      status: CheckStatus.Passing,
+      severity: Severity.Medium,
+      message: `Stored findings within thresholds (critical=${critical}, high=${high}, medium=${medium}).`,
+    };
+  },
+};

--- a/src/assessment/runner.integration.test.ts
+++ b/src/assessment/runner.integration.test.ts
@@ -207,7 +207,7 @@ describe('AssessmentRunner (integration)', () => {
       pillarFilter: Pillar.Security,
     });
 
-    expect(checks.length).toBeGreaterThanOrEqual(8);
+    expect(checks.length).toBeGreaterThanOrEqual(9);
     const ids = checks.map((c) => c.id).sort();
     expect(ids).toContain('security.run-as-non-root');
     expect(ids).toContain('security.privileged-containers');
@@ -217,6 +217,7 @@ describe('AssessmentRunner (integration)', () => {
     expect(ids).toContain('security.secrets-in-configmaps');
     expect(ids).toContain('security.external-secrets-usage');
     expect(ids).toContain('security.hardcoded-secrets');
+    expect(ids).toContain('security.stored-vulnerability-thresholds');
   });
 
   it('security checks run successfully with empty cluster (all pass)', async () => {
@@ -239,12 +240,12 @@ describe('AssessmentRunner (integration)', () => {
 
     expect(record.run_id).toBe('run-security-pillar');
     expect(record.state).toBe('completed');
-    expect(record.total_checks).toBe(8);
-    expect(record.passed_checks).toBe(8);
+    expect(record.total_checks).toBe(9);
+    expect(record.passed_checks).toBe(9);
     expect(record.failed_checks).toBe(0);
 
     const history = storage.queryHistory({ filters: { run_id: 'run-security-pillar' } });
-    expect(history).toHaveLength(8);
+    expect(history).toHaveLength(9);
     expect(history.every((h) => h.status === 'passing')).toBe(true);
   });
 

--- a/src/assessment/runner.ts
+++ b/src/assessment/runner.ts
@@ -35,6 +35,8 @@ import {
 import type { Config } from '../config/types.js';
 import type { KubernetesClient } from '../kubernetes/client.js';
 import type { Logger } from 'winston';
+import type { TrivyStatus } from '../status/types.js';
+import type { ImageScanRepository } from '../database/image-scan-repository.js';
 
 /** Default per-check timeout in milliseconds */
 const DEFAULT_CHECK_TIMEOUT_MS = 30_000;
@@ -59,6 +61,8 @@ export interface AssessmentRunnerDeps {
   config: Config;
   logger: Logger;
   storage?: AssessmentRepository;
+  getTrivyStatus?: () => TrivyStatus;
+  imageScanRepository?: ImageScanRepository;
 }
 
 /**
@@ -207,6 +211,8 @@ export class AssessmentRunner {
       mode: input.mode,
       pillarFilter: input.pillarFilter,
       checkIdFilter: input.checkIdFilter,
+      getTrivyStatus: this.deps.getTrivyStatus,
+      imageScanRepository: this.deps.imageScanRepository,
     };
 
     // Initial record (queued -> running)

--- a/src/assessment/types.ts
+++ b/src/assessment/types.ts
@@ -9,6 +9,8 @@
 import type { KubernetesClient } from '../kubernetes/client.js';
 import type { Config } from '../config/types.js';
 import type { Logger } from 'winston';
+import type { TrivyStatus } from '../status/types.js';
+import type { ImageScanRepository } from '../database/image-scan-repository.js';
 
 // ---------------------------------------------------------------------------
 // Pillar Taxonomy
@@ -161,6 +163,13 @@ export interface AssessmentRunContext {
   pillarFilter?: Pillar;
   /** Optional single check ID when mode is 'single-check' */
   checkIdFilter?: string;
+  /**
+   * When set (e.g. in-cluster operator), vulnerability checks skip if Trivy is not available.
+   * Omitted in standalone CLI runs that only read the local database.
+   */
+  getTrivyStatus?: () => TrivyStatus;
+  /** Optional repository for tests; defaults to the process SQLite database. */
+  imageScanRepository?: ImageScanRepository;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/commands/vulnerabilities.ts
+++ b/src/cli/commands/vulnerabilities.ts
@@ -1,0 +1,151 @@
+/**
+ * CLI: query stored image vulnerabilities (from Trivy-backed scans).
+ */
+
+import { z } from 'zod';
+import { DatabaseManager } from '../../database/manager.js';
+import { SchemaManager } from '../../database/schema.js';
+import {
+  ImageScanRepository,
+  type ImageVulnerabilityFilters,
+} from '../../database/image-scan-repository.js';
+import { formatOutput } from '../formatters.js';
+import { trivyStatusTracker } from '../../trivy/state.js';
+
+function writeError(message: string, details?: string) {
+  const err = details ? { error: message, details } : { error: message };
+  console.error(JSON.stringify(err));
+  process.exit(1);
+}
+
+function ensureDb() {
+  DatabaseManager.getInstance();
+  const schema = new SchemaManager();
+  schema.initialize();
+}
+
+const ListOptionsSchema = z.object({
+  severity: z.string().optional(),
+  imageReference: z.string().optional(),
+  vulnerabilityId: z.string().optional(),
+  scanId: z.string().optional(),
+  completedFrom: z.string().optional(),
+  completedTo: z.string().optional(),
+  limit: z
+    .string()
+    .default('100')
+    .transform(Number)
+    .pipe(z.number().int().positive().max(5000)),
+  offset: z
+    .string()
+    .default('0')
+    .transform(Number)
+    .pipe(z.number().int().nonnegative()),
+  format: z.enum(['json', 'yaml', 'table', 'compact']).default('json'),
+});
+
+const SummaryOptionsSchema = z.object({
+  format: z.enum(['json', 'yaml', 'table', 'compact']).default('json'),
+});
+
+export async function listVulnerabilities(options: Record<string, unknown>) {
+  try {
+    const validated = ListOptionsSchema.parse(options);
+    ensureDb();
+
+    const trivy = trivyStatusTracker.getStatus();
+    const scanningAvailable = Boolean(trivy.detected && trivy.serverUrl);
+
+    const filters: ImageVulnerabilityFilters = {};
+    if (validated.severity) {
+      filters.severity = validated.severity
+        .split(',')
+        .map((s) => s.trim().toLowerCase())
+        .filter(Boolean);
+    }
+    if (validated.imageReference) {
+      filters.image_reference = validated.imageReference;
+    }
+    if (validated.vulnerabilityId) {
+      filters.vulnerability_id = validated.vulnerabilityId;
+    }
+    if (validated.scanId) {
+      filters.scan_id = validated.scanId;
+    }
+    if (validated.completedFrom) {
+      filters.completed_from = validated.completedFrom;
+    }
+    if (validated.completedTo) {
+      filters.completed_to = validated.completedTo;
+    }
+
+    const repo = new ImageScanRepository();
+    const rows = repo.queryVulnerabilities({
+      filters,
+      limit: validated.limit,
+      offset: validated.offset,
+    });
+    const total = repo.countVulnerabilities(filters);
+
+    const result = {
+      scanning_available: scanningAvailable,
+      message: scanningAvailable
+        ? undefined
+        : 'Vulnerability scanning is unavailable (Trivy not detected or unreachable); listing stored findings only.',
+      vulnerabilities: rows,
+      pagination: {
+        total,
+        limit: validated.limit,
+        offset: validated.offset,
+        returned: rows.length,
+      },
+    };
+
+    console.log(formatOutput(result, validated.format));
+    process.exit(0);
+  } catch (err: unknown) {
+    if (err instanceof z.ZodError) {
+      const first = err.errors[0];
+      writeError('Invalid arguments', first?.message);
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    writeError('Failed to list vulnerabilities', msg);
+  }
+}
+
+export async function summarizeVulnerabilities(options: Record<string, unknown>) {
+  try {
+    const validated = SummaryOptionsSchema.parse(options);
+    ensureDb();
+
+    const trivy = trivyStatusTracker.getStatus();
+    const repo = new ImageScanRepository();
+    const grouped = repo.countVulnerabilitiesGroupedBySeverity();
+    const total = Object.values(grouped).reduce((a, b) => a + b, 0);
+
+    const summary = {
+      scanning_available: Boolean(trivy.detected && trivy.serverUrl),
+      total_findings: total,
+      by_severity: grouped,
+      trivy: {
+        detected: trivy.detected,
+        server_url: trivy.serverUrl,
+      },
+    };
+
+    if (!summary.scanning_available) {
+      (summary as { message?: string }).message =
+        'Vulnerability scanning is unavailable (Trivy not detected or unreachable). Summary reflects stored data only.';
+    }
+
+    console.log(formatOutput(summary, validated.format));
+    process.exit(0);
+  } catch (err: unknown) {
+    if (err instanceof z.ZodError) {
+      const first = err.errors[0];
+      writeError('Invalid arguments', first?.message);
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    writeError('Failed to summarize vulnerabilities', msg);
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,6 +12,7 @@ import {
   assessSummary,
   assessHistory,
 } from './commands/assess.js';
+import { listVulnerabilities, summarizeVulnerabilities } from './commands/vulnerabilities.js';
 
 /**
  * Create the assess command structure
@@ -113,7 +114,31 @@ export function createQueryCommands(): Command {
     .description('Get single event by ID')
     .option('--format <format>', 'Output format (json|yaml|table)', 'json')
     .action(getEvent);
-  
+
+  const vulnerabilities = query
+    .command('vulnerabilities')
+    .description('Query stored image vulnerability findings (Trivy)');
+
+  vulnerabilities
+    .command('list')
+    .description('List vulnerabilities with optional filters')
+    .option('--severity <levels>', 'Comma-separated severities (e.g. critical,high)')
+    .option('--image-reference <ref>', 'Filter by scanned image reference')
+    .option('--vulnerability-id <id>', 'Filter by CVE/advisory id')
+    .option('--scan-id <id>', 'Filter by scan id')
+    .option('--completed-from <iso>', 'Completed on/after (ISO 8601)')
+    .option('--completed-to <iso>', 'Completed on/before (ISO 8601)')
+    .option('--limit <number>', 'Limit results', '100')
+    .option('--offset <number>', 'Offset', '0')
+    .option('--format <format>', 'Output format (json|yaml|table|compact)', 'json')
+    .action(listVulnerabilities);
+
+  vulnerabilities
+    .command('summary')
+    .description('Summary counts by severity from stored findings')
+    .option('--format <format>', 'Output format (json|yaml|table|compact)', 'json')
+    .action(summarizeVulnerabilities);
+
   return query;
 }
 

--- a/src/database/image-scan-repository.test.ts
+++ b/src/database/image-scan-repository.test.ts
@@ -171,6 +171,45 @@ describe('ImageScanRepository', () => {
     expect(repo.getScanById('new')).not.toBeNull();
   });
 
+  it('counts vulnerabilities grouped by severity for completed scans', () => {
+    const repo = new ImageScanRepository();
+    repo.upsertScan({
+      scan_id: 's-group',
+      image_reference: 'img:1',
+      started_at: '2026-01-01T00:00:00.000Z',
+      completed_at: '2026-01-02T00:00:00.000Z',
+      state: 'completed',
+      scanner: 'trivy',
+    });
+    repo.replaceVulnerabilitiesForScan('s-group', [
+      {
+        id: 'v1',
+        scan_id: 's-group',
+        vulnerability_id: 'CVE-1',
+        severity: 'CRITICAL',
+        package_name: 'a',
+        installed_version: null,
+        fixed_version: null,
+        title: null,
+        raw_metadata: null,
+      },
+      {
+        id: 'v2',
+        scan_id: 's-group',
+        vulnerability_id: 'CVE-2',
+        severity: 'high',
+        package_name: 'b',
+        installed_version: null,
+        fixed_version: null,
+        title: null,
+        raw_metadata: null,
+      },
+    ]);
+    const g = repo.countVulnerabilitiesGroupedBySeverity();
+    expect(g.critical).toBe(1);
+    expect(g.high).toBe(1);
+  });
+
   it('empty repository returns no rows', () => {
     const repo = new ImageScanRepository();
     expect(repo.queryScans()).toEqual([]);

--- a/src/database/image-scan-repository.ts
+++ b/src/database/image-scan-repository.ts
@@ -307,6 +307,31 @@ export class ImageScanRepository {
     return this.db.prepare(query).all(...params) as ImageVulnerabilityRow[];
   }
 
+  /**
+   * Count stored vulnerability rows grouped by normalized severity (lowercase).
+   * Only includes rows linked to completed parent scans.
+   */
+  public countVulnerabilitiesGroupedBySeverity(): Record<string, number> {
+    const rows = this.db
+      .prepare(
+        `
+      SELECT LOWER(TRIM(v.severity)) AS sev, COUNT(*) AS c
+      FROM image_vulnerabilities v
+      INNER JOIN image_scans s ON s.scan_id = v.scan_id
+      WHERE s.completed_at IS NOT NULL
+      GROUP BY LOWER(TRIM(v.severity))
+    `
+      )
+      .all() as Array<{ sev: string; c: number }>;
+    const out: Record<string, number> = {};
+    for (const r of rows) {
+      if (r.sev) {
+        out[r.sev] = r.c;
+      }
+    }
+    return out;
+  }
+
   public countVulnerabilities(filters: ImageVulnerabilityFilters = {}): number {
     const conditions: string[] = [];
     const params: string[] = [];

--- a/src/trivy/metrics.ts
+++ b/src/trivy/metrics.ts
@@ -1,0 +1,93 @@
+/**
+ * Prometheus metrics for vulnerability scanning (M3).
+ * Registered on the shared operator registry; safe when Trivy is absent (gauges stay at zero).
+ */
+
+import { Gauge, Histogram } from 'prom-client';
+import { register } from '../collection/metrics.js';
+import { ImageScanRepository } from '../database/image-scan-repository.js';
+import { logger } from '../logging/logger.js';
+
+const SEVERITY_LABELS = ['critical', 'high', 'medium', 'low', 'unknown', 'info', 'other'] as const;
+
+/**
+ * Current vulnerability row counts in SQLite, by normalized severity label.
+ */
+export const vulnerabilityFindingsBySeverity = new Gauge({
+  name: 'kube9_operator_vulnerability_findings',
+  help: 'Count of stored vulnerability rows in the local database by severity',
+  labelNames: ['severity'],
+  registers: [register],
+});
+
+/**
+ * Whether Trivy integration is active (1) or not (0).
+ */
+export const scanningActive = new Gauge({
+  name: 'kube9_operator_scanning_active',
+  help: '1 when Trivy server is detected and available, else 0',
+  registers: [register],
+});
+
+/**
+ * Duration of a single image scan attempt, or a skipped cycle segment.
+ * Labels: outcome = success | failed | skipped
+ */
+export const imageScanDurationSeconds = new Histogram({
+  name: 'kube9_operator_image_scan_duration_seconds',
+  help: 'Duration of Trivy image scan attempts in seconds',
+  labelNames: ['outcome'],
+  buckets: [0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120],
+  registers: [register],
+});
+
+function ensureSeverityLabel(sev: string): (typeof SEVERITY_LABELS)[number] {
+  const s = sev.toLowerCase();
+  if ((SEVERITY_LABELS as readonly string[]).includes(s)) {
+    return s as (typeof SEVERITY_LABELS)[number];
+  }
+  return 'other';
+}
+
+/**
+ * Refresh severity gauges from the database (completed scans only).
+ */
+export function refreshVulnerabilityMetrics(repo?: ImageScanRepository): void {
+  try {
+    const r = repo ?? new ImageScanRepository();
+    const grouped = r.countVulnerabilitiesGroupedBySeverity();
+    const totals: Record<string, number> = {};
+    for (const label of SEVERITY_LABELS) {
+      totals[label] = 0;
+    }
+    for (const [sev, count] of Object.entries(grouped)) {
+      const lab = ensureSeverityLabel(sev);
+      totals[lab] = (totals[lab] ?? 0) + count;
+    }
+    for (const label of SEVERITY_LABELS) {
+      vulnerabilityFindingsBySeverity.set({ severity: label }, totals[label] ?? 0);
+    }
+  } catch (err) {
+    logger.warn('Failed to refresh vulnerability metrics from database', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+export function setScanningActiveGauge(active: boolean): void {
+  scanningActive.set(active ? 1 : 0);
+}
+
+export function recordImageScanDurationSeconds(
+  outcome: 'success' | 'failed' | 'skipped',
+  seconds: number
+): void {
+  try {
+    imageScanDurationSeconds.observe({ outcome }, seconds);
+  } catch (err) {
+    logger.warn('Failed to record image scan duration metric', {
+      outcome,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/src/trivy/persist-scan-result.test.ts
+++ b/src/trivy/persist-scan-result.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { vulnerabilitiesFromTrivyReport } from './persist-scan-result.js';
+
+describe('vulnerabilitiesFromTrivyReport', () => {
+  it('extracts rows from Trivy JSON', () => {
+    const report = {
+      Results: [
+        {
+          Vulnerabilities: [
+            {
+              VulnerabilityID: 'CVE-2024-1',
+              Severity: 'HIGH',
+              PkgName: 'openssl',
+              InstalledVersion: '1.0',
+              FixedVersion: '1.1',
+              Title: 'test',
+            },
+          ],
+        },
+      ],
+    };
+    const rows = vulnerabilitiesFromTrivyReport('scan-a', report);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.vulnerability_id).toBe('CVE-2024-1');
+    expect(rows[0]?.severity).toBe('high');
+    expect(rows[0]?.scan_id).toBe('scan-a');
+  });
+
+  it('returns empty for empty results', () => {
+    expect(vulnerabilitiesFromTrivyReport('s', {})).toEqual([]);
+  });
+});

--- a/src/trivy/persist-scan-result.ts
+++ b/src/trivy/persist-scan-result.ts
@@ -1,0 +1,118 @@
+/**
+ * Persist Trivy JSON report rows into image_scans / image_vulnerabilities.
+ */
+
+import { randomUUID } from 'crypto';
+import type { TrivyImageReport } from './scanner.js';
+import { ImageScanRepository } from '../database/image-scan-repository.js';
+import type { ImageVulnerabilityInput } from '../database/image-scan-contracts.js';
+
+export interface PersistTrivyReportOptions {
+  imageRef: string;
+  report: TrivyImageReport;
+  repo?: ImageScanRepository;
+  /** Defaults to a new UUID */
+  scanId?: string;
+  startedAt?: string;
+  completedAt?: string;
+}
+
+function normalizeSeverity(raw: string | undefined): string {
+  if (!raw || raw.trim() === '') {
+    return 'unknown';
+  }
+  return raw.trim().toLowerCase();
+}
+
+/**
+ * Walk Trivy JSON Results[].Vulnerabilities and build normalized rows.
+ */
+export function vulnerabilitiesFromTrivyReport(
+  scanId: string,
+  report: TrivyImageReport
+): ImageVulnerabilityInput[] {
+  const results = Array.isArray(report.Results) ? report.Results : [];
+  const rows: ImageVulnerabilityInput[] = [];
+  let idx = 0;
+
+  for (const block of results) {
+    if (!block || typeof block !== 'object') {
+      continue;
+    }
+    const vulns = (block as { Vulnerabilities?: unknown }).Vulnerabilities;
+    if (!Array.isArray(vulns)) {
+      continue;
+    }
+    for (const v of vulns) {
+      if (!v || typeof v !== 'object') {
+        continue;
+      }
+      const o = v as Record<string, unknown>;
+      const vid = String(o.VulnerabilityID ?? o.vulnerability_id ?? o.VulnerabilityId ?? '');
+      if (!vid) {
+        continue;
+      }
+      const severity = normalizeSeverity(
+        typeof o.Severity === 'string' ? o.Severity : typeof o.severity === 'string' ? o.severity : undefined
+      );
+      const pkg =
+        typeof o.PkgName === 'string'
+          ? o.PkgName
+          : typeof o.pkg_name === 'string'
+            ? o.pkg_name
+            : null;
+      const installed =
+        typeof o.InstalledVersion === 'string'
+          ? o.InstalledVersion
+          : typeof o.installed_version === 'string'
+            ? o.installed_version
+            : null;
+      const fixed =
+        typeof o.FixedVersion === 'string'
+          ? o.FixedVersion
+          : typeof o.fixed_version === 'string'
+            ? o.fixed_version
+            : null;
+      const title = typeof o.Title === 'string' ? o.Title : typeof o.title === 'string' ? o.title : null;
+      idx += 1;
+      rows.push({
+        id: `${scanId}-v-${idx}-${vid}`,
+        scan_id: scanId,
+        vulnerability_id: vid,
+        severity,
+        package_name: pkg,
+        installed_version: installed,
+        fixed_version: fixed,
+        title,
+        raw_metadata: JSON.stringify(o),
+      });
+    }
+  }
+
+  return rows;
+}
+
+/**
+ * Upsert a completed scan and replace vulnerability rows for that scan.
+ */
+export function persistTrivyReportToDatabase(options: PersistTrivyReportOptions): string {
+  const repo = options.repo ?? new ImageScanRepository();
+  const scanId = options.scanId ?? randomUUID();
+  const now = options.completedAt ?? new Date().toISOString();
+  const startedAt = options.startedAt ?? now;
+
+  repo.upsertScan({
+    scan_id: scanId,
+    image_reference: options.imageRef,
+    image_digest: null,
+    started_at: startedAt,
+    completed_at: now,
+    state: 'completed',
+    scanner: 'trivy',
+    error_message: null,
+  });
+
+  const rows = vulnerabilitiesFromTrivyReport(scanId, options.report);
+  repo.replaceVulnerabilitiesForScan(scanId, rows);
+  return scanId;
+}

--- a/src/trivy/workload-scan-cycle.test.ts
+++ b/src/trivy/workload-scan-cycle.test.ts
@@ -30,7 +30,11 @@ describe('runWorkloadImageScanCycle', () => {
       lastChecked: new Date().toISOString(),
     });
 
-    const r = await runWorkloadImageScanCycle({ kubernetesClient: client, getTrivyStatus });
+    const r = await runWorkloadImageScanCycle({
+      kubernetesClient: client,
+      getTrivyStatus,
+      persistTrivyReport: () => 'noop',
+    });
     expect(r.scansSkippedDueToTrivy).toBe(true);
     expect(r.uniqueImagesCollected).toBe(1);
     expect(scanSpy).not.toHaveBeenCalled();
@@ -54,6 +58,7 @@ describe('runWorkloadImageScanCycle', () => {
       kubernetesClient: client,
       getTrivyStatus,
       maxScansPerCycle: 10,
+      persistTrivyReport: () => 'noop',
     });
 
     expect(r.scansSkippedDueToTrivy).toBe(false);
@@ -84,6 +89,7 @@ describe('runWorkloadImageScanCycle', () => {
       kubernetesClient: client,
       getTrivyStatus,
       maxScansPerCycle: 10,
+      persistTrivyReport: () => 'noop',
     });
 
     expect(r.scansFailed).toBe(1);

--- a/src/trivy/workload-scan-cycle.ts
+++ b/src/trivy/workload-scan-cycle.ts
@@ -9,6 +9,12 @@ import { logger } from '../logging/logger.js';
 import { collectWorkloadImageReferences } from './collect-workload-images.js';
 import { scanContainerImageWhenDetected } from './scanner.js';
 import { DEFAULT_MAX_UNIQUE_WORKLOAD_IMAGES } from './workload-images.js';
+import { persistTrivyReportToDatabase, type PersistTrivyReportOptions } from './persist-scan-result.js';
+import {
+  recordImageScanDurationSeconds,
+  refreshVulnerabilityMetrics,
+  setScanningActiveGauge,
+} from './metrics.js';
 
 export interface WorkloadScanCycleOptions {
   kubernetesClient: KubernetesClient;
@@ -17,6 +23,8 @@ export interface WorkloadScanCycleOptions {
   maxUniqueImages?: number;
   /** Max scans to run per cycle (default: 100) */
   maxScansPerCycle?: number;
+  /** Override persistence (e.g. unit tests). Defaults to persistTrivyReportToDatabase. */
+  persistTrivyReport?: (options: PersistTrivyReportOptions) => string;
 }
 
 export interface WorkloadScanCycleResult {
@@ -45,15 +53,22 @@ function parseMaxScansPerCycle(): number {
 export async function runWorkloadImageScanCycle(
   options: WorkloadScanCycleOptions
 ): Promise<WorkloadScanCycleResult> {
+  const cycleStartMs = Date.now();
   const maxUnique = options.maxUniqueImages ?? DEFAULT_MAX_UNIQUE_WORKLOAD_IMAGES;
   const maxScans = options.maxScansPerCycle ?? parseMaxScansPerCycle();
+  const persist = options.persistTrivyReport ?? persistTrivyReportToDatabase;
 
   const { images, truncated } = await collectWorkloadImageReferences(options.kubernetesClient, {
     maxUniqueImages: maxUnique,
   });
 
   const status = options.getTrivyStatus();
+  setScanningActiveGauge(Boolean(status.detected && status.serverUrl));
+
   if (!status.detected || !status.serverUrl) {
+    const cycleSeconds = (Date.now() - cycleStartMs) / 1000;
+    recordImageScanDurationSeconds('skipped', cycleSeconds);
+    refreshVulnerabilityMetrics();
     logger.info('Workload images collected; skipping Trivy scans (integration not active)', {
       uniqueImagesCollected: images.length,
       truncated,
@@ -80,19 +95,25 @@ export async function runWorkloadImageScanCycle(
   let scansFailed = 0;
 
   for (const imageRef of toScan) {
+    const scanStart = Date.now();
     try {
-      await scanContainerImageWhenDetected(imageRef, {
+      const report = await scanContainerImageWhenDetected(imageRef, {
         getStatus: options.getTrivyStatus,
       });
+      persist({ imageRef, report });
       scansSucceeded++;
+      recordImageScanDurationSeconds('success', (Date.now() - scanStart) / 1000);
     } catch (err) {
       scansFailed++;
+      recordImageScanDurationSeconds('failed', (Date.now() - scanStart) / 1000);
       logger.warn('Trivy scan failed for workload image', {
         imageRef,
         error: err instanceof Error ? err.message : String(err),
       });
     }
   }
+
+  refreshVulnerabilityMetrics();
 
   if (truncated) {
     logger.warn('Workload image collection hit unique image cap', {


### PR DESCRIPTION
## Description

Implements [issue #99](https://github.com/alto9/kube9-operator/issues/99) (parent [#15](https://github.com/alto9/kube9-operator/issues/15)):

- **Assessment:** New check `security.stored-vulnerability-thresholds` compares stored finding counts to `VULN_MAX_CRITICAL`, `VULN_MAX_HIGH`, and `VULN_MAX_MEDIUM`. When `getTrivyStatus` is supplied and Trivy is not detected, the check **skips** with an explicit message (operator can wire deps later without failing the run).
- **CLI:** `kube9-operator query vulnerabilities list|summary` with filters on list (severity, image reference, CVE id, scan id, completed range) and summary counts by severity.
- **Prometheus:** `kube9_operator_vulnerability_findings{severity}`, `kube9_operator_scanning_active`, and `kube9_operator_image_scan_duration_seconds{outcome}` on the existing registry; gauges refreshed after scan cycles; safe zeros when scanning is off.
- **Persistence:** Trivy JSON is persisted to `image_scans` / `image_vulnerabilities` after each successful workload image scan.

## Testing

- `npm run lint`
- `npm test`
- `npm run test:integration`

Fixes #99