### PR TITLE
fix(deps): add husky devDependency for prepare script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kube9-operator",
-  "version": "1.4.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kube9-operator",
-      "version": "1.4.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",
@@ -31,6 +31,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.10.0",
         "@vitest/ui": "^4.0.14",
+        "husky": "^9.1.7",
         "nodemon": "^3.0.2",
         "semantic-release": "^25.0.2",
         "ts-node": "^10.9.2",
@@ -4524,6 +4525,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.10.0",
     "@vitest/ui": "^4.0.14",
+    "husky": "^9.1.7",
     "nodemon": "^3.0.2",
     "semantic-release": "^25.0.2",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
## Problem

`package.json` on `main` includes `"prepare": "husky"` (with `.husky/` in the repo) but **husky** was not listed in `devDependencies`. After `npm ci`, the `prepare` script runs `sh -c husky` and the binary is missing, so CI fails with:

```
sh: 1: husky: not found
npm error command failed
npm error command sh -c husky
```

## Change

Add `husky` as a devDependency and update `package-lock.json` via `npm install`.

## Testing

- `npm ci` (clean install)
- `npm run lint`
- `npm run test`

Fixes CI for any workflow that runs `npm ci` on current `main`.