### PR TITLE
[#15] Optional image vulnerability scanning with Trivy

### DIFF
--- a/.forge/data/data_model.md
+++ b/.forge/data/data_model.md
@@ -134,4 +134,39 @@ Tracks database schema migrations.
 | applied_at | TEXT | NOT NULL | ISO 8601 timestamp when migration was applied |
 | description | TEXT | NULL | Migration description |
 
+### image_scans (planned, M3)
+
+Records of vulnerability scan runs against a container image reference (digest or repo:tag as reported by the scanner).
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| scan_id | TEXT | PRIMARY KEY | Unique scan identifier |
+| image_reference | TEXT | NOT NULL | Image reference as collected from workloads / passed to Trivy |
+| image_digest | TEXT | NULL | Digest when available |
+| started_at | TEXT | NOT NULL | ISO 8601 timestamp |
+| completed_at | TEXT | NULL | ISO 8601 timestamp when scan finished |
+| state | TEXT | NOT NULL | Lifecycle: e.g. `queued`, `running`, `completed`, `failed`, `skipped` |
+| scanner | TEXT | NOT NULL | e.g. `trivy` |
+| error_message | TEXT | NULL | Populated when state is `failed` or scan was skipped due to missing scanner |
+
+**Indexes (planned):** `idx_image_scans_image_reference`, `idx_image_scans_completed_at DESC`, `idx_image_scans_state`.
+
+### image_vulnerabilities (planned, M3)
+
+Normalized vulnerability findings linked to a scan (and optionally to originating workload metadata via application logic).
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | TEXT | PRIMARY KEY | Unique row identifier |
+| scan_id | TEXT | NOT NULL, FOREIGN KEY → image_scans(scan_id) ON DELETE CASCADE | Parent scan |
+| vulnerability_id | TEXT | NOT NULL | Scanner vulnerability ID (e.g. CVE) |
+| severity | TEXT | NOT NULL | Normalized severity for filtering and metrics |
+| package_name | TEXT | NULL | Affected package if reported |
+| installed_version | TEXT | NULL | Installed version if reported |
+| fixed_version | TEXT | NULL | Fixed version if reported |
+| title | TEXT | NULL | Short title |
+| raw_metadata | TEXT | NULL | Optional JSON blob for scanner-specific fields |
+
+**Indexes (planned):** `idx_image_vulnerabilities_scan_id`, `idx_image_vulnerabilities_severity`, `idx_image_vulnerabilities_vulnerability_id`.
+
 **Note:** Collections and argocd_apps tables are planned for future milestones (M8/M9) but are not yet implemented in the current schema.

--- a/.forge/data/data_model.md
+++ b/.forge/data/data_model.md
@@ -134,7 +134,7 @@ Tracks database schema migrations.
 | applied_at | TEXT | NOT NULL | ISO 8601 timestamp when migration was applied |
 | description | TEXT | NULL | Migration description |
 
-### image_scans (planned, M3)
+### image_scans
 
 Records of vulnerability scan runs against a container image reference (digest or repo:tag as reported by the scanner).
 
@@ -149,9 +149,9 @@ Records of vulnerability scan runs against a container image reference (digest o
 | scanner | TEXT | NOT NULL | e.g. `trivy` |
 | error_message | TEXT | NULL | Populated when state is `failed` or scan was skipped due to missing scanner |
 
-**Indexes (planned):** `idx_image_scans_image_reference`, `idx_image_scans_completed_at DESC`, `idx_image_scans_state`.
+**Indexes:** `idx_image_scans_image_reference`, `idx_image_scans_completed_at DESC`, `idx_image_scans_state`.
 
-### image_vulnerabilities (planned, M3)
+### image_vulnerabilities
 
 Normalized vulnerability findings linked to a scan (and optionally to originating workload metadata via application logic).
 
@@ -167,6 +167,8 @@ Normalized vulnerability findings linked to a scan (and optionally to originatin
 | title | TEXT | NULL | Short title |
 | raw_metadata | TEXT | NULL | Optional JSON blob for scanner-specific fields |
 
-**Indexes (planned):** `idx_image_vulnerabilities_scan_id`, `idx_image_vulnerabilities_severity`, `idx_image_vulnerabilities_vulnerability_id`.
+**Indexes:** `idx_image_vulnerabilities_scan_id`, `idx_image_vulnerabilities_severity`, `idx_image_vulnerabilities_vulnerability_id`.
+
+**Retention:** Deleting a row in `image_scans` cascades to `image_vulnerabilities` (`ON DELETE CASCADE`). Optional time-based pruning is implemented in application code (`ImageScanRepository.deleteScansCompletedBefore`); there is no DB-level TTL trigger.
 
 **Note:** Collections and argocd_apps tables are planned for future milestones (M8/M9) but are not yet implemented in the current schema.

--- a/.forge/integration/external_systems.md
+++ b/.forge/integration/external_systems.md
@@ -67,6 +67,17 @@ Exposed in ConfigMap `kube9-operator-status` under `status.argocd`:
 - Application sync status tracking
 - Drift detection results
 
+## Trivy (optional, M3)
+
+**Scope boundary**: The kube9-operator Helm chart does **not** install, upgrade, or bundle Trivy or the Trivy Operator. Cluster operators (or platform UI that installs other components) may deploy Trivy separately. This integration is **optional**: if Trivy is not present or unreachable, the operator **must not** perform vulnerability scanning and must continue normal operation.
+
+**Behavior**:
+- **Detection**: Discover whether an in-cluster Trivy service (API and/or CLI invocation path) is available, using configuration similar in spirit to ArgoCD (env-driven endpoints, timeouts, periodic refresh). Exact discovery rules are implementation-defined but must default to “no Trivy” when nothing is configured or reachable.
+- **Scanning**: Run or request scans **only when** Trivy is detected and usable. No background scan loops that assume Trivy exists.
+- **Resilience**: Trivy errors, timeouts, or disappearance after detection must be handled gracefully (degraded scan status, structured logging, no crash loops).
+
+**Consumption**: Scan results feed SQLite persistence, security assessment checks, operator CLI query commands, and Prometheus metrics (see `.forge/data/data_model.md` and `.forge/operations/observability.md` as those contracts are extended for M3).
+
 ## Prometheus
 
 **Metrics Endpoint**:

--- a/.forge/operations/observability.md
+++ b/.forge/operations/observability.md
@@ -116,9 +116,18 @@ All metrics are exposed at `/metrics` endpoint and follow Prometheus naming conv
 - **Labels**:
   - `type`: Collection type
 
+### Vulnerability scanning metrics (planned, M3)
+
+Exposed only when Trivy-backed scanning is active; when Trivy is absent, these metrics should be zero or omitted per Prometheus registration rules (implementation detail), without failing scrapes.
+
+- **Counters**: vulnerability counts by normalized `severity` (and optionally `scanner` / `state`)
+- **Histograms**: scan duration seconds (labels for scan outcome such as `success`, `failed`, `skipped`)
+
+Exact metric names and label sets are defined at implementation time and registered alongside existing operator metrics.
+
 ### Metrics Registry
 - All metrics are registered in a single Prometheus registry
-- Metrics are collected from multiple modules (events, collection)
+- Metrics are collected from multiple modules (events, collection, vulnerability scanning when enabled)
 - Registry is exported for use by health server
 
 ## Health Check Logic

--- a/.forge/operations/security.md
+++ b/.forge/operations/security.md
@@ -123,6 +123,12 @@ securityContext:
 - **Image Compliance**: Dockerfile ensures non-root user.
 - **Helm Chart**: Deployment template enforces security contexts.
 
+## Optional image vulnerability scanning (M3)
+
+- **Trivy is optional**: The operator integrates with Trivy only when it is already deployed in the cluster and discoverable per configuration. There is **no** requirement to install Trivy via the kube9-operator Helm chart.
+- **No Trivy lifecycle in-chart**: Installing, upgrading, or operating the Trivy Operator or Trivy server is out of scope for this repository; platform or cluster admins own that lifecycle.
+- **Safe degradation**: When Trivy is absent or fails, the operator continues running; vulnerability features report unavailable or degraded state rather than blocking core operation.
+
 ## Security Best Practices Summary
 
 1. **Zero Ingress**: No external attack surface

--- a/.forge/runtime/execution_model.md
+++ b/.forge/runtime/execution_model.md
@@ -45,6 +45,7 @@ The kube9-operator binary supports multiple execution modes via Commander.js CLI
   - `assess history` - Historical results for trending
 - **Behavior**:
   - Loads configuration and initializes assessment registry
+  - For `assess run`, performs a one-time Trivy HTTP probe using the same `TRIVY_*` env vars as `serve`, then constructs `AssessmentRunner` with `getTrivyStatus` (snapshot from that probe) and `imageScanRepository`, matching in-process assessment behavior for checks such as `security.stored-vulnerability-thresholds` (skip when Trivy is not configured or unreachable; evaluate stored SQLite counts when Trivy is detected)
   - Runs assessments using AssessmentRunner
   - Reads/writes assessment results to database
   - Outputs results in specified format

--- a/.forge/technical_concepts.json
+++ b/.forge/technical_concepts.json
@@ -22,7 +22,7 @@
     },
     {
       "title": "SQLite Storage",
-      "description": "better-sqlite3 at /data/kube9.db. Tables: assessments, assessment_history, events. argocd_apps and collections planned for M8/M9.",
+      "description": "better-sqlite3 at /data/kube9.db. Tables: assessments, assessment_history, events, image_scans, image_vulnerabilities. argocd_apps and collections planned for M8/M9.",
       "context_sources": [".forge/data/data_model.md", ".forge/data/persistence_abstractions.md"]
     },
     {

--- a/charts/kube9-operator/README.md
+++ b/charts/kube9-operator/README.md
@@ -95,6 +95,17 @@ The following table lists the configurable parameters and their default values:
 | `argocd.namespace` | Custom namespace where ArgoCD is installed | `"argocd"` |
 | `argocd.selector` | Custom label selector for ArgoCD server deployment | `app.kubernetes.io/name=argocd-server` |
 | `argocd.detectionInterval` | Detection check interval in hours (valid range: 1–24) | `6` |
+| `trivy.autoDetect` | Probe `trivy.serverUrl` periodically for Trivy HTTP health | `true` |
+| `trivy.serverUrl` | Trivy server base URL (required for detection and scans) | (unset) |
+| `trivy.healthPath` | Health probe path (e.g. `/healthz`) | `"/healthz"` |
+| `trivy.detectionInterval` | Hours between Trivy re-detection attempts | `6` |
+| `trivy.detectionTimeoutMs` | Timeout for each Trivy health probe | `10000` |
+| `trivy.scanTimeoutMs` | `TRIVY_SCAN_TIMEOUT_MS` — per-image Trivy CLI scan timeout | `600000` |
+| `trivy.maxScansPerCycle` | Max distinct images scanned per workload cycle (sorted unique refs) | `100` |
+| `trivy.vulnMaxCritical` | `VULN_MAX_CRITICAL` — stored critical findings allowed (default `0` fails on any critical) | `0` |
+| `trivy.vulnMaxHigh` | `VULN_MAX_HIGH` | `1000000` |
+| `trivy.vulnMaxMedium` | `VULN_MAX_MEDIUM` | `1000000` |
+| `metrics.intervals.workloadImageScan` | Seconds between workload image collection / scan cycles | `86400` |
 
 ### Configuration Details
 

--- a/charts/kube9-operator/templates/deployment.yaml
+++ b/charts/kube9-operator/templates/deployment.yaml
@@ -86,6 +86,10 @@ spec:
           value: {{ .Values.trivy.detectionInterval | default 6 | quote }}
         - name: TRIVY_DETECTION_TIMEOUT_MS
           value: {{ .Values.trivy.detectionTimeoutMs | default 10000 | quote }}
+        - name: TRIVY_MAX_SCANS_PER_CYCLE
+          value: {{ .Values.trivy.maxScansPerCycle | default 100 | quote }}
+        - name: WORKLOAD_IMAGE_SCAN_INTERVAL_SECONDS
+          value: {{ .Values.metrics.intervals.workloadImageScan | default 86400 | quote }}
         # Event retention configuration
         - name: EVENT_RETENTION_INFO_WARNING_DAYS
           value: {{ .Values.events.retention.infoWarning | default 7 | quote }}

--- a/charts/kube9-operator/templates/deployment.yaml
+++ b/charts/kube9-operator/templates/deployment.yaml
@@ -69,6 +69,23 @@ spec:
         {{- end }}
         - name: ARGOCD_DETECTION_INTERVAL
           value: {{ .Values.argocd.detectionInterval | default 6 | quote }}
+        # Optional Trivy server detection
+        - name: TRIVY_AUTO_DETECT
+          value: {{ .Values.trivy.autoDetect | quote }}
+        {{- if kindIs "bool" .Values.trivy.enabled }}
+        - name: TRIVY_ENABLED
+          value: {{ .Values.trivy.enabled | quote }}
+        {{- end }}
+        {{- if .Values.trivy.serverUrl }}
+        - name: TRIVY_SERVER_URL
+          value: {{ .Values.trivy.serverUrl | quote }}
+        {{- end }}
+        - name: TRIVY_HEALTH_PATH
+          value: {{ .Values.trivy.healthPath | default "/healthz" | quote }}
+        - name: TRIVY_DETECTION_INTERVAL
+          value: {{ .Values.trivy.detectionInterval | default 6 | quote }}
+        - name: TRIVY_DETECTION_TIMEOUT_MS
+          value: {{ .Values.trivy.detectionTimeoutMs | default 10000 | quote }}
         # Event retention configuration
         - name: EVENT_RETENTION_INFO_WARNING_DAYS
           value: {{ .Values.events.retention.infoWarning | default 7 | quote }}

--- a/charts/kube9-operator/templates/deployment.yaml
+++ b/charts/kube9-operator/templates/deployment.yaml
@@ -88,6 +88,15 @@ spec:
           value: {{ .Values.trivy.detectionTimeoutMs | default 10000 | quote }}
         - name: TRIVY_MAX_SCANS_PER_CYCLE
           value: {{ .Values.trivy.maxScansPerCycle | default 100 | quote }}
+        - name: TRIVY_SCAN_TIMEOUT_MS
+          value: {{ .Values.trivy.scanTimeoutMs | default 600000 | quote }}
+        # Use .Values.trivy.vulnMax* without | default so 0 is preserved (Sprig default treats 0 as empty)
+        - name: VULN_MAX_CRITICAL
+          value: {{ .Values.trivy.vulnMaxCritical | quote }}
+        - name: VULN_MAX_HIGH
+          value: {{ .Values.trivy.vulnMaxHigh | quote }}
+        - name: VULN_MAX_MEDIUM
+          value: {{ .Values.trivy.vulnMaxMedium | quote }}
         - name: WORKLOAD_IMAGE_SCAN_INTERVAL_SECONDS
           value: {{ .Values.metrics.intervals.workloadImageScan | default 86400 | quote }}
         # Event retention configuration

--- a/charts/kube9-operator/values.schema.json
+++ b/charts/kube9-operator/values.schema.json
@@ -53,6 +53,12 @@
               "description": "Resource configuration patterns collection interval in seconds. Default: 43200 (12 hours). Minimum: 3600 (1 hour). Configurable for testing/debugging purposes.",
               "minimum": 3600,
               "default": 43200
+            },
+            "workloadImageScan": {
+              "type": "integer",
+              "description": "Workload image collection and optional Trivy scan cycle interval in seconds. Default: 86400 (24 hours). Minimum: 3600 (1 hour).",
+              "minimum": 3600,
+              "default": 86400
             }
           },
           "additionalProperties": false

--- a/charts/kube9-operator/values.schema.json
+++ b/charts/kube9-operator/values.schema.json
@@ -66,6 +66,34 @@
       },
       "additionalProperties": false
     },
+    "trivy": {
+      "type": "object",
+      "description": "Optional Trivy server detection and scan tuning (see chart README)",
+      "properties": {
+        "autoDetect": { "type": "boolean", "default": true },
+        "enabled": { "type": "boolean" },
+        "serverUrl": { "type": "string" },
+        "healthPath": { "type": "string", "default": "/healthz" },
+        "detectionInterval": { "type": "integer", "minimum": 1, "maximum": 24, "default": 6 },
+        "detectionTimeoutMs": { "type": "integer", "minimum": 1000, "default": 10000 },
+        "scanTimeoutMs": {
+          "type": "integer",
+          "description": "TRIVY_SCAN_TIMEOUT_MS — per-image Trivy CLI scan timeout in milliseconds",
+          "minimum": 1000,
+          "default": 600000
+        },
+        "maxScansPerCycle": { "type": "integer", "minimum": 1, "default": 100 },
+        "vulnMaxCritical": {
+          "type": "integer",
+          "description": "VULN_MAX_CRITICAL — max stored critical findings (default 0 is strict)",
+          "minimum": 0,
+          "default": 0
+        },
+        "vulnMaxHigh": { "type": "integer", "minimum": 0, "default": 1000000 },
+        "vulnMaxMedium": { "type": "integer", "minimum": 0, "default": 1000000 }
+      },
+      "additionalProperties": false
+    },
     "events": {
       "type": "object",
       "description": "Event storage configuration",

--- a/charts/kube9-operator/values.yaml
+++ b/charts/kube9-operator/values.yaml
@@ -60,8 +60,14 @@ trivy:
   healthPath: "/healthz"
   detectionInterval: 6
   detectionTimeoutMs: 10000
-  # Cap on Trivy image scans per workload-image cycle (after collection)
+  # Per-image scan timeout for the Trivy CLI (maps to TRIVY_SCAN_TIMEOUT_MS; default 600000 ms)
+  scanTimeoutMs: 600000
+  # Cap on Trivy image scans per workload-image cycle (sorted unique image refs; not full cluster in one cycle)
   maxScansPerCycle: 100
+  # Stored vulnerability assessment (maps to VULN_MAX_*). Default critical=0 fails on any critical finding.
+  vulnMaxCritical: 0
+  vulnMaxHigh: 1000000
+  vulnMaxMedium: 1000000
 
 # Collection interval configuration (for testing/debugging)
 # The operator enforces minimum intervals to prevent abuse

--- a/charts/kube9-operator/values.yaml
+++ b/charts/kube9-operator/values.yaml
@@ -60,6 +60,8 @@ trivy:
   healthPath: "/healthz"
   detectionInterval: 6
   detectionTimeoutMs: 10000
+  # Cap on Trivy image scans per workload-image cycle (after collection)
+  maxScansPerCycle: 100
 
 # Collection interval configuration (for testing/debugging)
 # The operator enforces minimum intervals to prevent abuse
@@ -74,6 +76,9 @@ metrics:
     # Resource configuration patterns collection interval in seconds (default: 43200 = 12 hours)
     # Minimum: 3600 seconds (1 hour)
     resourceConfigurationPatterns: 43200
+    # Workload image collection + optional Trivy scan cycle (default: 86400 = 24 hours)
+    # Minimum: 3600 seconds (1 hour)
+    workloadImageScan: 86400
 
 # Event storage configuration
 events:

--- a/charts/kube9-operator/values.yaml
+++ b/charts/kube9-operator/values.yaml
@@ -53,6 +53,14 @@ argocd:
   # Detection check interval in hours (default: 6)
   detectionInterval: 6
 
+# Optional Trivy server detection (does not install Trivy; set serverUrl to probe)
+trivy:
+  autoDetect: true
+  # serverUrl: "http://trivy.trivy-system.svc.cluster.local:4954"
+  healthPath: "/healthz"
+  detectionInterval: 6
+  detectionTimeoutMs: 10000
+
 # Collection interval configuration (for testing/debugging)
 # The operator enforces minimum intervals to prevent abuse
 metrics:

--- a/src/assessment/bootstrap.ts
+++ b/src/assessment/bootstrap.ts
@@ -16,6 +16,7 @@ import {
   secretsInConfigMapsCheck,
   externalSecretsUsageCheck,
   hardcodedSecretsCheck,
+  storedVulnerabilityThresholdsCheck,
 } from './checks/security/index.js';
 import {
   replicaCountsCheck,
@@ -43,6 +44,7 @@ const BUILT_IN_CHECKS: AssessmentCheck[] = [
   secretsInConfigMapsCheck,
   externalSecretsUsageCheck,
   hardcodedSecretsCheck,
+  storedVulnerabilityThresholdsCheck,
   replicaCountsCheck,
   spreadAntiAffinityCheck,
   podDisruptionBudgetsCheck,

--- a/src/assessment/checks/security/index.ts
+++ b/src/assessment/checks/security/index.ts
@@ -10,3 +10,4 @@ export { rbacClusterAdminMisuseCheck } from './rbac-cluster-admin-misuse.js';
 export { secretsInConfigMapsCheck } from './secrets-in-configmaps.js';
 export { externalSecretsUsageCheck } from './external-secrets-usage.js';
 export { hardcodedSecretsCheck } from './hardcoded-secrets.js';
+export { storedVulnerabilityThresholdsCheck } from './stored-vulnerability-thresholds.js';

--- a/src/assessment/checks/security/stored-vulnerability-thresholds.test.ts
+++ b/src/assessment/checks/security/stored-vulnerability-thresholds.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { storedVulnerabilityThresholdsCheck } from './stored-vulnerability-thresholds.js';
+import type { AssessmentRunContext } from '../../types.js';
+import { AssessmentRunMode } from '../../types.js';
+
+function buildCtx(partial: Partial<AssessmentRunContext>): AssessmentRunContext {
+  return {
+    kubernetes: {} as AssessmentRunContext['kubernetes'],
+    config: {} as AssessmentRunContext['config'],
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as AssessmentRunContext['logger'],
+    timeoutMs: 30000,
+    runId: 'r1',
+    mode: AssessmentRunMode.Full,
+    ...partial,
+  } as AssessmentRunContext;
+}
+
+describe('storedVulnerabilityThresholdsCheck', () => {
+  afterEach(() => {
+    delete process.env.VULN_MAX_CRITICAL;
+    delete process.env.VULN_MAX_HIGH;
+    delete process.env.VULN_MAX_MEDIUM;
+  });
+
+  it('skips when getTrivyStatus reports not detected', async () => {
+    const r = await storedVulnerabilityThresholdsCheck.run(
+      buildCtx({
+        getTrivyStatus: () => ({
+          detected: false,
+          serverUrl: null,
+          version: null,
+          lastChecked: new Date().toISOString(),
+        }),
+      })
+    );
+    expect(r.status).toBe('skipped');
+  });
+
+  it('passes when under thresholds', async () => {
+    const r = await storedVulnerabilityThresholdsCheck.run(
+      buildCtx({
+        imageScanRepository: {
+          countVulnerabilitiesGroupedBySeverity: () => ({ critical: 0, high: 0, medium: 0 }),
+        } as unknown as AssessmentRunContext['imageScanRepository'],
+      })
+    );
+    expect(r.status).toBe('passing');
+  });
+
+  it('fails when critical exceeds max', async () => {
+    process.env.VULN_MAX_CRITICAL = '0';
+    const r = await storedVulnerabilityThresholdsCheck.run(
+      buildCtx({
+        imageScanRepository: {
+          countVulnerabilitiesGroupedBySeverity: () => ({ critical: 2 }),
+        } as unknown as AssessmentRunContext['imageScanRepository'],
+      })
+    );
+    expect(r.status).toBe('failing');
+  });
+});

--- a/src/assessment/checks/security/stored-vulnerability-thresholds.ts
+++ b/src/assessment/checks/security/stored-vulnerability-thresholds.ts
@@ -1,0 +1,99 @@
+/**
+ * Security Check: Stored vulnerability thresholds
+ *
+ * Evaluates counts persisted from Trivy (or other scanners) against optional
+ * maxima. When getTrivyStatus is provided and Trivy is not detected, the check
+ * is skipped so the operator does not fail solely due to missing scanning.
+ */
+
+import type { AssessmentCheck, AssessmentCheckResult, AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus, Severity } from '../../types.js';
+import { ImageScanRepository } from '../../../database/image-scan-repository.js';
+
+const CHECK_ID = 'security.stored-vulnerability-thresholds';
+const CHECK_NAME = 'Stored vulnerability severity thresholds';
+
+function maxAllowed(envName: string, defaultValue: number): number {
+  const raw = process.env[envName];
+  if (raw === undefined || raw === '') {
+    return defaultValue;
+  }
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : defaultValue;
+}
+
+export const storedVulnerabilityThresholdsCheck: AssessmentCheck = {
+  id: CHECK_ID,
+  name: CHECK_NAME,
+  pillar: Pillar.Security,
+  description:
+    'Compares stored vulnerability counts by severity to VULN_MAX_CRITICAL, VULN_MAX_HIGH, and VULN_MAX_MEDIUM',
+  defaultSeverity: Severity.High,
+
+  async run(ctx: AssessmentRunContext): Promise<AssessmentCheckResult> {
+    const getTrivy = ctx.getTrivyStatus;
+    if (getTrivy) {
+      const st = getTrivy();
+      if (!st.detected || !st.serverUrl) {
+        return {
+          checkId: CHECK_ID,
+          checkName: CHECK_NAME,
+          pillar: Pillar.Security,
+          status: CheckStatus.Skipped,
+          severity: Severity.Medium,
+          message:
+            'Vulnerability scanning is unavailable (Trivy not detected or unreachable); threshold check skipped.',
+        };
+      }
+    }
+
+    const repo = ctx.imageScanRepository ?? new ImageScanRepository();
+    const grouped = repo.countVulnerabilitiesGroupedBySeverity();
+
+    const critical = grouped.critical ?? 0;
+    const high = grouped.high ?? 0;
+    const medium = grouped.medium ?? 0;
+
+    const maxCritical = maxAllowed('VULN_MAX_CRITICAL', 0);
+    const maxHigh = maxAllowed('VULN_MAX_HIGH', 1_000_000);
+    const maxMedium = maxAllowed('VULN_MAX_MEDIUM', 1_000_000);
+
+    const parts: string[] = [];
+    let failing = false;
+
+    if (critical > maxCritical) {
+      failing = true;
+      parts.push(`critical ${critical} exceeds max ${maxCritical}`);
+    }
+    if (high > maxHigh) {
+      failing = true;
+      parts.push(`high ${high} exceeds max ${maxHigh}`);
+    }
+    if (medium > maxMedium) {
+      failing = true;
+      parts.push(`medium ${medium} exceeds max ${maxMedium}`);
+    }
+
+    if (failing) {
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.Security,
+        status: CheckStatus.Failing,
+        severity: Severity.High,
+        message: `Stored vulnerability thresholds exceeded: ${parts.join('; ')}`,
+        remediation:
+          'Remediate findings, adjust workload images, or raise VULN_MAX_* only with explicit risk acceptance.',
+      };
+    }
+
+    return {
+      checkId: CHECK_ID,
+      checkName: CHECK_NAME,
+      pillar: Pillar.Security,
+      status: CheckStatus.Passing,
+      severity: Severity.Medium,
+      message: `Stored findings within thresholds (critical=${critical}, high=${high}, medium=${medium}).`,
+    };
+  },
+};

--- a/src/assessment/runner.integration.test.ts
+++ b/src/assessment/runner.integration.test.ts
@@ -76,6 +76,7 @@ const mockConfig = {
   clusterMetadataIntervalSeconds: 86400,
   resourceInventoryIntervalSeconds: 21600,
   resourceConfigurationPatternsIntervalSeconds: 43200,
+  workloadImageScanIntervalSeconds: 86400,
   eventRetentionInfoWarningDays: 7,
   eventRetentionErrorCriticalDays: 30,
 } as never;

--- a/src/assessment/runner.integration.test.ts
+++ b/src/assessment/runner.integration.test.ts
@@ -207,7 +207,7 @@ describe('AssessmentRunner (integration)', () => {
       pillarFilter: Pillar.Security,
     });
 
-    expect(checks.length).toBeGreaterThanOrEqual(8);
+    expect(checks.length).toBeGreaterThanOrEqual(9);
     const ids = checks.map((c) => c.id).sort();
     expect(ids).toContain('security.run-as-non-root');
     expect(ids).toContain('security.privileged-containers');
@@ -217,6 +217,7 @@ describe('AssessmentRunner (integration)', () => {
     expect(ids).toContain('security.secrets-in-configmaps');
     expect(ids).toContain('security.external-secrets-usage');
     expect(ids).toContain('security.hardcoded-secrets');
+    expect(ids).toContain('security.stored-vulnerability-thresholds');
   });
 
   it('security checks run successfully with empty cluster (all pass)', async () => {
@@ -239,12 +240,12 @@ describe('AssessmentRunner (integration)', () => {
 
     expect(record.run_id).toBe('run-security-pillar');
     expect(record.state).toBe('completed');
-    expect(record.total_checks).toBe(8);
-    expect(record.passed_checks).toBe(8);
+    expect(record.total_checks).toBe(9);
+    expect(record.passed_checks).toBe(9);
     expect(record.failed_checks).toBe(0);
 
     const history = storage.queryHistory({ filters: { run_id: 'run-security-pillar' } });
-    expect(history).toHaveLength(8);
+    expect(history).toHaveLength(9);
     expect(history.every((h) => h.status === 'passing')).toBe(true);
   });
 

--- a/src/assessment/runner.ts
+++ b/src/assessment/runner.ts
@@ -35,6 +35,8 @@ import {
 import type { Config } from '../config/types.js';
 import type { KubernetesClient } from '../kubernetes/client.js';
 import type { Logger } from 'winston';
+import type { TrivyStatus } from '../status/types.js';
+import type { ImageScanRepository } from '../database/image-scan-repository.js';
 
 /** Default per-check timeout in milliseconds */
 const DEFAULT_CHECK_TIMEOUT_MS = 30_000;
@@ -59,6 +61,8 @@ export interface AssessmentRunnerDeps {
   config: Config;
   logger: Logger;
   storage?: AssessmentRepository;
+  getTrivyStatus?: () => TrivyStatus;
+  imageScanRepository?: ImageScanRepository;
 }
 
 /**
@@ -207,6 +211,8 @@ export class AssessmentRunner {
       mode: input.mode,
       pillarFilter: input.pillarFilter,
       checkIdFilter: input.checkIdFilter,
+      getTrivyStatus: this.deps.getTrivyStatus,
+      imageScanRepository: this.deps.imageScanRepository,
     };
 
     // Initial record (queued -> running)

--- a/src/assessment/types.ts
+++ b/src/assessment/types.ts
@@ -9,6 +9,8 @@
 import type { KubernetesClient } from '../kubernetes/client.js';
 import type { Config } from '../config/types.js';
 import type { Logger } from 'winston';
+import type { TrivyStatus } from '../status/types.js';
+import type { ImageScanRepository } from '../database/image-scan-repository.js';
 
 // ---------------------------------------------------------------------------
 // Pillar Taxonomy
@@ -161,6 +163,13 @@ export interface AssessmentRunContext {
   pillarFilter?: Pillar;
   /** Optional single check ID when mode is 'single-check' */
   checkIdFilter?: string;
+  /**
+   * When set (e.g. in-cluster operator), vulnerability checks skip if Trivy is not available.
+   * Omitted in standalone CLI runs that only read the local database.
+   */
+  getTrivyStatus?: () => TrivyStatus;
+  /** Optional repository for tests; defaults to the process SQLite database. */
+  imageScanRepository?: ImageScanRepository;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/commands/assess.ts
+++ b/src/cli/commands/assess.ts
@@ -15,6 +15,9 @@ import { AssessmentRunMode, Pillar, PILLAR_VALUES } from '../../assessment/types
 import { kubernetesClient } from '../../kubernetes/client.js';
 import { loadConfig, setConfig } from '../../config/loader.js';
 import { logger } from '../../logging/logger.js';
+import { detectTrivyWithTimeout } from '../../trivy/detection.js';
+import { parseTrivyDetectionConfigFromEnv } from '../../trivy/env-config.js';
+import { ImageScanRepository } from '../../database/image-scan-repository.js';
 
 const PILLAR_OPTIONS = PILLAR_VALUES.join(', ');
 
@@ -155,10 +158,16 @@ export async function assessRun(options: Record<string, unknown>) {
     const config = await loadConfig();
     setConfig(config);
 
+    const trivyStatusAtRunStart = await detectTrivyWithTimeout(
+      parseTrivyDetectionConfigFromEnv()
+    );
+
     const runner = new AssessmentRunner({
       kubernetes: kubernetesClient,
       config,
       logger,
+      getTrivyStatus: () => trivyStatusAtRunStart,
+      imageScanRepository: new ImageScanRepository(),
     });
 
     const mode = validated.mode as AssessmentRunMode;

--- a/src/cli/commands/vulnerabilities.ts
+++ b/src/cli/commands/vulnerabilities.ts
@@ -1,0 +1,151 @@
+/**
+ * CLI: query stored image vulnerabilities (from Trivy-backed scans).
+ */
+
+import { z } from 'zod';
+import { DatabaseManager } from '../../database/manager.js';
+import { SchemaManager } from '../../database/schema.js';
+import {
+  ImageScanRepository,
+  type ImageVulnerabilityFilters,
+} from '../../database/image-scan-repository.js';
+import { formatOutput } from '../formatters.js';
+import { trivyStatusTracker } from '../../trivy/state.js';
+
+function writeError(message: string, details?: string) {
+  const err = details ? { error: message, details } : { error: message };
+  console.error(JSON.stringify(err));
+  process.exit(1);
+}
+
+function ensureDb() {
+  DatabaseManager.getInstance();
+  const schema = new SchemaManager();
+  schema.initialize();
+}
+
+const ListOptionsSchema = z.object({
+  severity: z.string().optional(),
+  imageReference: z.string().optional(),
+  vulnerabilityId: z.string().optional(),
+  scanId: z.string().optional(),
+  completedFrom: z.string().optional(),
+  completedTo: z.string().optional(),
+  limit: z
+    .string()
+    .default('100')
+    .transform(Number)
+    .pipe(z.number().int().positive().max(5000)),
+  offset: z
+    .string()
+    .default('0')
+    .transform(Number)
+    .pipe(z.number().int().nonnegative()),
+  format: z.enum(['json', 'yaml', 'table', 'compact']).default('json'),
+});
+
+const SummaryOptionsSchema = z.object({
+  format: z.enum(['json', 'yaml', 'table', 'compact']).default('json'),
+});
+
+export async function listVulnerabilities(options: Record<string, unknown>) {
+  try {
+    const validated = ListOptionsSchema.parse(options);
+    ensureDb();
+
+    const trivy = trivyStatusTracker.getStatus();
+    const scanningAvailable = Boolean(trivy.detected && trivy.serverUrl);
+
+    const filters: ImageVulnerabilityFilters = {};
+    if (validated.severity) {
+      filters.severity = validated.severity
+        .split(',')
+        .map((s) => s.trim().toLowerCase())
+        .filter(Boolean);
+    }
+    if (validated.imageReference) {
+      filters.image_reference = validated.imageReference;
+    }
+    if (validated.vulnerabilityId) {
+      filters.vulnerability_id = validated.vulnerabilityId;
+    }
+    if (validated.scanId) {
+      filters.scan_id = validated.scanId;
+    }
+    if (validated.completedFrom) {
+      filters.completed_from = validated.completedFrom;
+    }
+    if (validated.completedTo) {
+      filters.completed_to = validated.completedTo;
+    }
+
+    const repo = new ImageScanRepository();
+    const rows = repo.queryVulnerabilities({
+      filters,
+      limit: validated.limit,
+      offset: validated.offset,
+    });
+    const total = repo.countVulnerabilities(filters);
+
+    const result = {
+      scanning_available: scanningAvailable,
+      message: scanningAvailable
+        ? undefined
+        : 'Vulnerability scanning is unavailable (Trivy not detected or unreachable); listing stored findings only.',
+      vulnerabilities: rows,
+      pagination: {
+        total,
+        limit: validated.limit,
+        offset: validated.offset,
+        returned: rows.length,
+      },
+    };
+
+    console.log(formatOutput(result, validated.format));
+    process.exit(0);
+  } catch (err: unknown) {
+    if (err instanceof z.ZodError) {
+      const first = err.errors[0];
+      writeError('Invalid arguments', first?.message);
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    writeError('Failed to list vulnerabilities', msg);
+  }
+}
+
+export async function summarizeVulnerabilities(options: Record<string, unknown>) {
+  try {
+    const validated = SummaryOptionsSchema.parse(options);
+    ensureDb();
+
+    const trivy = trivyStatusTracker.getStatus();
+    const repo = new ImageScanRepository();
+    const grouped = repo.countVulnerabilitiesGroupedBySeverity();
+    const total = Object.values(grouped).reduce((a, b) => a + b, 0);
+
+    const summary = {
+      scanning_available: Boolean(trivy.detected && trivy.serverUrl),
+      total_findings: total,
+      by_severity: grouped,
+      trivy: {
+        detected: trivy.detected,
+        server_url: trivy.serverUrl,
+      },
+    };
+
+    if (!summary.scanning_available) {
+      (summary as { message?: string }).message =
+        'Vulnerability scanning is unavailable (Trivy not detected or unreachable). Summary reflects stored data only.';
+    }
+
+    console.log(formatOutput(summary, validated.format));
+    process.exit(0);
+  } catch (err: unknown) {
+    if (err instanceof z.ZodError) {
+      const first = err.errors[0];
+      writeError('Invalid arguments', first?.message);
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    writeError('Failed to summarize vulnerabilities', msg);
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,6 +12,7 @@ import {
   assessSummary,
   assessHistory,
 } from './commands/assess.js';
+import { listVulnerabilities, summarizeVulnerabilities } from './commands/vulnerabilities.js';
 
 /**
  * Create the assess command structure
@@ -113,7 +114,31 @@ export function createQueryCommands(): Command {
     .description('Get single event by ID')
     .option('--format <format>', 'Output format (json|yaml|table)', 'json')
     .action(getEvent);
-  
+
+  const vulnerabilities = query
+    .command('vulnerabilities')
+    .description('Query stored image vulnerability findings (Trivy)');
+
+  vulnerabilities
+    .command('list')
+    .description('List vulnerabilities with optional filters')
+    .option('--severity <levels>', 'Comma-separated severities (e.g. critical,high)')
+    .option('--image-reference <ref>', 'Filter by scanned image reference')
+    .option('--vulnerability-id <id>', 'Filter by CVE/advisory id')
+    .option('--scan-id <id>', 'Filter by scan id')
+    .option('--completed-from <iso>', 'Completed on/after (ISO 8601)')
+    .option('--completed-to <iso>', 'Completed on/before (ISO 8601)')
+    .option('--limit <number>', 'Limit results', '100')
+    .option('--offset <number>', 'Offset', '0')
+    .option('--format <format>', 'Output format (json|yaml|table|compact)', 'json')
+    .action(listVulnerabilities);
+
+  vulnerabilities
+    .command('summary')
+    .description('Summary counts by severity from stored findings')
+    .option('--format <format>', 'Output format (json|yaml|table|compact)', 'json')
+    .action(summarizeVulnerabilities);
+
   return query;
 }
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -31,6 +31,10 @@ export async function loadConfig(): Promise<Config> {
     process.env.RESOURCE_CONFIGURATION_PATTERNS_INTERVAL_SECONDS || '43200',
     10
   );
+  const workloadImageScanIntervalSeconds = parseInt(
+    process.env.WORKLOAD_IMAGE_SCAN_INTERVAL_SECONDS || '86400',
+    10
+  );
   const eventRetentionInfoWarningDays = parseInt(
     process.env.EVENT_RETENTION_INFO_WARNING_DAYS || '7',
     10
@@ -53,6 +57,7 @@ export async function loadConfig(): Promise<Config> {
     clusterMetadataIntervalSeconds,
     resourceInventoryIntervalSeconds,
     resourceConfigurationPatternsIntervalSeconds,
+    workloadImageScanIntervalSeconds,
     eventRetentionInfoWarningDays,
     eventRetentionErrorCriticalDays,
   };
@@ -65,6 +70,8 @@ export async function loadConfig(): Promise<Config> {
     clusterMetadataOverridden: process.env.CLUSTER_METADATA_INTERVAL_SECONDS !== undefined,
     resourceInventoryOverridden: process.env.RESOURCE_INVENTORY_INTERVAL_SECONDS !== undefined,
     resourceConfigurationPatternsOverridden: process.env.RESOURCE_CONFIGURATION_PATTERNS_INTERVAL_SECONDS !== undefined,
+    workloadImageScanIntervalSeconds: config.workloadImageScanIntervalSeconds,
+    workloadImageScanOverridden: process.env.WORKLOAD_IMAGE_SCAN_INTERVAL_SECONDS !== undefined,
   });
 
   return config;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -41,6 +41,13 @@ export interface Config {
   resourceConfigurationPatternsIntervalSeconds: number;
 
   /**
+   * Workload container image collection / scan cycle interval in seconds
+   * (collects from Pods, Deployments, StatefulSets; Trivy scans only when Trivy is active).
+   * Default: 86400 (24 hours), Minimum: 3600 (1 hour)
+   */
+  workloadImageScanIntervalSeconds: number;
+
+  /**
    * Event retention for info/warning severity (days)
    * Default: 7 days
    */

--- a/src/database/image-scan-contracts.ts
+++ b/src/database/image-scan-contracts.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+export const ImageScanStateSchema = z.enum([
+  'queued',
+  'running',
+  'completed',
+  'failed',
+  'skipped',
+]);
+
+export const ImageScanRecordSchema = z.object({
+  scan_id: z.string().min(1),
+  image_reference: z.string().min(1),
+  image_digest: z.string().min(1).optional().nullable(),
+  started_at: z.string().min(1),
+  completed_at: z.string().min(1).optional().nullable(),
+  state: ImageScanStateSchema,
+  scanner: z.string().min(1),
+  error_message: z.string().optional().nullable(),
+});
+
+export type ImageScanRecord = z.infer<typeof ImageScanRecordSchema>;
+
+export const ImageVulnerabilityInputSchema = z.object({
+  id: z.string().min(1),
+  scan_id: z.string().min(1),
+  vulnerability_id: z.string().min(1),
+  severity: z.string().min(1),
+  package_name: z.string().optional().nullable(),
+  installed_version: z.string().optional().nullable(),
+  fixed_version: z.string().optional().nullable(),
+  title: z.string().optional().nullable(),
+  raw_metadata: z.string().optional().nullable(),
+});
+
+export type ImageVulnerabilityInput = z.infer<typeof ImageVulnerabilityInputSchema>;

--- a/src/database/image-scan-repository.test.ts
+++ b/src/database/image-scan-repository.test.ts
@@ -171,6 +171,45 @@ describe('ImageScanRepository', () => {
     expect(repo.getScanById('new')).not.toBeNull();
   });
 
+  it('counts vulnerabilities grouped by severity for completed scans', () => {
+    const repo = new ImageScanRepository();
+    repo.upsertScan({
+      scan_id: 's-group',
+      image_reference: 'img:1',
+      started_at: '2026-01-01T00:00:00.000Z',
+      completed_at: '2026-01-02T00:00:00.000Z',
+      state: 'completed',
+      scanner: 'trivy',
+    });
+    repo.replaceVulnerabilitiesForScan('s-group', [
+      {
+        id: 'v1',
+        scan_id: 's-group',
+        vulnerability_id: 'CVE-1',
+        severity: 'CRITICAL',
+        package_name: 'a',
+        installed_version: null,
+        fixed_version: null,
+        title: null,
+        raw_metadata: null,
+      },
+      {
+        id: 'v2',
+        scan_id: 's-group',
+        vulnerability_id: 'CVE-2',
+        severity: 'high',
+        package_name: 'b',
+        installed_version: null,
+        fixed_version: null,
+        title: null,
+        raw_metadata: null,
+      },
+    ]);
+    const g = repo.countVulnerabilitiesGroupedBySeverity();
+    expect(g.critical).toBe(1);
+    expect(g.high).toBe(1);
+  });
+
   it('empty repository returns no rows', () => {
     const repo = new ImageScanRepository();
     expect(repo.queryScans()).toEqual([]);

--- a/src/database/image-scan-repository.test.ts
+++ b/src/database/image-scan-repository.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { SchemaManager } from './schema.js';
+import { DatabaseManager } from './manager.js';
+import { ImageScanRepository } from './image-scan-repository.js';
+import { existsSync, rmSync, mkdirSync } from 'fs';
+import path from 'path';
+
+const testDbDir = path.join(process.cwd(), 'test-image-scan-temp');
+
+describe('ImageScanRepository', () => {
+  beforeAll(() => {
+    if (existsSync(testDbDir)) {
+      rmSync(testDbDir, { recursive: true, force: true });
+    }
+    mkdirSync(testDbDir, { recursive: true });
+    process.env.DB_PATH = testDbDir;
+  });
+
+  afterAll(() => {
+    DatabaseManager.reset();
+    if (existsSync(testDbDir)) {
+      rmSync(testDbDir, { recursive: true, force: true });
+    }
+    delete process.env.DB_PATH;
+  });
+
+  beforeEach(() => {
+    DatabaseManager.reset();
+    const dbPath = path.join(testDbDir, 'kube9.db');
+    if (existsSync(dbPath)) {
+      rmSync(dbPath);
+    }
+    const schema = new SchemaManager();
+    schema.initialize();
+  });
+
+  afterEach(() => {
+    DatabaseManager.reset();
+  });
+
+  it('stores and retrieves scans with filters', () => {
+    const repo = new ImageScanRepository();
+    const t0 = '2026-01-01T00:00:00.000Z';
+    const t1 = '2026-01-15T12:00:00.000Z';
+    repo.upsertScan({
+      scan_id: 'scan-a',
+      image_reference: 'docker.io/library/nginx:1.25',
+      started_at: t0,
+      completed_at: t1,
+      state: 'completed',
+      scanner: 'trivy',
+    });
+    repo.upsertScan({
+      scan_id: 'scan-b',
+      image_reference: 'gcr.io/foo/bar:v2',
+      started_at: '2026-02-01T00:00:00.000Z',
+      state: 'failed',
+      scanner: 'trivy',
+      error_message: 'timeout',
+    });
+
+    expect(repo.getScanById('scan-a')?.image_reference).toBe('docker.io/library/nginx:1.25');
+    const byRef = repo.queryScans({
+      filters: { image_reference: 'docker.io/library/nginx:1.25' },
+    });
+    expect(byRef).toHaveLength(1);
+
+    const contains = repo.queryScans({
+      filters: { image_reference_contains: 'nginx' },
+    });
+    expect(contains.map((s) => s.scan_id)).toContain('scan-a');
+
+    const inRange = repo.queryScans({
+      filters: { completed_from: '2026-01-10T00:00:00.000Z', completed_to: '2026-01-20T00:00:00.000Z' },
+    });
+    expect(inRange.map((s) => s.scan_id)).toEqual(['scan-a']);
+
+    expect(repo.countScans({ state: 'failed' })).toBe(1);
+  });
+
+  it('replaces vulnerabilities and filters by severity and time', () => {
+    const repo = new ImageScanRepository();
+    const started = '2026-03-01T10:00:00.000Z';
+    const completed = '2026-03-01T10:05:00.000Z';
+    repo.upsertScan({
+      scan_id: 'scan-1',
+      image_reference: 'alpine:3',
+      started_at: started,
+      completed_at: completed,
+      state: 'completed',
+      scanner: 'trivy',
+    });
+    repo.replaceVulnerabilitiesForScan('scan-1', [
+      {
+        id: 'v1',
+        scan_id: 'scan-1',
+        vulnerability_id: 'CVE-2024-1',
+        severity: 'HIGH',
+        title: 'test',
+      },
+      {
+        id: 'v2',
+        scan_id: 'scan-1',
+        vulnerability_id: 'CVE-2024-2',
+        severity: 'LOW',
+      },
+    ]);
+
+    expect(repo.countVulnerabilities({ scan_id: 'scan-1' })).toBe(2);
+    const highs = repo.queryVulnerabilities({
+      filters: { severity: 'HIGH', completed_from: '2026-03-01T00:00:00.000Z' },
+    });
+    expect(highs).toHaveLength(1);
+    expect(highs[0]?.vulnerability_id).toBe('CVE-2024-1');
+
+    repo.replaceVulnerabilitiesForScan('scan-1', [
+      {
+        id: 'v3',
+        scan_id: 'scan-1',
+        vulnerability_id: 'CVE-2024-3',
+        severity: 'CRITICAL',
+      },
+    ]);
+    expect(repo.countVulnerabilities({ scan_id: 'scan-1' })).toBe(1);
+  });
+
+  it('cascades deletes when removing a scan', () => {
+    const repo = new ImageScanRepository();
+    repo.upsertScan({
+      scan_id: 'scan-c',
+      image_reference: 'x:y',
+      started_at: new Date().toISOString(),
+      state: 'completed',
+      scanner: 'trivy',
+    });
+    repo.insertVulnerabilities([
+      {
+        id: 'row1',
+        scan_id: 'scan-c',
+        vulnerability_id: 'CVE-1',
+        severity: 'MEDIUM',
+      },
+    ]);
+    expect(repo.countVulnerabilities({ scan_id: 'scan-c' })).toBe(1);
+    repo.deleteScan('scan-c');
+    expect(repo.getScanById('scan-c')).toBeNull();
+    expect(repo.countVulnerabilities({ scan_id: 'scan-c' })).toBe(0);
+  });
+
+  it('deleteScansCompletedBefore removes old completed scans', () => {
+    const repo = new ImageScanRepository();
+    repo.upsertScan({
+      scan_id: 'old',
+      image_reference: 'a:b',
+      started_at: '2020-01-01T00:00:00.000Z',
+      completed_at: '2020-01-02T00:00:00.000Z',
+      state: 'completed',
+      scanner: 'trivy',
+    });
+    repo.upsertScan({
+      scan_id: 'new',
+      image_reference: 'c:d',
+      started_at: '2026-01-01T00:00:00.000Z',
+      completed_at: '2026-01-02T00:00:00.000Z',
+      state: 'completed',
+      scanner: 'trivy',
+    });
+    const n = repo.deleteScansCompletedBefore('2025-01-01T00:00:00.000Z');
+    expect(n).toBe(1);
+    expect(repo.getScanById('old')).toBeNull();
+    expect(repo.getScanById('new')).not.toBeNull();
+  });
+
+  it('empty repository returns no rows', () => {
+    const repo = new ImageScanRepository();
+    expect(repo.queryScans()).toEqual([]);
+    expect(repo.queryVulnerabilities()).toEqual([]);
+    expect(repo.countScans()).toBe(0);
+    expect(repo.countVulnerabilities()).toBe(0);
+  });
+});

--- a/src/database/image-scan-repository.ts
+++ b/src/database/image-scan-repository.ts
@@ -1,0 +1,381 @@
+/**
+ * Persistence for Trivy (or other) image scans and normalized vulnerability rows.
+ */
+
+import { DatabaseManager } from './manager.js';
+import Database from 'better-sqlite3';
+import {
+  ImageScanRecord,
+  ImageScanRecordSchema,
+  ImageVulnerabilityInput,
+  ImageVulnerabilityInputSchema,
+} from './image-scan-contracts.js';
+
+export interface ImageScanRow {
+  scan_id: string;
+  image_reference: string;
+  image_digest: string | null;
+  started_at: string;
+  completed_at: string | null;
+  state: string;
+  scanner: string;
+  error_message: string | null;
+}
+
+export interface ImageVulnerabilityRow {
+  id: string;
+  scan_id: string;
+  vulnerability_id: string;
+  severity: string;
+  package_name: string | null;
+  installed_version: string | null;
+  fixed_version: string | null;
+  title: string | null;
+  raw_metadata: string | null;
+}
+
+export interface ImageScanFilters {
+  state?: string;
+  image_reference?: string;
+  /** Match image_reference with SQL LIKE '%' || value || '%' */
+  image_reference_contains?: string;
+  started_from?: string;
+  started_to?: string;
+  completed_from?: string;
+  completed_to?: string;
+}
+
+export interface ImageScanQueryOptions {
+  filters?: ImageScanFilters;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ImageVulnerabilityFilters {
+  scan_id?: string;
+  severity?: string | string[];
+  vulnerability_id?: string;
+  image_reference?: string;
+  /** Time range on parent scan completed_at (ISO 8601), inclusive */
+  completed_from?: string;
+  completed_to?: string;
+}
+
+export interface ImageVulnerabilityQueryOptions {
+  filters?: ImageVulnerabilityFilters;
+  limit?: number;
+  offset?: number;
+}
+
+export class ImageScanRepository {
+  private db: Database.Database;
+
+  constructor() {
+    const manager = DatabaseManager.getInstance();
+    this.db = manager.getDatabase();
+  }
+
+  public upsertScan(record: ImageScanRecord): void {
+    const v = ImageScanRecordSchema.parse(record);
+    const stmt = this.db.prepare(`
+      INSERT INTO image_scans (
+        scan_id, image_reference, image_digest, started_at, completed_at,
+        state, scanner, error_message
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(scan_id) DO UPDATE SET
+        image_reference = excluded.image_reference,
+        image_digest = excluded.image_digest,
+        started_at = excluded.started_at,
+        completed_at = COALESCE(excluded.completed_at, completed_at),
+        state = excluded.state,
+        scanner = excluded.scanner,
+        error_message = excluded.error_message
+    `);
+    stmt.run(
+      v.scan_id,
+      v.image_reference,
+      v.image_digest ?? null,
+      v.started_at,
+      v.completed_at ?? null,
+      v.state,
+      v.scanner,
+      v.error_message ?? null
+    );
+  }
+
+  public getScanById(scanId: string): ImageScanRecord | null {
+    const row = this.db
+      .prepare('SELECT * FROM image_scans WHERE scan_id = ?')
+      .get(scanId) as ImageScanRow | undefined;
+    if (!row) return null;
+    return this.rowToScanRecord(row);
+  }
+
+  public queryScans(options: ImageScanQueryOptions = {}): ImageScanRecord[] {
+    const { filters = {}, limit = 100, offset = 0 } = options;
+    const conditions: string[] = [];
+    const params: (string | number)[] = [];
+
+    if (filters.state) {
+      conditions.push('state = ?');
+      params.push(filters.state);
+    }
+    if (filters.image_reference) {
+      conditions.push('image_reference = ?');
+      params.push(filters.image_reference);
+    }
+    if (filters.image_reference_contains) {
+      conditions.push('image_reference LIKE ?');
+      params.push(`%${filters.image_reference_contains}%`);
+    }
+    if (filters.started_from) {
+      conditions.push('started_at >= ?');
+      params.push(filters.started_from);
+    }
+    if (filters.started_to) {
+      conditions.push('started_at <= ?');
+      params.push(filters.started_to);
+    }
+    if (filters.completed_from) {
+      conditions.push('completed_at IS NOT NULL AND completed_at >= ?');
+      params.push(filters.completed_from);
+    }
+    if (filters.completed_to) {
+      conditions.push('completed_at IS NOT NULL AND completed_at <= ?');
+      params.push(filters.completed_to);
+    }
+
+    let query = 'SELECT * FROM image_scans';
+    if (conditions.length > 0) {
+      query += ' WHERE ' + conditions.join(' AND ');
+    }
+    query += ' ORDER BY started_at DESC LIMIT ? OFFSET ?';
+    params.push(limit, offset);
+
+    const rows = this.db.prepare(query).all(...params) as ImageScanRow[];
+    return rows.map((r) => this.rowToScanRecord(r));
+  }
+
+  public countScans(filters: ImageScanFilters = {}): number {
+    const conditions: string[] = [];
+    const params: string[] = [];
+
+    if (filters.state) {
+      conditions.push('state = ?');
+      params.push(filters.state);
+    }
+    if (filters.image_reference) {
+      conditions.push('image_reference = ?');
+      params.push(filters.image_reference);
+    }
+    if (filters.image_reference_contains) {
+      conditions.push('image_reference LIKE ?');
+      params.push(`%${filters.image_reference_contains}%`);
+    }
+    if (filters.started_from) {
+      conditions.push('started_at >= ?');
+      params.push(filters.started_from);
+    }
+    if (filters.started_to) {
+      conditions.push('started_at <= ?');
+      params.push(filters.started_to);
+    }
+    if (filters.completed_from) {
+      conditions.push('completed_at IS NOT NULL AND completed_at >= ?');
+      params.push(filters.completed_from);
+    }
+    if (filters.completed_to) {
+      conditions.push('completed_at IS NOT NULL AND completed_at <= ?');
+      params.push(filters.completed_to);
+    }
+
+    let query = 'SELECT COUNT(*) as count FROM image_scans';
+    if (conditions.length > 0) {
+      query += ' WHERE ' + conditions.join(' AND ');
+    }
+    const result = this.db.prepare(query).get(...params) as { count: number };
+    return result.count;
+  }
+
+  /**
+   * Replace all vulnerability rows for a scan (idempotent completion write).
+   */
+  public replaceVulnerabilitiesForScan(
+    scanId: string,
+    rows: ImageVulnerabilityInput[]
+  ): void {
+    const validated = rows.map((r) => ImageVulnerabilityInputSchema.parse(r));
+    const del = this.db.prepare('DELETE FROM image_vulnerabilities WHERE scan_id = ?');
+    const ins = this.db.prepare(`
+      INSERT INTO image_vulnerabilities (
+        id, scan_id, vulnerability_id, severity, package_name,
+        installed_version, fixed_version, title, raw_metadata
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    const run = this.db.transaction(() => {
+      del.run(scanId);
+      for (const row of validated) {
+        ins.run(
+          row.id,
+          row.scan_id,
+          row.vulnerability_id,
+          row.severity,
+          row.package_name ?? null,
+          row.installed_version ?? null,
+          row.fixed_version ?? null,
+          row.title ?? null,
+          row.raw_metadata ?? null
+        );
+      }
+    });
+    run();
+  }
+
+  public insertVulnerabilities(rows: ImageVulnerabilityInput[]): void {
+    if (rows.length === 0) return;
+    const validated = rows.map((r) => ImageVulnerabilityInputSchema.parse(r));
+    const ins = this.db.prepare(`
+      INSERT INTO image_vulnerabilities (
+        id, scan_id, vulnerability_id, severity, package_name,
+        installed_version, fixed_version, title, raw_metadata
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    const run = this.db.transaction(() => {
+      for (const row of validated) {
+        ins.run(
+          row.id,
+          row.scan_id,
+          row.vulnerability_id,
+          row.severity,
+          row.package_name ?? null,
+          row.installed_version ?? null,
+          row.fixed_version ?? null,
+          row.title ?? null,
+          row.raw_metadata ?? null
+        );
+      }
+    });
+    run();
+  }
+
+  public queryVulnerabilities(
+    options: ImageVulnerabilityQueryOptions = {}
+  ): ImageVulnerabilityRow[] {
+    const { filters = {}, limit = 500, offset = 0 } = options;
+    const conditions: string[] = [];
+    const params: (string | number)[] = [];
+
+    if (filters.scan_id) {
+      conditions.push('v.scan_id = ?');
+      params.push(filters.scan_id);
+    }
+    if (filters.vulnerability_id) {
+      conditions.push('v.vulnerability_id = ?');
+      params.push(filters.vulnerability_id);
+    }
+    if (filters.image_reference) {
+      conditions.push('s.image_reference = ?');
+      params.push(filters.image_reference);
+    }
+    if (filters.severity) {
+      const sev = Array.isArray(filters.severity) ? filters.severity : [filters.severity];
+      conditions.push(`v.severity IN (${sev.map(() => '?').join(',')})`);
+      params.push(...sev);
+    }
+    if (filters.completed_from) {
+      conditions.push('s.completed_at IS NOT NULL AND s.completed_at >= ?');
+      params.push(filters.completed_from);
+    }
+    if (filters.completed_to) {
+      conditions.push('s.completed_at IS NOT NULL AND s.completed_at <= ?');
+      params.push(filters.completed_to);
+    }
+
+    let query = `
+      SELECT v.id, v.scan_id, v.vulnerability_id, v.severity, v.package_name,
+             v.installed_version, v.fixed_version, v.title, v.raw_metadata
+      FROM image_vulnerabilities v
+      INNER JOIN image_scans s ON s.scan_id = v.scan_id
+    `;
+    if (conditions.length > 0) {
+      query += ' WHERE ' + conditions.join(' AND ');
+    }
+    query += ' ORDER BY v.severity DESC, v.vulnerability_id ASC LIMIT ? OFFSET ?';
+    params.push(limit, offset);
+
+    return this.db.prepare(query).all(...params) as ImageVulnerabilityRow[];
+  }
+
+  public countVulnerabilities(filters: ImageVulnerabilityFilters = {}): number {
+    const conditions: string[] = [];
+    const params: string[] = [];
+
+    if (filters.scan_id) {
+      conditions.push('v.scan_id = ?');
+      params.push(filters.scan_id);
+    }
+    if (filters.vulnerability_id) {
+      conditions.push('v.vulnerability_id = ?');
+      params.push(filters.vulnerability_id);
+    }
+    if (filters.image_reference) {
+      conditions.push('s.image_reference = ?');
+      params.push(filters.image_reference);
+    }
+    if (filters.severity) {
+      const sev = Array.isArray(filters.severity) ? filters.severity : [filters.severity];
+      conditions.push(`v.severity IN (${sev.map(() => '?').join(',')})`);
+      params.push(...sev);
+    }
+    if (filters.completed_from) {
+      conditions.push('s.completed_at IS NOT NULL AND s.completed_at >= ?');
+      params.push(filters.completed_from);
+    }
+    if (filters.completed_to) {
+      conditions.push('s.completed_at IS NOT NULL AND s.completed_at <= ?');
+      params.push(filters.completed_to);
+    }
+
+    let query = `
+      SELECT COUNT(*) as count
+      FROM image_vulnerabilities v
+      INNER JOIN image_scans s ON s.scan_id = v.scan_id
+    `;
+    if (conditions.length > 0) {
+      query += ' WHERE ' + conditions.join(' AND ');
+    }
+    const result = this.db.prepare(query).get(...params) as { count: number };
+    return result.count;
+  }
+
+  public deleteScan(scanId: string): number {
+    const r = this.db.prepare('DELETE FROM image_scans WHERE scan_id = ?').run(scanId);
+    return r.changes;
+  }
+
+  /**
+   * Retention helper: remove completed scans (and cascaded vulnerabilities) older than cutoff.
+   */
+  public deleteScansCompletedBefore(isoTimestamp: string): number {
+    const r = this.db
+      .prepare(
+        `DELETE FROM image_scans WHERE completed_at IS NOT NULL AND completed_at < ?`
+      )
+      .run(isoTimestamp);
+    return r.changes;
+  }
+
+  private rowToScanRecord(row: ImageScanRow): ImageScanRecord {
+    return ImageScanRecordSchema.parse({
+      scan_id: row.scan_id,
+      image_reference: row.image_reference,
+      image_digest: row.image_digest ?? undefined,
+      started_at: row.started_at,
+      completed_at: row.completed_at ?? undefined,
+      state: row.state,
+      scanner: row.scanner,
+      error_message: row.error_message ?? undefined,
+    });
+  }
+}

--- a/src/database/image-scan-repository.ts
+++ b/src/database/image-scan-repository.ts
@@ -307,6 +307,31 @@ export class ImageScanRepository {
     return this.db.prepare(query).all(...params) as ImageVulnerabilityRow[];
   }
 
+  /**
+   * Count stored vulnerability rows grouped by normalized severity (lowercase).
+   * Only includes rows linked to completed parent scans.
+   */
+  public countVulnerabilitiesGroupedBySeverity(): Record<string, number> {
+    const rows = this.db
+      .prepare(
+        `
+      SELECT LOWER(TRIM(v.severity)) AS sev, COUNT(*) AS c
+      FROM image_vulnerabilities v
+      INNER JOIN image_scans s ON s.scan_id = v.scan_id
+      WHERE s.completed_at IS NOT NULL
+      GROUP BY LOWER(TRIM(v.severity))
+    `
+      )
+      .all() as Array<{ sev: string; c: number }>;
+    const out: Record<string, number> = {};
+    for (const r of rows) {
+      if (r.sev) {
+        out[r.sev] = r.c;
+      }
+    }
+    return out;
+  }
+
   public countVulnerabilities(filters: ImageVulnerabilityFilters = {}): number {
     const conditions: string[] = [];
     const params: string[] = [];

--- a/src/database/schema.test.ts
+++ b/src/database/schema.test.ts
@@ -116,7 +116,7 @@ describe('SchemaManager', () => {
     
     expect(versions.length).toBeGreaterThanOrEqual(1);
     expect(versions[0]?.version).toBe(1);
-    expect(schema.getVersion()).toBeGreaterThanOrEqual(2);
+    expect(schema.getVersion()).toBeGreaterThanOrEqual(3);
   });
 
   it('schema version has correct fields', () => {
@@ -256,7 +256,33 @@ describe('SchemaManager', () => {
     const versionAfter = schema.getVersion();
     
     expect(versionBefore).toBe(versionAfter);
-    expect(versionAfter).toBeGreaterThanOrEqual(2);
+    expect(versionAfter).toBeGreaterThanOrEqual(3);
+  });
+
+  it('creates image_scans and image_vulnerabilities when migrating to v3', () => {
+    const schema = new SchemaManager();
+    schema.initialize();
+
+    const manager = DatabaseManager.getInstance();
+    const db = manager.getDatabase();
+
+    const scans = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='image_scans'`)
+      .get() as { name: string } | undefined;
+    expect(scans?.name).toBe('image_scans');
+
+    const vulns = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='image_vulnerabilities'`)
+      .get() as { name: string } | undefined;
+    expect(vulns?.name).toBe('image_vulnerabilities');
+
+    const fk = db.prepare(`PRAGMA foreign_key_list(image_vulnerabilities)`).all() as Array<{
+      table: string;
+      from: string;
+      to: string;
+    }>;
+    const scanFk = fk.find((x) => x.from === 'scan_id' && x.table === 'image_scans');
+    expect(scanFk?.to).toBe('scan_id');
   });
 
   it('migration runs cleanly on fresh database', () => {
@@ -264,7 +290,7 @@ describe('SchemaManager', () => {
     const schema = new SchemaManager();
     schema.initialize();
     
-    expect(schema.getVersion()).toBeGreaterThanOrEqual(1);
+    expect(schema.getVersion()).toBeGreaterThanOrEqual(3);
     
     const manager = DatabaseManager.getInstance();
     const db = manager.getDatabase();

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -7,7 +7,7 @@ import Database from 'better-sqlite3';
 import { logger } from '../logging/logger.js';
 
 /** Latest schema version - bump when adding migrations */
-const LATEST_SCHEMA_VERSION = 2;
+const LATEST_SCHEMA_VERSION = 3;
 
 /**
  * SchemaManager handles database schema initialization and migrations
@@ -49,6 +49,10 @@ export class SchemaManager {
       {
         version: 2,
         apply: () => this.migrateToV2(),
+      },
+      {
+        version: 3,
+        apply: () => this.migrateToV3(),
       },
     ];
 
@@ -111,6 +115,47 @@ export class SchemaManager {
       CREATE INDEX IF NOT EXISTS idx_assessment_history_status ON assessment_history(status);
       CREATE INDEX IF NOT EXISTS idx_assessment_history_assessed_at ON assessment_history(assessed_at DESC);
       CREATE INDEX IF NOT EXISTS idx_assessment_history_run_pillar ON assessment_history(run_id, pillar);
+    `);
+  }
+
+  /**
+   * Migration v3: image vulnerability scan storage (M3 Security).
+   * Retention: child rows use ON DELETE CASCADE from image_scans; optional
+   * time-based pruning is left to application code (see ImageScanRepository.deleteScansCompletedBefore).
+   */
+  private migrateToV3(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS image_scans (
+        scan_id TEXT PRIMARY KEY,
+        image_reference TEXT NOT NULL,
+        image_digest TEXT,
+        started_at TEXT NOT NULL,
+        completed_at TEXT,
+        state TEXT NOT NULL CHECK (state IN ('queued', 'running', 'completed', 'failed', 'skipped')),
+        scanner TEXT NOT NULL,
+        error_message TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_image_scans_image_reference ON image_scans(image_reference);
+      CREATE INDEX IF NOT EXISTS idx_image_scans_completed_at ON image_scans(completed_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_image_scans_state ON image_scans(state);
+
+      CREATE TABLE IF NOT EXISTS image_vulnerabilities (
+        id TEXT PRIMARY KEY,
+        scan_id TEXT NOT NULL,
+        vulnerability_id TEXT NOT NULL,
+        severity TEXT NOT NULL,
+        package_name TEXT,
+        installed_version TEXT,
+        fixed_version TEXT,
+        title TEXT,
+        raw_metadata TEXT,
+        FOREIGN KEY (scan_id) REFERENCES image_scans(scan_id) ON DELETE CASCADE
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_image_vulnerabilities_scan_id ON image_vulnerabilities(scan_id);
+      CREATE INDEX IF NOT EXISTS idx_image_vulnerabilities_severity ON image_vulnerabilities(severity);
+      CREATE INDEX IF NOT EXISTS idx_image_vulnerabilities_vulnerability_id ON image_vulnerabilities(vulnerability_id);
     `);
   }
 

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -20,7 +20,8 @@ import { logger } from './logging/logger.js';
 import { detectArgoCDWithTimeout, type ArgoCDDetectionConfig } from './argocd/detection.js';
 import { argocdStatusTracker } from './argocd/state.js';
 import { ArgoCDDetectionManager } from './argocd/detection-manager.js';
-import { detectTrivyWithTimeout, type TrivyDetectionConfig } from './trivy/detection.js';
+import { detectTrivyWithTimeout } from './trivy/detection.js';
+import { parseTrivyDetectionConfigFromEnv } from './trivy/env-config.js';
 import { trivyStatusTracker } from './trivy/state.js';
 import { TrivyDetectionManager } from './trivy/detection-manager.js';
 import { runWorkloadImageScanCycle } from './trivy/workload-scan-cycle.js';
@@ -92,19 +93,6 @@ function parseArgoCDConfig(): ArgoCDDetectionConfig {
   };
 }
 
-function parseTrivyConfig(): TrivyDetectionConfig {
-  const enabledEnv = process.env.TRIVY_ENABLED;
-  return {
-    autoDetect: process.env.TRIVY_AUTO_DETECT !== 'false',
-    enabled:
-      enabledEnv === 'true' ? true : enabledEnv === 'false' ? false : undefined,
-    serverUrl: process.env.TRIVY_SERVER_URL?.trim() || undefined,
-    healthPath: process.env.TRIVY_HEALTH_PATH || '/healthz',
-    detectionInterval: parseInt(process.env.TRIVY_DETECTION_INTERVAL || '6', 10),
-    detectionTimeoutMs: parseInt(process.env.TRIVY_DETECTION_TIMEOUT_MS || '10000', 10)
-  };
-}
-
 // Perform initial ArgoCD detection during startup
 async function performInitialArgoCDDetection(): Promise<void> {
   try {
@@ -134,7 +122,7 @@ async function performInitialArgoCDDetection(): Promise<void> {
 async function performInitialTrivyDetection(): Promise<void> {
   try {
     logger.info('Performing initial Trivy detection');
-    const trivyConfig = parseTrivyConfig();
+    const trivyConfig = parseTrivyDetectionConfigFromEnv();
     const trivyStatus = await detectTrivyWithTimeout(trivyConfig);
     trivyStatusTracker.setStatus(trivyStatus);
 
@@ -201,7 +189,7 @@ export async function startOperator() {
 
     await performInitialTrivyDetection();
 
-    const trivyConfig = parseTrivyConfig();
+    const trivyConfig = parseTrivyDetectionConfigFromEnv();
     const initialTrivyStatus = trivyStatusTracker.getStatus();
     const trivyDetectionManager = new TrivyDetectionManager();
     trivyDetectionManager.start(trivyConfig, initialTrivyStatus);

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -23,6 +23,7 @@ import { ArgoCDDetectionManager } from './argocd/detection-manager.js';
 import { detectTrivyWithTimeout, type TrivyDetectionConfig } from './trivy/detection.js';
 import { trivyStatusTracker } from './trivy/state.js';
 import { TrivyDetectionManager } from './trivy/detection-manager.js';
+import { runWorkloadImageScanCycle } from './trivy/workload-scan-cycle.js';
 import { SchemaManager } from './database/schema.js';
 import { KubernetesEventWatcher } from './events/kubernetes-event-watcher.js';
 import { EventQueueWorker } from './events/queue-worker.js';
@@ -335,6 +336,31 @@ export async function startOperator() {
           recordCollection('resource-configuration-patterns', 'failed', durationSeconds);
           collectionStatsTracker.recordFailure('resource-configuration-patterns');
           // Don't throw - scheduler will retry on next interval
+        }
+      }
+    );
+
+    collectionScheduler.register(
+      'workload-image-scan',
+      config.workloadImageScanIntervalSeconds,
+      3600, // 1 hour minimum interval
+      3600, // 0-1 hour random offset range
+      async () => {
+        const startTime = Date.now();
+        try {
+          await runWorkloadImageScanCycle({
+            kubernetesClient,
+            getTrivyStatus: () => trivyStatusTracker.getStatus(),
+          });
+          const durationSeconds = (Date.now() - startTime) / 1000;
+          recordCollection('workload-image-scan', 'success', durationSeconds);
+          collectionStatsTracker.recordSuccess('workload-image-scan');
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          logger.error('Workload image collection or scan cycle failed', { error: errorMessage });
+          const durationSeconds = (Date.now() - startTime) / 1000;
+          recordCollection('workload-image-scan', 'failed', durationSeconds);
+          collectionStatsTracker.recordFailure('workload-image-scan');
         }
       }
     );

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -20,6 +20,9 @@ import { logger } from './logging/logger.js';
 import { detectArgoCDWithTimeout, type ArgoCDDetectionConfig } from './argocd/detection.js';
 import { argocdStatusTracker } from './argocd/state.js';
 import { ArgoCDDetectionManager } from './argocd/detection-manager.js';
+import { detectTrivyWithTimeout, type TrivyDetectionConfig } from './trivy/detection.js';
+import { trivyStatusTracker } from './trivy/state.js';
+import { TrivyDetectionManager } from './trivy/detection-manager.js';
 import { SchemaManager } from './database/schema.js';
 import { KubernetesEventWatcher } from './events/kubernetes-event-watcher.js';
 import { EventQueueWorker } from './events/queue-worker.js';
@@ -29,6 +32,7 @@ import { registerEventWatcher } from './events/health.js';
 let statusWriterInstance: StatusWriter | null = null;
 let collectionSchedulerInstance: CollectionScheduler | null = null;
 let argoCDDetectionManagerInstance: ArgoCDDetectionManager | null = null;
+let trivyDetectionManagerInstance: TrivyDetectionManager | null = null;
 let eventWatcherInstance: KubernetesEventWatcher | null = null;
 let eventQueueWorkerInstance: EventQueueWorker | null = null;
 
@@ -87,6 +91,19 @@ function parseArgoCDConfig(): ArgoCDDetectionConfig {
   };
 }
 
+function parseTrivyConfig(): TrivyDetectionConfig {
+  const enabledEnv = process.env.TRIVY_ENABLED;
+  return {
+    autoDetect: process.env.TRIVY_AUTO_DETECT !== 'false',
+    enabled:
+      enabledEnv === 'true' ? true : enabledEnv === 'false' ? false : undefined,
+    serverUrl: process.env.TRIVY_SERVER_URL?.trim() || undefined,
+    healthPath: process.env.TRIVY_HEALTH_PATH || '/healthz',
+    detectionInterval: parseInt(process.env.TRIVY_DETECTION_INTERVAL || '6', 10),
+    detectionTimeoutMs: parseInt(process.env.TRIVY_DETECTION_TIMEOUT_MS || '10000', 10)
+  };
+}
+
 // Perform initial ArgoCD detection during startup
 async function performInitialArgoCDDetection(): Promise<void> {
   try {
@@ -110,6 +127,28 @@ async function performInitialArgoCDDetection(): Promise<void> {
     const errorMessage = error instanceof Error ? error.message : String(error);
     logger.warn('ArgoCD detection failed during startup', { error: errorMessage });
     // Continue with default status (not detected)
+  }
+}
+
+async function performInitialTrivyDetection(): Promise<void> {
+  try {
+    logger.info('Performing initial Trivy detection');
+    const trivyConfig = parseTrivyConfig();
+    const trivyStatus = await detectTrivyWithTimeout(trivyConfig);
+    trivyStatusTracker.setStatus(trivyStatus);
+
+    if (trivyStatus.detected) {
+      logger.info('Trivy detection completed', {
+        detected: true,
+        serverUrl: trivyStatus.serverUrl,
+        version: trivyStatus.version
+      });
+    } else {
+      logger.info('Trivy detection completed', { detected: false });
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.warn('Trivy detection failed during startup', { error: errorMessage });
   }
 }
 
@@ -158,6 +197,14 @@ export async function startOperator() {
     const argoCDDetectionManager = new ArgoCDDetectionManager();
     argoCDDetectionManager.start(kubernetesClient, argoCDConfig, initialArgoCDStatus);
     argoCDDetectionManagerInstance = argoCDDetectionManager;
+
+    await performInitialTrivyDetection();
+
+    const trivyConfig = parseTrivyConfig();
+    const initialTrivyStatus = trivyStatusTracker.getStatus();
+    const trivyDetectionManager = new TrivyDetectionManager();
+    trivyDetectionManager.start(trivyConfig, initialTrivyStatus);
+    trivyDetectionManagerInstance = trivyDetectionManager;
     
     // Start status writer for periodic ConfigMap updates
     logger.info('Starting status writer...');
@@ -313,6 +360,7 @@ export async function startOperator() {
           null,
           collectionSchedulerInstance,
           argoCDDetectionManagerInstance,
+          trivyDetectionManagerInstance,
           eventWatcherInstance,
           eventQueueWorkerInstance
         ).catch((error) => {
@@ -330,6 +378,7 @@ export async function startOperator() {
           null,
           collectionSchedulerInstance,
           argoCDDetectionManagerInstance,
+          trivyDetectionManagerInstance,
           eventWatcherInstance,
           eventQueueWorkerInstance
         ).catch((error) => {

--- a/src/registration/manager.test.ts
+++ b/src/registration/manager.test.ts
@@ -21,6 +21,7 @@ function createMockConfig(): Config {
     clusterMetadataIntervalSeconds: 86400,
     resourceInventoryIntervalSeconds: 21600,
     resourceConfigurationPatternsIntervalSeconds: 43200,
+    workloadImageScanIntervalSeconds: 86400,
     eventRetentionInfoWarningDays: 7,
     eventRetentionErrorCriticalDays: 30,
   };

--- a/src/shutdown/handler.ts
+++ b/src/shutdown/handler.ts
@@ -2,6 +2,7 @@ import type { StatusWriter } from '../status/writer.js';
 import type { RegistrationManager } from '../registration/manager.js';
 import type { CollectionScheduler } from '../collection/scheduler.js';
 import type { ArgoCDDetectionManager } from '../argocd/detection-manager.js';
+import type { TrivyDetectionManager } from '../trivy/detection-manager.js';
 import type { KubernetesEventWatcher } from '../events/kubernetes-event-watcher.js';
 import type { EventQueueWorker } from '../events/queue-worker.js';
 import { stopHealthServer } from '../health/server.js';
@@ -9,6 +10,7 @@ import type { OperatorStatus } from '../status/types.js';
 import { logger } from '../logging/logger.js';
 import { collectionStatsTracker } from '../collection/stats-tracker.js';
 import { argocdStatusTracker } from '../argocd/state.js';
+import { trivyStatusTracker } from '../trivy/state.js';
 
 /**
  * Operator version (semver)
@@ -40,6 +42,7 @@ let isShuttingDown = false;
  * @param registrationManager - Optional registration manager instance to stop
  * @param collectionScheduler - Optional collection scheduler instance to stop
  * @param argoCDDetectionManager - Optional ArgoCD detection manager instance to stop
+ * @param trivyDetectionManager - Optional Trivy detection manager instance to stop
  * @param eventWatcher - Optional event watcher instance to stop
  * @param eventQueueWorker - Optional event queue worker instance to stop
  */
@@ -48,6 +51,7 @@ export async function gracefulShutdown(
   registrationManager: RegistrationManager | null,
   collectionScheduler: CollectionScheduler | null,
   argoCDDetectionManager: ArgoCDDetectionManager | null,
+  trivyDetectionManager: TrivyDetectionManager | null,
   eventWatcher: KubernetesEventWatcher | null,
   eventQueueWorker: EventQueueWorker | null
 ): Promise<void> {
@@ -87,6 +91,10 @@ export async function gracefulShutdown(
       argoCDDetectionManager.stop();
     }
 
+    if (trivyDetectionManager) {
+      trivyDetectionManager.stop();
+    }
+
     // Stop status writer (clears interval)
     statusWriter.stop();
 
@@ -106,6 +114,7 @@ export async function gracefulShutdown(
     // Build final status indicating shutdown
     const collectionStats = collectionStatsTracker.getStats();
     const argocdStatus = argocdStatusTracker.getStatus();
+    const trivyStatus = trivyStatusTracker.getStatus();
     const finalStatus: OperatorStatus = {
       mode: "operated",
       tier: "free",
@@ -121,7 +130,8 @@ export async function gracefulShutdown(
         collectionsStoredCount: collectionStats.collectionsStoredCount,
         lastSuccessTime: collectionStats.lastSuccessTime
       },
-      argocd: argocdStatus
+      argocd: argocdStatus,
+      trivy: trivyStatus
     };
 
     // Include clusterId if registered

--- a/src/status/calculator.test.ts
+++ b/src/status/calculator.test.ts
@@ -38,6 +38,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -81,6 +82,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -104,6 +106,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -137,6 +140,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -159,6 +163,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -181,6 +186,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -226,6 +232,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -254,6 +261,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -281,6 +289,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -310,6 +319,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -347,6 +357,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -390,6 +401,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -438,6 +450,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');
@@ -466,6 +479,7 @@ describe('calculateStatus', () => {
         clusterMetadataIntervalSeconds: 86400,
         resourceInventoryIntervalSeconds: 21600,
         resourceConfigurationPatternsIntervalSeconds: 43200,
+        workloadImageScanIntervalSeconds: 86400,
       } as any);
 
       const calculatorModule = await import('./calculator.js');

--- a/src/status/calculator.test.ts
+++ b/src/status/calculator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import type { RegistrationState, CollectionStats, ArgoCDStatus } from './types.js';
+import type { RegistrationState, CollectionStats, ArgoCDStatus, TrivyStatus } from './types.js';
 
 describe('calculateStatus', () => {
   let originalPodNamespace: string | undefined;
@@ -64,6 +64,7 @@ describe('calculateStatus', () => {
       expect(status.lastUpdate).toBeDefined();
       expect(status.collectionStats).toBeDefined();
       expect(status.argocd).toBeDefined();
+      expect(status.trivy).toBeDefined();
     });
 
     it('should return operated mode regardless config inputs', async () => {
@@ -371,6 +372,54 @@ describe('calculateStatus', () => {
 
       expect(status.argocd).toEqual(argocdStatus);
       expect(status.namespace).toBe('kube9-system');
+    });
+  });
+
+  describe('trivy status', () => {
+    it('should include Trivy status in operator status', async () => {
+      delete process.env.POD_NAMESPACE;
+
+      vi.resetModules();
+      const configLoader = await import('../config/loader.js');
+      vi.spyOn(configLoader, 'getConfig').mockReturnValue({
+        apiKey: null,
+        serverUrl: 'https://api.kube9.dev',
+        logLevel: 'info',
+        statusUpdateIntervalSeconds: 60,
+        reregistrationIntervalHours: 24,
+        clusterMetadataIntervalSeconds: 86400,
+        resourceInventoryIntervalSeconds: 21600,
+        resourceConfigurationPatternsIntervalSeconds: 43200,
+      } as any);
+
+      const calculatorModule = await import('./calculator.js');
+      const trivyStatus: TrivyStatus = {
+        detected: true,
+        serverUrl: 'http://trivy:4954',
+        version: '0.58.0',
+        lastChecked: '2025-01-01T00:00:00Z',
+      };
+
+      const status = calculatorModule.calculateStatus(
+        { isRegistered: false, consecutiveFailures: 0 },
+        null,
+        true,
+        {
+          totalSuccessCount: 0,
+          totalFailureCount: 0,
+          collectionsStoredCount: 0,
+          lastSuccessTime: null,
+        },
+        {
+          detected: false,
+          namespace: null,
+          version: null,
+          lastChecked: '2025-01-01T00:00:00Z',
+        },
+        trivyStatus
+      );
+
+      expect(status.trivy).toEqual(trivyStatus);
     });
   });
 

--- a/src/status/calculator.ts
+++ b/src/status/calculator.ts
@@ -1,4 +1,10 @@
-import type { OperatorStatus, RegistrationState, CollectionStats, ArgoCDStatus } from './types.js';
+import type {
+  OperatorStatus,
+  RegistrationState,
+  CollectionStats,
+  ArgoCDStatus,
+  TrivyStatus,
+} from './types.js';
 
 /**
  * Operator version (semver)
@@ -37,6 +43,13 @@ const DEFAULT_ARGOCD_STATUS: ArgoCDStatus = {
   lastChecked: new Date().toISOString(),
 };
 
+const DEFAULT_TRIVY_STATUS: TrivyStatus = {
+  detected: false,
+  serverUrl: null,
+  version: null,
+  lastChecked: new Date().toISOString(),
+};
+
 /**
  * Calculate the current operator status based on configuration and system state
  * 
@@ -45,6 +58,7 @@ const DEFAULT_ARGOCD_STATUS: ArgoCDStatus = {
  * @param canWriteConfigMap - Whether the operator can write to ConfigMap (defaults to true)
  * @param collectionStats - Optional collection statistics (defaults to zero stats)
  * @param argocdStatus - Optional ArgoCD detection status (defaults to not detected)
+ * @param trivyStatus - Optional Trivy detection status (defaults to unavailable)
  * @returns OperatorStatus object with current operator state
  */
 export function calculateStatus(
@@ -57,7 +71,8 @@ export function calculateStatus(
     collectionsStoredCount: 0,
     lastSuccessTime: null
   },
-  argocdStatus: ArgoCDStatus = DEFAULT_ARGOCD_STATUS
+  argocdStatus: ArgoCDStatus = DEFAULT_ARGOCD_STATUS,
+  trivyStatus: TrivyStatus = DEFAULT_TRIVY_STATUS
 ): OperatorStatus {
   const { isRegistered, clusterId, consecutiveFailures = 0 } = registrationState;
   
@@ -112,7 +127,8 @@ export function calculateStatus(
       collectionsStoredCount: collectionStats.collectionsStoredCount,
       lastSuccessTime: collectionStats.lastSuccessTime
     },
-    argocd: argocdStatus
+    argocd: argocdStatus,
+    trivy: trivyStatus
   };
   
   // Include clusterId only when registered (pro tier)

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -55,6 +55,31 @@ export interface ArgoCDStatus {
 }
 
 /**
+ * Optional Trivy server detection (remote HTTP health probe)
+ */
+export interface TrivyStatus {
+  /**
+   * Whether a Trivy server was reached at the configured URL
+   */
+  detected: boolean;
+
+  /**
+   * Base URL of the Trivy server when detected
+   */
+  serverUrl: string | null;
+
+  /**
+   * Server version when available (e.g. from /version)
+   */
+  version: string | null;
+
+  /**
+   * ISO 8601 timestamp of last detection check
+   */
+  lastChecked: string;
+}
+
+/**
  * Operator Status Model
  * Represents the current state and health of the kube9 operator
  */
@@ -130,6 +155,11 @@ export interface OperatorStatus {
    * Tracks whether ArgoCD is installed in the cluster
    */
   argocd: ArgoCDStatus;
+
+  /**
+   * Optional Trivy server awareness (does not install or manage Trivy)
+   */
+  trivy: TrivyStatus;
 }
 
 /**

--- a/src/status/writer.ts
+++ b/src/status/writer.ts
@@ -6,6 +6,7 @@ import type { RegistrationManager } from '../registration/manager.js';
 import { logger } from '../logging/logger.js';
 import { collectionStatsTracker } from '../collection/stats-tracker.js';
 import { argocdStatusTracker } from '../argocd/state.js';
+import { trivyStatusTracker } from '../trivy/state.js';
 
 /**
  * Default registration state when registration manager is not available
@@ -195,13 +196,15 @@ export class StatusWriter {
       
       // Get current ArgoCD status
       const argocdStatus = argocdStatusTracker.getStatus();
+      const trivyStatus = trivyStatusTracker.getStatus();
       
       const status = calculateStatus(
         registrationState,
         this.lastWriteError,
         canWriteConfigMap,
         collectionStats,
-        argocdStatus
+        argocdStatus,
+        trivyStatus
       );
 
       // Convert status to JSON string

--- a/src/trivy/collect-workload-images.test.ts
+++ b/src/trivy/collect-workload-images.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { collectImagesFromListResponses } from './collect-workload-images.js';
+import type * as k8s from '@kubernetes/client-node';
+
+describe('collectImagesFromListResponses', () => {
+  it('dedupes across pods, deployments, and statefulsets', () => {
+    const pods: k8s.V1PodList = {
+      apiVersion: 'v1',
+      kind: 'PodList',
+      items: [
+        {
+          metadata: { name: 'p', namespace: 'ns' },
+          spec: {
+            containers: [{ name: 'c', image: 'shared:1' }],
+            initContainers: [{ name: 'i', image: 'init:1' }],
+          },
+        },
+      ],
+    };
+    const deployments: k8s.V1DeploymentList = {
+      apiVersion: 'apps/v1',
+      kind: 'DeploymentList',
+      items: [
+        {
+          metadata: { name: 'd', namespace: 'ns' },
+          spec: {
+            selector: { matchLabels: { app: 'd' } },
+            template: {
+              metadata: { labels: { app: 'd' } },
+              spec: {
+                containers: [{ name: 'c', image: 'shared:1' }],
+                initContainers: [{ name: 'i', image: 'init:1' }],
+              },
+            },
+          },
+        },
+      ],
+    };
+    const statefulSets: k8s.V1StatefulSetList = {
+      apiVersion: 'apps/v1',
+      kind: 'StatefulSetList',
+      items: [
+        {
+          metadata: { name: 's', namespace: 'ns' },
+          spec: {
+            selector: { matchLabels: { app: 's' } },
+            template: {
+              metadata: { labels: { app: 's' } },
+              spec: {
+                containers: [{ name: 'c', image: 'sts:1' }],
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    const { images, truncated } = collectImagesFromListResponses({
+      pods,
+      deployments,
+      statefulSets,
+    });
+    expect(truncated).toBe(false);
+    expect(images).toEqual(['init:1', 'shared:1', 'sts:1']);
+  });
+});

--- a/src/trivy/collect-workload-images.ts
+++ b/src/trivy/collect-workload-images.ts
@@ -1,0 +1,82 @@
+/**
+ * Lists Pods, Deployments, and StatefulSets and collects distinct normalized container image references.
+ * Uses existing read-only workload RBAC; does not invoke Trivy.
+ */
+
+import type * as k8s from '@kubernetes/client-node';
+import type { KubernetesClient } from '../kubernetes/client.js';
+import {
+  DEFAULT_MAX_UNIQUE_WORKLOAD_IMAGES,
+  addPodSpecImagesInto,
+} from './workload-images.js';
+
+export interface CollectWorkloadImagesResult {
+  /** Sorted unique normalized image references */
+  images: string[];
+  /** True if the unique cap was reached while still finding new references */
+  truncated: boolean;
+}
+
+/**
+ * Collect distinct container image references from all Pods, Deployments, and StatefulSets cluster-wide.
+ * ReplicaSets are not listed separately; their images are covered by Pods and Deployment templates.
+ */
+export async function collectWorkloadImageReferences(
+  client: KubernetesClient,
+  options?: { maxUniqueImages?: number }
+): Promise<CollectWorkloadImagesResult> {
+  const maxUnique = options?.maxUniqueImages ?? DEFAULT_MAX_UNIQUE_WORKLOAD_IMAGES;
+  const unique = new Set<string>();
+  let truncated = false;
+  const onTruncated = (): void => {
+    truncated = true;
+  };
+
+  const [podsRes, deploymentsRes, statefulSetsRes] = await Promise.all([
+    client.coreApi.listPodForAllNamespaces(),
+    client.appsApi.listDeploymentForAllNamespaces(),
+    client.appsApi.listStatefulSetForAllNamespaces(),
+  ]);
+
+  for (const pod of podsRes.items ?? []) {
+    addPodSpecImagesInto(unique, pod.spec, maxUnique, onTruncated);
+  }
+
+  for (const d of deploymentsRes.items ?? []) {
+    addPodSpecImagesInto(unique, d.spec?.template?.spec, maxUnique, onTruncated);
+  }
+
+  for (const s of statefulSetsRes.items ?? []) {
+    addPodSpecImagesInto(unique, s.spec?.template?.spec, maxUnique, onTruncated);
+  }
+
+  const images = Array.from(unique).sort((a, b) => a.localeCompare(b));
+  return { images, truncated };
+}
+
+/** @internal Exported for tests that build mock list responses */
+export function collectImagesFromListResponses(responses: {
+  pods: k8s.V1PodList;
+  deployments: k8s.V1DeploymentList;
+  statefulSets: k8s.V1StatefulSetList;
+}): CollectWorkloadImagesResult {
+  const maxUnique = DEFAULT_MAX_UNIQUE_WORKLOAD_IMAGES;
+  const unique = new Set<string>();
+  let truncated = false;
+  const onTruncated = (): void => {
+    truncated = true;
+  };
+
+  for (const pod of responses.pods.items ?? []) {
+    addPodSpecImagesInto(unique, pod.spec, maxUnique, onTruncated);
+  }
+  for (const d of responses.deployments.items ?? []) {
+    addPodSpecImagesInto(unique, d.spec?.template?.spec, maxUnique, onTruncated);
+  }
+  for (const s of responses.statefulSets.items ?? []) {
+    addPodSpecImagesInto(unique, s.spec?.template?.spec, maxUnique, onTruncated);
+  }
+
+  const images = Array.from(unique).sort((a, b) => a.localeCompare(b));
+  return { images, truncated };
+}

--- a/src/trivy/detection-manager.ts
+++ b/src/trivy/detection-manager.ts
@@ -1,0 +1,67 @@
+/**
+ * Periodic Trivy server re-detection (presence may change after startup).
+ */
+
+import { logger } from '../logging/logger.js';
+import { detectTrivyWithTimeout, type TrivyDetectionConfig } from './detection.js';
+import { trivyStatusTracker } from './state.js';
+import type { TrivyStatus } from '../status/types.js';
+
+export class TrivyDetectionManager {
+  private intervalHandle: NodeJS.Timeout | null = null;
+  private currentStatus!: TrivyStatus;
+
+  start(config: TrivyDetectionConfig, initialStatus: TrivyStatus): void {
+    this.currentStatus = initialStatus;
+    const intervalMs = config.detectionInterval * 60 * 60 * 1000;
+
+    this.intervalHandle = setInterval(() => {
+      this.performPeriodicCheck(config).catch((err) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.error('Periodic Trivy detection failed', { error: msg });
+      });
+    }, intervalMs);
+
+    logger.info('Trivy periodic detection started', {
+      intervalHours: config.detectionInterval,
+    });
+  }
+
+  stop(): void {
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+      logger.info('Trivy periodic detection stopped');
+    }
+  }
+
+  private async performPeriodicCheck(config: TrivyDetectionConfig): Promise<void> {
+    logger.debug('Performing periodic Trivy detection');
+    const newStatus = await detectTrivyWithTimeout(config);
+
+    if (this.hasStatusChanged(newStatus)) {
+      logger.info('Trivy status changed', {
+        previous: {
+          detected: this.currentStatus.detected,
+          serverUrl: this.currentStatus.serverUrl,
+        },
+        current: {
+          detected: newStatus.detected,
+          serverUrl: newStatus.serverUrl,
+        },
+      });
+      this.currentStatus = newStatus;
+      trivyStatusTracker.setStatus(newStatus);
+    } else {
+      logger.debug('Trivy status unchanged, skipping tracker update');
+    }
+  }
+
+  private hasStatusChanged(newStatus: TrivyStatus): boolean {
+    return (
+      this.currentStatus.detected !== newStatus.detected ||
+      this.currentStatus.serverUrl !== newStatus.serverUrl ||
+      this.currentStatus.version !== newStatus.version
+    );
+  }
+}

--- a/src/trivy/detection.test.ts
+++ b/src/trivy/detection.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { detectTrivy, probeTrivyHealth, type TrivyDetectionConfig } from './detection.js';
+
+const baseConfig = (): TrivyDetectionConfig => ({
+  autoDetect: true,
+  healthPath: '/healthz',
+  detectionInterval: 6,
+  detectionTimeoutMs: 5000,
+  serverUrl: 'http://127.0.0.1:4954',
+});
+
+describe('probeTrivyHealth', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('returns true when health endpoint responds OK', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+    });
+
+    const ok = await probeTrivyHealth('http://127.0.0.1:4954', '/healthz', 5000);
+    expect(ok).toBe(true);
+    expect(globalThis.fetch).toHaveBeenCalled();
+  });
+
+  it('returns false on non-OK HTTP status', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+    });
+
+    const ok = await probeTrivyHealth('http://127.0.0.1:4954', '/healthz', 5000);
+    expect(ok).toBe(false);
+  });
+});
+
+describe('detectTrivy', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('reports not detected when autoDetect is false', async () => {
+    const status = await detectTrivy({
+      ...baseConfig(),
+      autoDetect: false,
+    });
+    expect(status.detected).toBe(false);
+    expect(status.serverUrl).toBeNull();
+  });
+
+  it('reports not detected when server URL is missing', async () => {
+    const status = await detectTrivy({
+      ...baseConfig(),
+      serverUrl: undefined,
+    });
+    expect(status.detected).toBe(false);
+  });
+
+  it('reports detected when health probe succeeds', async () => {
+    globalThis.fetch = vi
+      .fn()
+      // health
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+      // /version optional
+      .mockResolvedValueOnce({ ok: false, status: 404 });
+
+    const status = await detectTrivy(baseConfig());
+    expect(status.detected).toBe(true);
+    expect(status.serverUrl).toBe('http://127.0.0.1:4954');
+  });
+
+  it('parses JSON version from /version when available', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ Version: '0.58.0' }),
+      });
+
+    const status = await detectTrivy(baseConfig());
+    expect(status.detected).toBe(true);
+    expect(status.version).toBe('0.58.0');
+  });
+});

--- a/src/trivy/detection.ts
+++ b/src/trivy/detection.ts
@@ -1,0 +1,172 @@
+/**
+ * Optional Trivy server detection via HTTP health endpoint (e.g. GET /healthz).
+ */
+
+import { logger } from '../logging/logger.js';
+import type { TrivyStatus } from '../status/types.js';
+
+export interface TrivyDetectionConfig {
+  autoDetect: boolean;
+  enabled?: boolean;
+  /** Base URL of the Trivy server (e.g. http://trivy.trivy-system.svc:4954) */
+  serverUrl?: string;
+  /** Path for HTTP health probe (default /healthz) */
+  healthPath: string;
+  /** Re-check interval in hours */
+  detectionInterval: number;
+  /** Per-request timeout for the health probe */
+  detectionTimeoutMs: number;
+}
+
+function emptyStatus(lastChecked: string): TrivyStatus {
+  return {
+    detected: false,
+    serverUrl: null,
+    version: null,
+    lastChecked,
+  };
+}
+
+function normalizeBaseUrl(url: string): string {
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return '';
+  }
+  return trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed;
+}
+
+/**
+ * Probe Trivy HTTP health endpoint. Trivy server exposes GET /healthz (200, body "ok") by default.
+ */
+export async function probeTrivyHealth(
+  baseUrl: string,
+  healthPath: string,
+  timeoutMs: number
+): Promise<boolean> {
+  const root = normalizeBaseUrl(baseUrl);
+  if (!root) {
+    return false;
+  }
+  const path = healthPath.startsWith('/') ? healthPath : `/${healthPath}`;
+  const target = new URL(path, `${root}/`);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(target, {
+      method: 'GET',
+      signal: controller.signal,
+      headers: { accept: 'text/plain, */*' },
+    });
+    if (!res.ok) {
+      logger.debug('Trivy health probe returned non-OK status', {
+        status: res.status,
+        url: target.href,
+      });
+      return false;
+    }
+    return true;
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    logger.debug('Trivy health probe failed', { url: target.href, error: msg });
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Optionally fetch Trivy version from GET /version when present (non-fatal if missing).
+ */
+async function tryFetchVersion(baseUrl: string, timeoutMs: number): Promise<string | null> {
+  const root = normalizeBaseUrl(baseUrl);
+  if (!root) {
+    return null;
+  }
+  const target = new URL('/version', `${root}/`);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(target, {
+      method: 'GET',
+      signal: controller.signal,
+      headers: { accept: 'application/json, text/plain, */*' },
+    });
+    if (!res.ok) {
+      return null;
+    }
+    const text = (await res.text()).trim();
+    if (!text) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(text) as { Version?: string; version?: string };
+      return parsed.Version ?? parsed.version ?? null;
+    } catch {
+      return text.length > 64 ? `${text.slice(0, 61)}...` : text;
+    }
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Detect whether a Trivy server is reachable at the configured URL.
+ */
+export async function detectTrivy(config: TrivyDetectionConfig): Promise<TrivyStatus> {
+  const now = new Date().toISOString();
+
+  if (config.enabled === false || config.autoDetect === false) {
+    logger.debug('Trivy detection disabled via configuration');
+    return emptyStatus(now);
+  }
+
+  const serverUrl = config.serverUrl?.trim();
+  if (!serverUrl) {
+    logger.debug('Trivy server URL not set; reporting unavailable');
+    return emptyStatus(now);
+  }
+
+  if (config.enabled === true) {
+    logger.debug('Trivy explicitly enabled, probing configured server URL');
+  }
+
+  const ok = await probeTrivyHealth(serverUrl, config.healthPath, config.detectionTimeoutMs);
+  if (!ok) {
+    logger.info('Trivy not detected or unreachable', { serverUrl });
+    return {
+      detected: false,
+      serverUrl: null,
+      version: null,
+      lastChecked: now,
+    };
+  }
+
+  const version = await tryFetchVersion(serverUrl, config.detectionTimeoutMs);
+  logger.info('Trivy server detected', { serverUrl, version });
+  return {
+    detected: true,
+    serverUrl: normalizeBaseUrl(serverUrl),
+    version,
+    lastChecked: now,
+  };
+}
+
+export async function detectTrivyWithTimeout(
+  config: TrivyDetectionConfig,
+  timeoutMs?: number
+): Promise<TrivyStatus> {
+  const outer =
+    timeoutMs ?? Math.max(30000, config.detectionTimeoutMs + 2000);
+
+  const timeoutPromise = new Promise<TrivyStatus>((resolve) => {
+    setTimeout(() => {
+      logger.warn('Trivy detection timed out', { timeoutMs: outer });
+      resolve(emptyStatus(new Date().toISOString()));
+    }, outer);
+  });
+
+  return Promise.race([detectTrivy(config), timeoutPromise]);
+}

--- a/src/trivy/env-config.test.ts
+++ b/src/trivy/env-config.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests for Trivy env parsing shared by operator and assess CLI.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { parseTrivyDetectionConfigFromEnv } from './env-config.js';
+
+describe('parseTrivyDetectionConfigFromEnv', () => {
+  const envKeys = [
+    'TRIVY_AUTO_DETECT',
+    'TRIVY_ENABLED',
+    'TRIVY_SERVER_URL',
+    'TRIVY_HEALTH_PATH',
+    'TRIVY_DETECTION_INTERVAL',
+    'TRIVY_DETECTION_TIMEOUT_MS',
+  ] as const;
+
+  beforeEach(() => {
+    for (const k of envKeys) {
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of envKeys) {
+      delete process.env[k];
+    }
+  });
+
+  it('uses defaults when env is unset', () => {
+    const c = parseTrivyDetectionConfigFromEnv();
+    expect(c.autoDetect).toBe(true);
+    expect(c.healthPath).toBe('/healthz');
+    expect(c.detectionInterval).toBe(6);
+    expect(c.detectionTimeoutMs).toBe(10000);
+    expect(c.serverUrl).toBeUndefined();
+    expect(c.enabled).toBeUndefined();
+  });
+
+  it('parses explicit server URL and disables autoDetect', () => {
+    process.env.TRIVY_SERVER_URL = ' http://trivy:4954 ';
+    process.env.TRIVY_AUTO_DETECT = 'false';
+    process.env.TRIVY_ENABLED = 'true';
+    const c = parseTrivyDetectionConfigFromEnv();
+    expect(c.serverUrl).toBe('http://trivy:4954');
+    expect(c.autoDetect).toBe(false);
+    expect(c.enabled).toBe(true);
+  });
+});

--- a/src/trivy/env-config.ts
+++ b/src/trivy/env-config.ts
@@ -1,0 +1,18 @@
+/**
+ * Parse Trivy HTTP detection settings from process.env (operator and CLI).
+ */
+
+import type { TrivyDetectionConfig } from './detection.js';
+
+export function parseTrivyDetectionConfigFromEnv(): TrivyDetectionConfig {
+  const enabledEnv = process.env.TRIVY_ENABLED;
+  return {
+    autoDetect: process.env.TRIVY_AUTO_DETECT !== 'false',
+    enabled:
+      enabledEnv === 'true' ? true : enabledEnv === 'false' ? false : undefined,
+    serverUrl: process.env.TRIVY_SERVER_URL?.trim() || undefined,
+    healthPath: process.env.TRIVY_HEALTH_PATH || '/healthz',
+    detectionInterval: parseInt(process.env.TRIVY_DETECTION_INTERVAL || '6', 10),
+    detectionTimeoutMs: parseInt(process.env.TRIVY_DETECTION_TIMEOUT_MS || '10000', 10),
+  };
+}

--- a/src/trivy/metrics.ts
+++ b/src/trivy/metrics.ts
@@ -1,0 +1,93 @@
+/**
+ * Prometheus metrics for vulnerability scanning (M3).
+ * Registered on the shared operator registry; safe when Trivy is absent (gauges stay at zero).
+ */
+
+import { Gauge, Histogram } from 'prom-client';
+import { register } from '../collection/metrics.js';
+import { ImageScanRepository } from '../database/image-scan-repository.js';
+import { logger } from '../logging/logger.js';
+
+const SEVERITY_LABELS = ['critical', 'high', 'medium', 'low', 'unknown', 'info', 'other'] as const;
+
+/**
+ * Current vulnerability row counts in SQLite, by normalized severity label.
+ */
+export const vulnerabilityFindingsBySeverity = new Gauge({
+  name: 'kube9_operator_vulnerability_findings',
+  help: 'Count of stored vulnerability rows in the local database by severity',
+  labelNames: ['severity'],
+  registers: [register],
+});
+
+/**
+ * Whether Trivy integration is active (1) or not (0).
+ */
+export const scanningActive = new Gauge({
+  name: 'kube9_operator_scanning_active',
+  help: '1 when Trivy server is detected and available, else 0',
+  registers: [register],
+});
+
+/**
+ * Duration of a single image scan attempt, or a skipped cycle segment.
+ * Labels: outcome = success | failed | skipped
+ */
+export const imageScanDurationSeconds = new Histogram({
+  name: 'kube9_operator_image_scan_duration_seconds',
+  help: 'Duration of Trivy image scan attempts in seconds',
+  labelNames: ['outcome'],
+  buckets: [0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120],
+  registers: [register],
+});
+
+function ensureSeverityLabel(sev: string): (typeof SEVERITY_LABELS)[number] {
+  const s = sev.toLowerCase();
+  if ((SEVERITY_LABELS as readonly string[]).includes(s)) {
+    return s as (typeof SEVERITY_LABELS)[number];
+  }
+  return 'other';
+}
+
+/**
+ * Refresh severity gauges from the database (completed scans only).
+ */
+export function refreshVulnerabilityMetrics(repo?: ImageScanRepository): void {
+  try {
+    const r = repo ?? new ImageScanRepository();
+    const grouped = r.countVulnerabilitiesGroupedBySeverity();
+    const totals: Record<string, number> = {};
+    for (const label of SEVERITY_LABELS) {
+      totals[label] = 0;
+    }
+    for (const [sev, count] of Object.entries(grouped)) {
+      const lab = ensureSeverityLabel(sev);
+      totals[lab] = (totals[lab] ?? 0) + count;
+    }
+    for (const label of SEVERITY_LABELS) {
+      vulnerabilityFindingsBySeverity.set({ severity: label }, totals[label] ?? 0);
+    }
+  } catch (err) {
+    logger.warn('Failed to refresh vulnerability metrics from database', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+export function setScanningActiveGauge(active: boolean): void {
+  scanningActive.set(active ? 1 : 0);
+}
+
+export function recordImageScanDurationSeconds(
+  outcome: 'success' | 'failed' | 'skipped',
+  seconds: number
+): void {
+  try {
+    imageScanDurationSeconds.observe({ outcome }, seconds);
+  } catch (err) {
+    logger.warn('Failed to record image scan duration metric', {
+      outcome,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/src/trivy/persist-scan-result.test.ts
+++ b/src/trivy/persist-scan-result.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { vulnerabilitiesFromTrivyReport } from './persist-scan-result.js';
+
+describe('vulnerabilitiesFromTrivyReport', () => {
+  it('extracts rows from Trivy JSON', () => {
+    const report = {
+      Results: [
+        {
+          Vulnerabilities: [
+            {
+              VulnerabilityID: 'CVE-2024-1',
+              Severity: 'HIGH',
+              PkgName: 'openssl',
+              InstalledVersion: '1.0',
+              FixedVersion: '1.1',
+              Title: 'test',
+            },
+          ],
+        },
+      ],
+    };
+    const rows = vulnerabilitiesFromTrivyReport('scan-a', report);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.vulnerability_id).toBe('CVE-2024-1');
+    expect(rows[0]?.severity).toBe('high');
+    expect(rows[0]?.scan_id).toBe('scan-a');
+  });
+
+  it('returns empty for empty results', () => {
+    expect(vulnerabilitiesFromTrivyReport('s', {})).toEqual([]);
+  });
+});

--- a/src/trivy/persist-scan-result.ts
+++ b/src/trivy/persist-scan-result.ts
@@ -1,0 +1,118 @@
+/**
+ * Persist Trivy JSON report rows into image_scans / image_vulnerabilities.
+ */
+
+import { randomUUID } from 'crypto';
+import type { TrivyImageReport } from './scanner.js';
+import { ImageScanRepository } from '../database/image-scan-repository.js';
+import type { ImageVulnerabilityInput } from '../database/image-scan-contracts.js';
+
+export interface PersistTrivyReportOptions {
+  imageRef: string;
+  report: TrivyImageReport;
+  repo?: ImageScanRepository;
+  /** Defaults to a new UUID */
+  scanId?: string;
+  startedAt?: string;
+  completedAt?: string;
+}
+
+function normalizeSeverity(raw: string | undefined): string {
+  if (!raw || raw.trim() === '') {
+    return 'unknown';
+  }
+  return raw.trim().toLowerCase();
+}
+
+/**
+ * Walk Trivy JSON Results[].Vulnerabilities and build normalized rows.
+ */
+export function vulnerabilitiesFromTrivyReport(
+  scanId: string,
+  report: TrivyImageReport
+): ImageVulnerabilityInput[] {
+  const results = Array.isArray(report.Results) ? report.Results : [];
+  const rows: ImageVulnerabilityInput[] = [];
+  let idx = 0;
+
+  for (const block of results) {
+    if (!block || typeof block !== 'object') {
+      continue;
+    }
+    const vulns = (block as { Vulnerabilities?: unknown }).Vulnerabilities;
+    if (!Array.isArray(vulns)) {
+      continue;
+    }
+    for (const v of vulns) {
+      if (!v || typeof v !== 'object') {
+        continue;
+      }
+      const o = v as Record<string, unknown>;
+      const vid = String(o.VulnerabilityID ?? o.vulnerability_id ?? o.VulnerabilityId ?? '');
+      if (!vid) {
+        continue;
+      }
+      const severity = normalizeSeverity(
+        typeof o.Severity === 'string' ? o.Severity : typeof o.severity === 'string' ? o.severity : undefined
+      );
+      const pkg =
+        typeof o.PkgName === 'string'
+          ? o.PkgName
+          : typeof o.pkg_name === 'string'
+            ? o.pkg_name
+            : null;
+      const installed =
+        typeof o.InstalledVersion === 'string'
+          ? o.InstalledVersion
+          : typeof o.installed_version === 'string'
+            ? o.installed_version
+            : null;
+      const fixed =
+        typeof o.FixedVersion === 'string'
+          ? o.FixedVersion
+          : typeof o.fixed_version === 'string'
+            ? o.fixed_version
+            : null;
+      const title = typeof o.Title === 'string' ? o.Title : typeof o.title === 'string' ? o.title : null;
+      idx += 1;
+      rows.push({
+        id: `${scanId}-v-${idx}-${vid}`,
+        scan_id: scanId,
+        vulnerability_id: vid,
+        severity,
+        package_name: pkg,
+        installed_version: installed,
+        fixed_version: fixed,
+        title,
+        raw_metadata: JSON.stringify(o),
+      });
+    }
+  }
+
+  return rows;
+}
+
+/**
+ * Upsert a completed scan and replace vulnerability rows for that scan.
+ */
+export function persistTrivyReportToDatabase(options: PersistTrivyReportOptions): string {
+  const repo = options.repo ?? new ImageScanRepository();
+  const scanId = options.scanId ?? randomUUID();
+  const now = options.completedAt ?? new Date().toISOString();
+  const startedAt = options.startedAt ?? now;
+
+  repo.upsertScan({
+    scan_id: scanId,
+    image_reference: options.imageRef,
+    image_digest: null,
+    started_at: startedAt,
+    completed_at: now,
+    state: 'completed',
+    scanner: 'trivy',
+    error_message: null,
+  });
+
+  const rows = vulnerabilitiesFromTrivyReport(scanId, options.report);
+  repo.replaceVulnerabilitiesForScan(scanId, rows);
+  return scanId;
+}

--- a/src/trivy/scanner.test.ts
+++ b/src/trivy/scanner.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { spawn as nodeSpawn } from 'node:child_process';
+import {
+  scanContainerImage,
+  TrivyScanFailure,
+} from './scanner.js';
+
+function fakeSpawnSuccess(json: object): typeof nodeSpawn {
+  return ((() => {
+    const proc = new EventEmitter();
+    const stdout = new EventEmitter();
+    const stderr = new EventEmitter();
+    (proc as any).stdout = stdout;
+    (proc as any).stderr = stderr;
+    (proc as any).kill = vi.fn();
+
+    queueMicrotask(() => {
+      stdout.emit('data', Buffer.from(JSON.stringify(json)));
+      proc.emit('close', 0);
+    });
+
+    return proc as any;
+  }) as unknown) as typeof nodeSpawn;
+}
+
+describe('scanContainerImage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('parses JSON report from trivy CLI stdout', async () => {
+    const report = await scanContainerImage('alpine:3', {
+      serverUrl: 'http://127.0.0.1:4954',
+      cliPath: 'trivy',
+      scanTimeoutMs: 5000,
+      maxAttempts: 1,
+      spawnImpl: fakeSpawnSuccess({ SchemaVersion: 2, ArtifactName: 'alpine:3' }),
+    });
+
+    expect(report.SchemaVersion).toBe(2);
+    expect(report.ArtifactName).toBe('alpine:3');
+  });
+
+  it('throws TrivyScanFailure on non-zero exit', async () => {
+    const spawnImpl = ((() => {
+      const proc = new EventEmitter();
+      const stdout = new EventEmitter();
+      const stderr = new EventEmitter();
+      (proc as any).stdout = stdout;
+      (proc as any).stderr = stderr;
+      (proc as any).kill = vi.fn();
+
+      queueMicrotask(() => {
+        stderr.emit('data', Buffer.from('scan failed'));
+        proc.emit('close', 1);
+      });
+
+      return proc as any;
+    }) as unknown) as typeof nodeSpawn;
+
+    await expect(
+      scanContainerImage('bad:image', {
+        serverUrl: 'http://127.0.0.1:4954',
+        maxAttempts: 1,
+        spawnImpl,
+      })
+    ).rejects.toMatchObject({
+      code: 'TRIVY_CLI_FAILED',
+    });
+  });
+
+  it('maps invalid JSON to TRIVY_SCAN_PARSE', async () => {
+    const spawnImpl = ((() => {
+      const proc = new EventEmitter();
+      const stdout = new EventEmitter();
+      const stderr = new EventEmitter();
+      (proc as any).stdout = stdout;
+      (proc as any).stderr = stderr;
+      (proc as any).kill = vi.fn();
+
+      queueMicrotask(() => {
+        stdout.emit('data', Buffer.from('not-json'));
+        proc.emit('close', 0);
+      });
+
+      return proc as any;
+    }) as unknown) as typeof nodeSpawn;
+
+    try {
+      await scanContainerImage('alpine:3', {
+        serverUrl: 'http://127.0.0.1:4954',
+        maxAttempts: 1,
+        spawnImpl,
+      });
+      expect.fail('expected throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(TrivyScanFailure);
+      expect((e as TrivyScanFailure).code).toBe('TRIVY_SCAN_PARSE');
+    }
+  });
+});

--- a/src/trivy/scanner.ts
+++ b/src/trivy/scanner.ts
@@ -1,0 +1,193 @@
+/**
+ * Trivy image scanner using the documented CLI client/server path:
+ * `trivy image --server <url> --format json <imageRef>`
+ */
+
+import { spawn } from 'node:child_process';
+import { logger } from '../logging/logger.js';
+import { trivyStatusTracker } from './state.js';
+import type { TrivyStatus } from '../status/types.js';
+
+/** Minimal shape of `trivy image -f json` output */
+export interface TrivyImageReport {
+  SchemaVersion?: number;
+  ArtifactName?: string;
+  Results?: unknown[];
+  [key: string]: unknown;
+}
+
+export type TrivyScanFailureCode =
+  | 'TRIVY_NOT_DETECTED'
+  | 'TRIVY_CLI_FAILED'
+  | 'TRIVY_SCAN_TIMEOUT'
+  | 'TRIVY_SCAN_PARSE';
+
+export class TrivyScanFailure extends Error {
+  readonly code: TrivyScanFailureCode;
+  readonly exitCode: number | null;
+
+  constructor(
+    code: TrivyScanFailureCode,
+    message: string,
+    options?: { exitCode?: number | null; cause?: unknown }
+  ) {
+    super(message, options?.cause ? { cause: options.cause } : undefined);
+    this.name = 'TrivyScanFailure';
+    this.code = code;
+    this.exitCode = options?.exitCode ?? null;
+  }
+}
+
+export interface TrivyScannerOptions {
+  /** Remote Trivy server URL (must match detection) */
+  serverUrl: string;
+  /** Path to trivy binary (default: trivy) */
+  cliPath?: string;
+  /** Total timeout for a single scan attempt */
+  scanTimeoutMs?: number;
+  /** Retries on spawn/timeout failures (not on non-zero exit with output) */
+  maxAttempts?: number;
+  /** Override `child_process.spawn` (for tests) */
+  spawnImpl?: typeof spawn;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function runTrivyOnce(
+  imageRef: string,
+  serverUrl: string,
+  cliPath: string,
+  timeoutMs: number,
+  spawnImpl: TrivyScannerOptions['spawnImpl']
+): Promise<string> {
+  const spawnFn = spawnImpl ?? spawn;
+  return new Promise((resolve, reject) => {
+    const proc = spawnFn(
+      cliPath,
+      ['image', '--server', serverUrl, '--format', 'json', '--quiet', imageRef],
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env },
+      }
+    );
+
+    let stdout = '';
+    let stderr = '';
+
+    const timer = setTimeout(() => {
+      proc.kill('SIGKILL');
+      reject(new TrivyScanFailure('TRIVY_SCAN_TIMEOUT', `Trivy scan timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    proc.stdout?.on('data', (d: Buffer) => {
+      stdout += d.toString();
+    });
+    proc.stderr?.on('data', (d: Buffer) => {
+      stderr += d.toString();
+    });
+
+    proc.on('error', (err) => {
+      clearTimeout(timer);
+      reject(
+        new TrivyScanFailure('TRIVY_CLI_FAILED', `Failed to spawn Trivy CLI: ${err.message}`, {
+          cause: err,
+        })
+      );
+    });
+
+    proc.on('close', (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(
+          new TrivyScanFailure(
+            'TRIVY_CLI_FAILED',
+            stderr.trim() || `trivy exited with code ${code}`,
+            { exitCode: code }
+          )
+        );
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+/**
+ * Scan a container image reference using the Trivy CLI against a remote server.
+ * Does not run unless the caller provides a server URL (typically after detection).
+ */
+export async function scanContainerImage(
+  imageRef: string,
+  options: TrivyScannerOptions
+): Promise<TrivyImageReport> {
+  const cliPath = options.cliPath ?? process.env.TRIVY_CLI_PATH ?? 'trivy';
+  const scanTimeoutMs = options.scanTimeoutMs ?? parseInt(process.env.TRIVY_SCAN_TIMEOUT_MS || '600000', 10);
+  const maxAttempts = options.maxAttempts ?? 3;
+  const spawnImpl = options.spawnImpl;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const raw = await runTrivyOnce(
+        imageRef,
+        options.serverUrl,
+        cliPath,
+        scanTimeoutMs,
+        spawnImpl
+      );
+      try {
+        return JSON.parse(raw) as TrivyImageReport;
+      } catch (err) {
+        throw new TrivyScanFailure('TRIVY_SCAN_PARSE', 'Failed to parse Trivy JSON output', {
+          cause: err,
+        });
+      }
+    } catch (err) {
+      lastError = err;
+      const retryable = err instanceof TrivyScanFailure && err.code === 'TRIVY_SCAN_TIMEOUT';
+
+      if (!retryable || attempt === maxAttempts) {
+        throw err;
+      }
+      const backoffMs = 1000 * 2 ** (attempt - 1);
+      logger.warn('Trivy scan attempt failed, retrying', {
+        attempt,
+        maxAttempts,
+        backoffMs,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      await sleep(backoffMs);
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new TrivyScanFailure('TRIVY_CLI_FAILED', String(lastError));
+}
+
+/**
+ * Runs a container image scan only when the tracker reports a detected Trivy server.
+ */
+export async function scanContainerImageWhenDetected(
+  imageRef: string,
+  options: Omit<TrivyScannerOptions, 'serverUrl'> & {
+    getStatus?: () => TrivyStatus;
+  }
+): Promise<TrivyImageReport> {
+  const status = options.getStatus?.() ?? trivyStatusTracker.getStatus();
+  if (!status.detected || !status.serverUrl) {
+    throw new TrivyScanFailure(
+      'TRIVY_NOT_DETECTED',
+      'Trivy server is not detected or unavailable; skipping scan'
+    );
+  }
+  return scanContainerImage(imageRef, {
+    cliPath: options.cliPath,
+    scanTimeoutMs: options.scanTimeoutMs,
+    maxAttempts: options.maxAttempts,
+    spawnImpl: options.spawnImpl,
+    serverUrl: status.serverUrl,
+  });
+}

--- a/src/trivy/state.ts
+++ b/src/trivy/state.ts
@@ -1,0 +1,30 @@
+/**
+ * In-memory Trivy detection status for operator status ConfigMap.
+ */
+
+import type { TrivyStatus } from '../status/types.js';
+
+const DEFAULT_TRIVY_STATUS: TrivyStatus = {
+  detected: false,
+  serverUrl: null,
+  version: null,
+  lastChecked: new Date().toISOString(),
+};
+
+export class TrivyStatusTracker {
+  private status: TrivyStatus = { ...DEFAULT_TRIVY_STATUS };
+
+  getStatus(): TrivyStatus {
+    return { ...this.status };
+  }
+
+  setStatus(status: TrivyStatus): void {
+    this.status = { ...status };
+  }
+
+  reset(): void {
+    this.status = { ...DEFAULT_TRIVY_STATUS };
+  }
+}
+
+export const trivyStatusTracker = new TrivyStatusTracker();

--- a/src/trivy/workload-images.test.ts
+++ b/src/trivy/workload-images.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeContainerImageRef,
+  extractImagesFromPodSpec,
+} from './workload-images.js';
+import type * as k8s from '@kubernetes/client-node';
+
+describe('normalizeContainerImageRef', () => {
+  it('trims whitespace and rejects empty', () => {
+    expect(normalizeContainerImageRef('  alpine:3.20  ')).toBe('alpine:3.20');
+    expect(normalizeContainerImageRef('')).toBeNull();
+    expect(normalizeContainerImageRef('   ')).toBeNull();
+  });
+
+  it('preserves digest and tag forms as reported by Kubernetes', () => {
+    expect(normalizeContainerImageRef('repo.io/ns/app:v1@sha256:abc')).toBe(
+      'repo.io/ns/app:v1@sha256:abc'
+    );
+    expect(normalizeContainerImageRef('busybox:latest')).toBe('busybox:latest');
+  });
+});
+
+describe('extractImagesFromPodSpec', () => {
+  it('collects containers, initContainers, and ephemeralContainers', () => {
+    const spec: k8s.V1PodSpec = {
+      containers: [{ name: 'a', image: 'img:a' }],
+      initContainers: [{ name: 'i', image: 'img:b' }],
+      ephemeralContainers: [{ name: 'e', image: 'img:a' }],
+    };
+    const { images, truncated } = extractImagesFromPodSpec(spec);
+    expect(truncated).toBe(false);
+    expect(images).toEqual(['img:a', 'img:b']);
+  });
+
+  it('dedupes within the spec and sorts', () => {
+    const spec: k8s.V1PodSpec = {
+      containers: [
+        { name: 'x', image: 'z:1' },
+        { name: 'y', image: 'a:1' },
+      ],
+    };
+    expect(extractImagesFromPodSpec(spec).images).toEqual(['a:1', 'z:1']);
+  });
+
+  it('respects maxUnique for a single spec', () => {
+    const spec: k8s.V1PodSpec = {
+      containers: [
+        { name: 'a', image: 'one:1' },
+        { name: 'b', image: 'two:2' },
+        { name: 'c', image: 'three:3' },
+      ],
+    };
+    const { images, truncated } = extractImagesFromPodSpec(spec, { maxUnique: 2 });
+    expect(truncated).toBe(true);
+    expect(images.length).toBeLessThanOrEqual(2);
+  });
+});

--- a/src/trivy/workload-images.ts
+++ b/src/trivy/workload-images.ts
@@ -1,0 +1,99 @@
+/**
+ * Container image references from workload API objects (Pods, Deployments, StatefulSets).
+ *
+ * Normalization for Trivy scanner input:
+ * - Leading and trailing whitespace is stripped; empty values are ignored.
+ * - References are passed through as Kubernetes reports them (tag and/or digest).
+ * - When a digest is present (`repo@sha256:...` or `:tag@sha256:...`), that immutable
+ *   form is preferred for scanning; tag-only refs are unchanged.
+ *
+ * This module does not call Trivy or any scanner; it only shapes strings from the API.
+ */
+
+import type * as k8s from '@kubernetes/client-node';
+
+/** Default cap on distinct normalized references collected per pass (deterministic truncation). */
+export const DEFAULT_MAX_UNIQUE_WORKLOAD_IMAGES = 10_000;
+
+/**
+ * Normalize a raw container image field from the API for deduplication and scanner input.
+ */
+export function normalizeContainerImageRef(raw: string): string | null {
+  const s = raw.trim();
+  if (!s.length) {
+    return null;
+  }
+  return s;
+}
+
+function addImagesFromContainers(
+  containers: k8s.V1Container[] | undefined,
+  into: Set<string>,
+  maxUnique: number,
+  onTruncated: () => void
+): void {
+  if (!containers?.length) {
+    return;
+  }
+  for (const c of containers) {
+    tryAddNormalized(into, c.image, maxUnique, onTruncated);
+  }
+}
+
+function tryAddNormalized(
+  into: Set<string>,
+  raw: string | undefined,
+  maxUnique: number,
+  onTruncated: () => void
+): void {
+  const n = normalizeContainerImageRef(raw ?? '');
+  if (!n) {
+    return;
+  }
+  if (into.has(n)) {
+    return;
+  }
+  if (into.size >= maxUnique) {
+    onTruncated();
+    return;
+  }
+  into.add(n);
+}
+
+/**
+ * Add all image references from a Pod spec into a shared set (for cross-resource collection with one cap).
+ */
+export function addPodSpecImagesInto(
+  into: Set<string>,
+  spec: k8s.V1PodSpec | undefined,
+  maxUnique: number,
+  onTruncated: () => void
+): void {
+  addImagesFromContainers(spec?.containers, into, maxUnique, onTruncated);
+  addImagesFromContainers(spec?.initContainers, into, maxUnique, onTruncated);
+  if (spec?.ephemeralContainers?.length) {
+    for (const ec of spec.ephemeralContainers) {
+      tryAddNormalized(into, ec.image, maxUnique, onTruncated);
+    }
+  }
+}
+
+/**
+ * Extract normalized image references from a Pod spec (containers, init, ephemeral).
+ */
+export function extractImagesFromPodSpec(
+  spec: k8s.V1PodSpec | undefined,
+  options?: { maxUnique?: number }
+): { images: string[]; truncated: boolean } {
+  const maxUnique = options?.maxUnique ?? DEFAULT_MAX_UNIQUE_WORKLOAD_IMAGES;
+  const into = new Set<string>();
+  let truncated = false;
+  const onTruncated = (): void => {
+    truncated = true;
+  };
+
+  addPodSpecImagesInto(into, spec, maxUnique, onTruncated);
+
+  const images = Array.from(into).sort((a, b) => a.localeCompare(b));
+  return { images, truncated };
+}

--- a/src/trivy/workload-scan-cycle.test.ts
+++ b/src/trivy/workload-scan-cycle.test.ts
@@ -30,7 +30,11 @@ describe('runWorkloadImageScanCycle', () => {
       lastChecked: new Date().toISOString(),
     });
 
-    const r = await runWorkloadImageScanCycle({ kubernetesClient: client, getTrivyStatus });
+    const r = await runWorkloadImageScanCycle({
+      kubernetesClient: client,
+      getTrivyStatus,
+      persistTrivyReport: () => 'noop',
+    });
     expect(r.scansSkippedDueToTrivy).toBe(true);
     expect(r.uniqueImagesCollected).toBe(1);
     expect(scanSpy).not.toHaveBeenCalled();
@@ -54,6 +58,7 @@ describe('runWorkloadImageScanCycle', () => {
       kubernetesClient: client,
       getTrivyStatus,
       maxScansPerCycle: 10,
+      persistTrivyReport: () => 'noop',
     });
 
     expect(r.scansSkippedDueToTrivy).toBe(false);
@@ -84,6 +89,7 @@ describe('runWorkloadImageScanCycle', () => {
       kubernetesClient: client,
       getTrivyStatus,
       maxScansPerCycle: 10,
+      persistTrivyReport: () => 'noop',
     });
 
     expect(r.scansFailed).toBe(1);

--- a/src/trivy/workload-scan-cycle.test.ts
+++ b/src/trivy/workload-scan-cycle.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { runWorkloadImageScanCycle } from './workload-scan-cycle.js';
+import type { KubernetesClient } from '../kubernetes/client.js';
+import type { TrivyStatus } from '../status/types.js';
+import * as collectMod from './collect-workload-images.js';
+import * as scannerMod from './scanner.js';
+
+describe('runWorkloadImageScanCycle', () => {
+  const client = {} as KubernetesClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.TRIVY_MAX_SCANS_PER_CYCLE;
+  });
+
+  it('collects but skips scans when Trivy is not detected', async () => {
+    vi.spyOn(collectMod, 'collectWorkloadImageReferences').mockResolvedValue({
+      images: ['a:1'],
+      truncated: false,
+    });
+    const scanSpy = vi.spyOn(scannerMod, 'scanContainerImageWhenDetected');
+
+    const getTrivyStatus = (): TrivyStatus => ({
+      detected: false,
+      serverUrl: null,
+      version: null,
+      lastChecked: new Date().toISOString(),
+    });
+
+    const r = await runWorkloadImageScanCycle({ kubernetesClient: client, getTrivyStatus });
+    expect(r.scansSkippedDueToTrivy).toBe(true);
+    expect(r.uniqueImagesCollected).toBe(1);
+    expect(scanSpy).not.toHaveBeenCalled();
+  });
+
+  it('collects and scans when Trivy is detected', async () => {
+    vi.spyOn(collectMod, 'collectWorkloadImageReferences').mockResolvedValue({
+      images: ['alpine:3', 'busybox:1'],
+      truncated: false,
+    });
+    const scanSpy = vi.spyOn(scannerMod, 'scanContainerImageWhenDetected').mockResolvedValue({});
+
+    const getTrivyStatus = (): TrivyStatus => ({
+      detected: true,
+      serverUrl: 'http://trivy:4954',
+      version: '1',
+      lastChecked: new Date().toISOString(),
+    });
+
+    const r = await runWorkloadImageScanCycle({
+      kubernetesClient: client,
+      getTrivyStatus,
+      maxScansPerCycle: 10,
+    });
+
+    expect(r.scansSkippedDueToTrivy).toBe(false);
+    expect(r.uniqueImagesCollected).toBe(2);
+    expect(r.scansAttempted).toBe(2);
+    expect(r.scansSucceeded).toBe(2);
+    expect(scanSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('continues after a failed scan', async () => {
+    vi.spyOn(collectMod, 'collectWorkloadImageReferences').mockResolvedValue({
+      images: ['a:1', 'b:2'],
+      truncated: false,
+    });
+    const scanSpy = vi
+      .spyOn(scannerMod, 'scanContainerImageWhenDetected')
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce({});
+
+    const getTrivyStatus = (): TrivyStatus => ({
+      detected: true,
+      serverUrl: 'http://trivy:4954',
+      version: '1',
+      lastChecked: new Date().toISOString(),
+    });
+
+    const r = await runWorkloadImageScanCycle({
+      kubernetesClient: client,
+      getTrivyStatus,
+      maxScansPerCycle: 10,
+    });
+
+    expect(r.scansFailed).toBe(1);
+    expect(r.scansSucceeded).toBe(1);
+    expect(scanSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/trivy/workload-scan-cycle.ts
+++ b/src/trivy/workload-scan-cycle.ts
@@ -9,6 +9,12 @@ import { logger } from '../logging/logger.js';
 import { collectWorkloadImageReferences } from './collect-workload-images.js';
 import { scanContainerImageWhenDetected } from './scanner.js';
 import { DEFAULT_MAX_UNIQUE_WORKLOAD_IMAGES } from './workload-images.js';
+import { persistTrivyReportToDatabase, type PersistTrivyReportOptions } from './persist-scan-result.js';
+import {
+  recordImageScanDurationSeconds,
+  refreshVulnerabilityMetrics,
+  setScanningActiveGauge,
+} from './metrics.js';
 
 export interface WorkloadScanCycleOptions {
   kubernetesClient: KubernetesClient;
@@ -17,6 +23,8 @@ export interface WorkloadScanCycleOptions {
   maxUniqueImages?: number;
   /** Max scans to run per cycle (default: 100) */
   maxScansPerCycle?: number;
+  /** Override persistence (e.g. unit tests). Defaults to persistTrivyReportToDatabase. */
+  persistTrivyReport?: (options: PersistTrivyReportOptions) => string;
 }
 
 export interface WorkloadScanCycleResult {
@@ -45,15 +53,22 @@ function parseMaxScansPerCycle(): number {
 export async function runWorkloadImageScanCycle(
   options: WorkloadScanCycleOptions
 ): Promise<WorkloadScanCycleResult> {
+  const cycleStartMs = Date.now();
   const maxUnique = options.maxUniqueImages ?? DEFAULT_MAX_UNIQUE_WORKLOAD_IMAGES;
   const maxScans = options.maxScansPerCycle ?? parseMaxScansPerCycle();
+  const persist = options.persistTrivyReport ?? persistTrivyReportToDatabase;
 
   const { images, truncated } = await collectWorkloadImageReferences(options.kubernetesClient, {
     maxUniqueImages: maxUnique,
   });
 
   const status = options.getTrivyStatus();
+  setScanningActiveGauge(Boolean(status.detected && status.serverUrl));
+
   if (!status.detected || !status.serverUrl) {
+    const cycleSeconds = (Date.now() - cycleStartMs) / 1000;
+    recordImageScanDurationSeconds('skipped', cycleSeconds);
+    refreshVulnerabilityMetrics();
     logger.info('Workload images collected; skipping Trivy scans (integration not active)', {
       uniqueImagesCollected: images.length,
       truncated,
@@ -80,19 +95,25 @@ export async function runWorkloadImageScanCycle(
   let scansFailed = 0;
 
   for (const imageRef of toScan) {
+    const scanStart = Date.now();
     try {
-      await scanContainerImageWhenDetected(imageRef, {
+      const report = await scanContainerImageWhenDetected(imageRef, {
         getStatus: options.getTrivyStatus,
       });
+      persist({ imageRef, report });
       scansSucceeded++;
+      recordImageScanDurationSeconds('success', (Date.now() - scanStart) / 1000);
     } catch (err) {
       scansFailed++;
+      recordImageScanDurationSeconds('failed', (Date.now() - scanStart) / 1000);
       logger.warn('Trivy scan failed for workload image', {
         imageRef,
         error: err instanceof Error ? err.message : String(err),
       });
     }
   }
+
+  refreshVulnerabilityMetrics();
 
   if (truncated) {
     logger.warn('Workload image collection hit unique image cap', {

--- a/src/trivy/workload-scan-cycle.ts
+++ b/src/trivy/workload-scan-cycle.ts
@@ -1,0 +1,119 @@
+/**
+ * One pass: collect workload image references from the API, then optionally
+ * run Trivy scans for each reference when Trivy integration is active.
+ */
+
+import type { KubernetesClient } from '../kubernetes/client.js';
+import type { TrivyStatus } from '../status/types.js';
+import { logger } from '../logging/logger.js';
+import { collectWorkloadImageReferences } from './collect-workload-images.js';
+import { scanContainerImageWhenDetected } from './scanner.js';
+import { DEFAULT_MAX_UNIQUE_WORKLOAD_IMAGES } from './workload-images.js';
+
+export interface WorkloadScanCycleOptions {
+  kubernetesClient: KubernetesClient;
+  getTrivyStatus: () => TrivyStatus;
+  /** Max distinct normalized refs to collect (default: 10_000) */
+  maxUniqueImages?: number;
+  /** Max scans to run per cycle (default: 100) */
+  maxScansPerCycle?: number;
+}
+
+export interface WorkloadScanCycleResult {
+  /** True when Trivy was not active, so no scans were run (collection may still have run) */
+  scansSkippedDueToTrivy: boolean;
+  uniqueImagesCollected: number;
+  truncated: boolean;
+  scansAttempted: number;
+  scansSucceeded: number;
+  scansFailed: number;
+}
+
+function parseMaxScansPerCycle(): number {
+  const raw = process.env.TRIVY_MAX_SCANS_PER_CYCLE;
+  if (raw === undefined || raw === '') {
+    return 100;
+  }
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : 100;
+}
+
+/**
+ * Collects workload images from the API (no Trivy dependency), then feeds the list
+ * into the Trivy CLI scan path only when Trivy is detected and available.
+ */
+export async function runWorkloadImageScanCycle(
+  options: WorkloadScanCycleOptions
+): Promise<WorkloadScanCycleResult> {
+  const maxUnique = options.maxUniqueImages ?? DEFAULT_MAX_UNIQUE_WORKLOAD_IMAGES;
+  const maxScans = options.maxScansPerCycle ?? parseMaxScansPerCycle();
+
+  const { images, truncated } = await collectWorkloadImageReferences(options.kubernetesClient, {
+    maxUniqueImages: maxUnique,
+  });
+
+  const status = options.getTrivyStatus();
+  if (!status.detected || !status.serverUrl) {
+    logger.info('Workload images collected; skipping Trivy scans (integration not active)', {
+      uniqueImagesCollected: images.length,
+      truncated,
+    });
+    return {
+      scansSkippedDueToTrivy: true,
+      uniqueImagesCollected: images.length,
+      truncated,
+      scansAttempted: 0,
+      scansSucceeded: 0,
+      scansFailed: 0,
+    };
+  }
+
+  const toScan = images.slice(0, maxScans);
+  if (images.length > maxScans) {
+    logger.info('Workload image scan cycle limiting scans per cycle', {
+      totalUnique: images.length,
+      maxScansPerCycle: maxScans,
+    });
+  }
+
+  let scansSucceeded = 0;
+  let scansFailed = 0;
+
+  for (const imageRef of toScan) {
+    try {
+      await scanContainerImageWhenDetected(imageRef, {
+        getStatus: options.getTrivyStatus,
+      });
+      scansSucceeded++;
+    } catch (err) {
+      scansFailed++;
+      logger.warn('Trivy scan failed for workload image', {
+        imageRef,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  if (truncated) {
+    logger.warn('Workload image collection hit unique image cap', {
+      maxUniqueImages: maxUnique,
+    });
+  }
+
+  logger.info('Workload image scan cycle completed', {
+    uniqueImagesCollected: images.length,
+    truncated,
+    scansAttempted: toScan.length,
+    scansSucceeded,
+    scansFailed,
+  });
+
+  return {
+    scansSkippedDueToTrivy: false,
+    uniqueImagesCollected: images.length,
+    truncated,
+    scansAttempted: toScan.length,
+    scansSucceeded,
+    scansFailed,
+  };
+}


### PR DESCRIPTION
This pull request merges the **parent development branch** [`feature/issue-15`](https://github.com/alto9/kube9-operator/tree/feature/issue-15) into `main` for **[#15 – Implement optional image vulnerability scanning with Trivy](https://github.com/alto9/kube9-operator/issues/15)**.

## Summary

Delivers optional Trivy-backed vulnerability scanning: detection, workload image collection, SQLite persistence, assessment checks, CLI queries, Prometheus metrics, and graceful behavior when Trivy is absent—as described in the parent issue and linked sub-issues.

## References

- Parent issue: https://github.com/alto9/kube9-operator/issues/15

Closes #15