### PR TITLE
106 add over provisioning detection cost checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,10 @@ RUN apk add --no-cache python3 make g++
 # Copy package files
 COPY package*.json ./
 
-# Install only production dependencies
-RUN npm ci --omit=dev
+# Omit devDependencies (husky lives there). If package.json has a `prepare` script that
+# invokes `husky`, it would fail with "husky: not found" unless we skip lifecycle scripts.
+# better-sqlite3 needs a native build — rebuild it after install.
+RUN npm ci --omit=dev --ignore-scripts && npm rebuild better-sqlite3
 
 # Copy built dist folder from build stage
 COPY --from=builder /app/dist ./dist

--- a/src/assessment/bootstrap.ts
+++ b/src/assessment/bootstrap.ts
@@ -32,7 +32,10 @@ import {
   namespaceResourceGovernanceCheck,
   nodeAffinityAndPlacementCheck,
 } from './checks/performance-efficiency/index.js';
-import { resourceRequestLimitRatiosCheck } from './checks/cost-optimization/index.js';
+import {
+  resourceRequestLimitRatiosCheck,
+  overProvisioningDetectionCheck,
+} from './checks/cost-optimization/index.js';
 
 /** Built-in checks to register at bootstrap (extend as checks are implemented) */
 const BUILT_IN_CHECKS: AssessmentCheck[] = [
@@ -56,6 +59,7 @@ const BUILT_IN_CHECKS: AssessmentCheck[] = [
   namespaceResourceGovernanceCheck,
   nodeAffinityAndPlacementCheck,
   resourceRequestLimitRatiosCheck,
+  overProvisioningDetectionCheck,
 ];
 
 /**

--- a/src/assessment/checks/cost-optimization/index.ts
+++ b/src/assessment/checks/cost-optimization/index.ts
@@ -3,3 +3,4 @@
  */
 
 export { resourceRequestLimitRatiosCheck } from './resource-request-limit-ratios.js';
+export { overProvisioningDetectionCheck } from './over-provisioning-detection.js';

--- a/src/assessment/checks/cost-optimization/over-provisioning-detection.test.ts
+++ b/src/assessment/checks/cost-optimization/over-provisioning-detection.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi } from 'vitest';
+import { overProvisioningDetectionCheck } from './over-provisioning-detection.js';
+import type { AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus } from '../../types.js';
+
+function createMockCtx(
+  deployments: unknown[] = [],
+  statefulSets: unknown[] = [],
+  daemonSets: unknown[] = [],
+): AssessmentRunContext {
+  return {
+    kubernetes: {
+      appsApi: {
+        listDeploymentForAllNamespaces: vi.fn().mockResolvedValue({ items: deployments }),
+        listStatefulSetForAllNamespaces: vi.fn().mockResolvedValue({ items: statefulSets }),
+        listDaemonSetForAllNamespaces: vi.fn().mockResolvedValue({ items: daemonSets }),
+      },
+    },
+    config: {} as never,
+    timeoutMs: 30000,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+    runId: 'test-run',
+    mode: 'full',
+  } as unknown as AssessmentRunContext;
+}
+
+describe('overProvisioningDetectionCheck', () => {
+  it('passes when no workloads or requests are within thresholds', async () => {
+    const ctx = createMockCtx([]);
+    const result = await overProvisioningDetectionCheck.run(ctx);
+
+    expect(result.checkId).toBe('cost-optimization.over-provisioning-detection');
+    expect(result.pillar).toBe(Pillar.CostOptimization);
+    expect(result.status).toBe(CheckStatus.Passing);
+  });
+
+  it('passes for modest per-pod and total reservations', async () => {
+    const deployments = [
+      {
+        metadata: { namespace: 'default', name: 'app' },
+        spec: {
+          replicas: 3,
+          template: {
+            spec: {
+              containers: [
+                {
+                  name: 'main',
+                  resources: {
+                    requests: { cpu: '500m', memory: '256Mi' },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ];
+    const ctx = createMockCtx(deployments);
+    const result = await overProvisioningDetectionCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Passing);
+  });
+
+  it('warns when per-pod CPU requests reach warning threshold', async () => {
+    const deployments = [
+      {
+        metadata: { namespace: 'default', name: 'big' },
+        spec: {
+          replicas: 1,
+          template: {
+            spec: {
+              containers: [
+                {
+                  name: 'main',
+                  resources: {
+                    requests: { cpu: '4', memory: '128Mi' },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ];
+    const ctx = createMockCtx(deployments);
+    const result = await overProvisioningDetectionCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Warning);
+    expect(result.message).toContain('per-pod CPU');
+    expect(result.message).toContain('4.00 cores');
+  });
+
+  it('fails when per-pod CPU requests reach fail threshold', async () => {
+    const deployments = [
+      {
+        metadata: { namespace: 'default', name: 'huge' },
+        spec: {
+          replicas: 1,
+          template: {
+            spec: {
+              containers: [
+                {
+                  name: 'main',
+                  resources: {
+                    requests: { cpu: '16', memory: '128Mi' },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ];
+    const ctx = createMockCtx(deployments);
+    const result = await overProvisioningDetectionCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Failing);
+    expect(result.message).toContain('per-pod CPU');
+    expect(result.message).toContain('16.00');
+  });
+
+  it('warns when scaled CPU reservation exceeds total warning threshold', async () => {
+    const deployments = [
+      {
+        metadata: { namespace: 'default', name: 'wide' },
+        spec: {
+          replicas: 10,
+          template: {
+            spec: {
+              containers: [
+                {
+                  name: 'main',
+                  resources: {
+                    requests: { cpu: '4', memory: '128Mi' },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ];
+    const ctx = createMockCtx(deployments);
+    const result = await overProvisioningDetectionCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Warning);
+    expect(result.message).toContain('total CPU reservation');
+    expect(result.message).toContain('40.00');
+  });
+
+  it('warns for high per-pod memory requests', async () => {
+    const deployments = [
+      {
+        metadata: { namespace: 'default', name: 'mem' },
+        spec: {
+          replicas: 1,
+          template: {
+            spec: {
+              containers: [
+                {
+                  name: 'main',
+                  resources: {
+                    requests: { cpu: '100m', memory: '20Gi' },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ];
+    const ctx = createMockCtx(deployments);
+    const result = await overProvisioningDetectionCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Warning);
+    expect(result.message).toContain('per-pod memory');
+  });
+
+  it('uses max(init, app) for effective pod CPU', async () => {
+    const deployments = [
+      {
+        metadata: { namespace: 'default', name: 'init-heavy' },
+        spec: {
+          replicas: 1,
+          template: {
+            spec: {
+              initContainers: [
+                {
+                  name: 'warm',
+                  resources: {
+                    requests: { cpu: '8', memory: '128Mi' },
+                  },
+                },
+              ],
+              containers: [
+                {
+                  name: 'main',
+                  resources: {
+                    requests: { cpu: '100m', memory: '128Mi' },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ];
+    const ctx = createMockCtx(deployments);
+    const result = await overProvisioningDetectionCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Warning);
+    expect(result.message).toMatch(/8\.00 cores/);
+  });
+
+  it('skips kube-system workloads', async () => {
+    const deployments = [
+      {
+        metadata: { namespace: 'kube-system', name: 'big' },
+        spec: {
+          replicas: 1,
+          template: {
+            spec: {
+              containers: [
+                {
+                  name: 'main',
+                  resources: {
+                    requests: { cpu: '16', memory: '128Mi' },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ];
+    const ctx = createMockCtx(deployments);
+    const result = await overProvisioningDetectionCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Passing);
+  });
+
+  it('skips resource-exempt workloads', async () => {
+    const deployments = [
+      {
+        metadata: {
+          namespace: 'default',
+          name: 'exempt',
+          labels: { 'kube9.io/resource-exempt': 'true' },
+        },
+        spec: {
+          replicas: 1,
+          template: {
+            spec: {
+              containers: [
+                {
+                  name: 'main',
+                  resources: {
+                    requests: { cpu: '16', memory: '128Mi' },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ];
+    const ctx = createMockCtx(deployments);
+    const result = await overProvisioningDetectionCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Passing);
+  });
+});

--- a/src/assessment/checks/cost-optimization/over-provisioning-detection.ts
+++ b/src/assessment/checks/cost-optimization/over-provisioning-detection.ts
@@ -1,0 +1,289 @@
+/**
+ * Cost optimization: over-provisioning detection from declared requests.
+ *
+ * Uses only Kubernetes workload configuration (no metrics). Heuristics flag
+ * per-pod or fleet-level CPU/memory requests that are far above typical
+ * service needs — a signal to right-size or revisit quota / limits.
+ *
+ * Heuristics (see exported constants for tunable thresholds):
+ * - Effective per-pod request = max(sum(initContainers requests), sum(containers requests)) per resource.
+ * - Warn/fail when per-pod CPU or memory requests exceed configured ceilings.
+ * - Warn/fail when total reservation (replicas × per-pod request) exceeds fleet-level ceilings.
+ */
+
+import * as k8s from '@kubernetes/client-node';
+import type { AssessmentCheck, AssessmentCheckResult, AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus, Severity } from '../../types.js';
+import { isResourceCheckRelevant, type WorkloadMetadata } from '../reliability/heuristics.js';
+import { parseCpuCores, parseMemoryBytes } from '../shared/resource-quantities.js';
+
+const CHECK_ID = 'cost-optimization.over-provisioning-detection';
+const CHECK_NAME = 'Over-Provisioning Detection';
+
+const REMEDIATION =
+  'Validate actual CPU and memory usage (metrics, Vertical Pod Autoscaler recommendations, or load tests), then lower requests/limits and quotas to match steady-state need plus a modest buffer. Tighten namespace ResourceQuota if capacity was reserved but workloads use far less.';
+
+/** Per-pod CPU request (cores) at or above: warning — likely more than typical microservices need. */
+export const OVERPROVISION_PER_POD_CPU_WARN_CORES = 4;
+/** Per-pod CPU request (cores) at or above: failing — material over-provisioning for a single pod. */
+export const OVERPROVISION_PER_POD_CPU_FAIL_CORES = 16;
+
+/** Per-pod memory request (bytes) at or above: warning. */
+export const OVERPROVISION_PER_POD_MEMORY_WARN_BYTES = 16 * 1024 ** 3;
+/** Per-pod memory request (bytes) at or above: failing. */
+export const OVERPROVISION_PER_POD_MEMORY_FAIL_BYTES = 64 * 1024 ** 3;
+
+/** Total workload CPU reservation (replicas × effective per-pod CPU) in cores: warning. */
+export const OVERPROVISION_TOTAL_CPU_WARN_CORES = 32;
+/** Total workload CPU reservation: failing. */
+export const OVERPROVISION_TOTAL_CPU_FAIL_CORES = 128;
+
+/** Total workload memory reservation (replicas × per-pod memory): warning. */
+export const OVERPROVISION_TOTAL_MEMORY_WARN_BYTES = 256 * 1024 ** 3;
+/** Total workload memory reservation: failing (1 TiB). */
+export const OVERPROVISION_TOTAL_MEMORY_FAIL_BYTES = 1024 ** 4;
+
+type FindingLevel = 'fail' | 'warn';
+
+interface Finding {
+  level: FindingLevel;
+  text: string;
+}
+
+function toWorkloadMeta(meta: k8s.V1ObjectMeta | undefined, kind: string): WorkloadMetadata {
+  return {
+    namespace: meta?.namespace ?? '',
+    name: meta?.name ?? 'unknown',
+    kind,
+    labels: meta?.labels as Record<string, string> | undefined,
+  };
+}
+
+function sumContainerCpuRequests(containers: k8s.V1Container[] | undefined): number {
+  if (!containers?.length) return 0;
+  let sum = 0;
+  for (const c of containers) {
+    const v = parseCpuCores(c.resources?.requests?.cpu);
+    if (v !== undefined) sum += v;
+  }
+  return sum;
+}
+
+function sumContainerMemoryRequests(containers: k8s.V1Container[] | undefined): number {
+  if (!containers?.length) return 0;
+  let sum = 0;
+  for (const c of containers) {
+    const v = parseMemoryBytes(c.resources?.requests?.memory);
+    if (v !== undefined) sum += v;
+  }
+  return sum;
+}
+
+/**
+ * Effective scheduling request for CPU: max(init sum, app sum), matching Kubernetes
+ * overlap rules for init vs workload containers.
+ */
+function effectivePodCpuRequestCores(template: k8s.V1PodTemplateSpec | undefined): number {
+  const init = sumContainerCpuRequests(template?.spec?.initContainers);
+  const app = sumContainerCpuRequests(template?.spec?.containers);
+  return Math.max(init, app);
+}
+
+function effectivePodMemoryRequestBytes(template: k8s.V1PodTemplateSpec | undefined): number {
+  const init = sumContainerMemoryRequests(template?.spec?.initContainers);
+  const app = sumContainerMemoryRequests(template?.spec?.containers);
+  return Math.max(init, app);
+}
+
+function formatGi(bytes: number): string {
+  return `${(bytes / 1024 ** 3).toFixed(1)}Gi`;
+}
+
+function classifyCpu(
+  workload: string,
+  perPodCores: number,
+  totalCores: number,
+  out: Finding[],
+): void {
+  if (perPodCores <= 0 && totalCores <= 0) return;
+
+  if (perPodCores >= OVERPROVISION_PER_POD_CPU_FAIL_CORES) {
+    out.push({
+      level: 'fail',
+      text: `${workload}: per-pod CPU requests total ${perPodCores.toFixed(2)} cores (>= ${OVERPROVISION_PER_POD_CPU_FAIL_CORES}); verify need or right-size`,
+    });
+  } else if (perPodCores >= OVERPROVISION_PER_POD_CPU_WARN_CORES) {
+    out.push({
+      level: 'warn',
+      text: `${workload}: per-pod CPU requests ${perPodCores.toFixed(2)} cores (>= ${OVERPROVISION_PER_POD_CPU_WARN_CORES}); review for over-provisioning`,
+    });
+  }
+
+  if (totalCores >= OVERPROVISION_TOTAL_CPU_FAIL_CORES) {
+    out.push({
+      level: 'fail',
+      text: `${workload}: total CPU reservation ~${totalCores.toFixed(2)} cores (replicas × per-pod, >= ${OVERPROVISION_TOTAL_CPU_FAIL_CORES}); review aggregate capacity`,
+    });
+  } else if (totalCores >= OVERPROVISION_TOTAL_CPU_WARN_CORES) {
+    out.push({
+      level: 'warn',
+      text: `${workload}: total CPU reservation ~${totalCores.toFixed(2)} cores (>= ${OVERPROVISION_TOTAL_CPU_WARN_CORES}); review fleet sizing`,
+    });
+  }
+}
+
+function classifyMemory(
+  workload: string,
+  perPodBytes: number,
+  totalBytes: number,
+  out: Finding[],
+): void {
+  if (perPodBytes <= 0 && totalBytes <= 0) return;
+
+  if (perPodBytes >= OVERPROVISION_PER_POD_MEMORY_FAIL_BYTES) {
+    out.push({
+      level: 'fail',
+      text: `${workload}: per-pod memory requests ${formatGi(perPodBytes)} (>= ${formatGi(OVERPROVISION_PER_POD_MEMORY_FAIL_BYTES)}); verify need or right-size`,
+    });
+  } else if (perPodBytes >= OVERPROVISION_PER_POD_MEMORY_WARN_BYTES) {
+    out.push({
+      level: 'warn',
+      text: `${workload}: per-pod memory requests ${formatGi(perPodBytes)} (>= ${formatGi(OVERPROVISION_PER_POD_MEMORY_WARN_BYTES)}); review for over-provisioning`,
+    });
+  }
+
+  if (totalBytes >= OVERPROVISION_TOTAL_MEMORY_FAIL_BYTES) {
+    out.push({
+      level: 'fail',
+      text: `${workload}: total memory reservation ~${formatGi(totalBytes)} (>= ${formatGi(OVERPROVISION_TOTAL_MEMORY_FAIL_BYTES)}); review aggregate capacity`,
+    });
+  } else if (totalBytes >= OVERPROVISION_TOTAL_MEMORY_WARN_BYTES) {
+    out.push({
+      level: 'warn',
+      text: `${workload}: total memory reservation ~${formatGi(totalBytes)} (>= ${formatGi(OVERPROVISION_TOTAL_MEMORY_WARN_BYTES)}); review fleet sizing`,
+    });
+  }
+}
+
+function collectWorkloadFindings(
+  workload: string,
+  template: k8s.V1PodTemplateSpec | undefined,
+  replicas: number,
+  out: Finding[],
+): void {
+  if (replicas <= 0) return;
+  const perPodCpu = effectivePodCpuRequestCores(template);
+  const perPodMem = effectivePodMemoryRequestBytes(template);
+  const totalCpu = perPodCpu * replicas;
+  const totalMem = perPodMem * replicas;
+  classifyCpu(workload, perPodCpu, totalCpu, out);
+  classifyMemory(workload, perPodMem, totalMem, out);
+}
+
+export const overProvisioningDetectionCheck: AssessmentCheck = {
+  id: CHECK_ID,
+  name: CHECK_NAME,
+  pillar: Pillar.CostOptimization,
+  description:
+    'Flags declared CPU/memory requests that suggest over-provisioning at per-pod or scaled workload level (configuration-only heuristics)',
+  defaultSeverity: Severity.Medium,
+
+  async run(ctx: AssessmentRunContext): Promise<AssessmentCheckResult> {
+    const [deploymentsRes, statefulSetsRes, daemonSetsRes] = await Promise.all([
+      ctx.kubernetes.appsApi.listDeploymentForAllNamespaces(),
+      ctx.kubernetes.appsApi.listStatefulSetForAllNamespaces(),
+      ctx.kubernetes.appsApi.listDaemonSetForAllNamespaces(),
+    ]);
+
+    const deployments = deploymentsRes.items ?? [];
+    const statefulSets = statefulSetsRes.items ?? [];
+    const daemonSets = daemonSetsRes.items ?? [];
+
+    const failures: string[] = [];
+    const warnings: string[] = [];
+
+    for (const d of deployments) {
+      const meta = toWorkloadMeta(d.metadata, 'Deployment');
+      if (!isResourceCheckRelevant(meta)) continue;
+      const workload = `${meta.namespace}/${meta.name} (Deployment)`;
+      const findings: Finding[] = [];
+      const replicas = d.spec?.replicas ?? 0;
+      collectWorkloadFindings(workload, d.spec?.template, replicas, findings);
+      for (const f of findings) {
+        if (f.level === 'fail') failures.push(f.text);
+        else warnings.push(f.text);
+      }
+    }
+
+    for (const s of statefulSets) {
+      const meta = toWorkloadMeta(s.metadata, 'StatefulSet');
+      if (!isResourceCheckRelevant(meta)) continue;
+      const workload = `${meta.namespace}/${meta.name} (StatefulSet)`;
+      const findings: Finding[] = [];
+      const replicas = s.spec?.replicas ?? 0;
+      collectWorkloadFindings(workload, s.spec?.template, replicas, findings);
+      for (const f of findings) {
+        if (f.level === 'fail') failures.push(f.text);
+        else warnings.push(f.text);
+      }
+    }
+
+    for (const ds of daemonSets) {
+      const meta = toWorkloadMeta(ds.metadata, 'DaemonSet');
+      if (!isResourceCheckRelevant(meta)) continue;
+      const workload = `${meta.namespace}/${meta.name} (DaemonSet)`;
+      const findings: Finding[] = [];
+      const replicas = ds.status?.desiredNumberScheduled ?? 0;
+      collectWorkloadFindings(workload, ds.spec?.template, replicas, findings);
+      for (const f of findings) {
+        if (f.level === 'fail') failures.push(f.text);
+        else warnings.push(f.text);
+      }
+    }
+
+    if (failures.length > 0) {
+      const message =
+        failures.length <= 5
+          ? failures.join('; ')
+          : `${failures.length} over-provisioning issues: ${failures.slice(0, 3).join('; ')}...`;
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.CostOptimization,
+        status: CheckStatus.Failing,
+        severity: Severity.High,
+        objectKind: 'Deployment',
+        message,
+        remediation: REMEDIATION,
+      };
+    }
+
+    if (warnings.length > 0) {
+      const message =
+        warnings.length <= 5
+          ? warnings.join('; ')
+          : `${warnings.length} over-provisioning warnings: ${warnings.slice(0, 3).join('; ')}...`;
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.CostOptimization,
+        status: CheckStatus.Warning,
+        severity: Severity.Medium,
+        objectKind: 'Deployment',
+        message,
+        remediation: REMEDIATION,
+      };
+    }
+
+    return {
+      checkId: CHECK_ID,
+      checkName: CHECK_NAME,
+      pillar: Pillar.CostOptimization,
+      status: CheckStatus.Passing,
+      severity: Severity.Medium,
+      message:
+        'No likely over-provisioning from declared requests for in-scope workloads (per thresholds in over-provisioning-detection)',
+      remediation: REMEDIATION,
+    };
+  },
+};

--- a/src/assessment/runner.integration.test.ts
+++ b/src/assessment/runner.integration.test.ts
@@ -298,8 +298,11 @@ describe('AssessmentRunner (integration)', () => {
       pillarFilter: Pillar.CostOptimization,
     });
 
-    expect(checks.length).toBe(1);
-    expect(checks[0].id).toBe('cost-optimization.resource-request-limit-ratios');
+    expect(checks.length).toBe(2);
+    expect(checks.map((c) => c.id).sort()).toEqual([
+      'cost-optimization.over-provisioning-detection',
+      'cost-optimization.resource-request-limit-ratios',
+    ]);
 
     const storage = new AssessmentRepository();
     const runner = new AssessmentRunner({
@@ -316,12 +319,15 @@ describe('AssessmentRunner (integration)', () => {
     });
 
     expect(record.run_id).toBe('run-cost-pillar');
-    expect(record.total_checks).toBe(1);
-    expect(record.completed_checks).toBe(1);
-    expect(record.passed_checks).toBe(1);
+    expect(record.total_checks).toBe(2);
+    expect(record.completed_checks).toBe(2);
+    expect(record.passed_checks).toBe(2);
 
     const history = storage.queryHistory({ filters: { run_id: 'run-cost-pillar' } });
-    expect(history).toHaveLength(1);
-    expect(history[0].check_id).toBe('cost-optimization.resource-request-limit-ratios');
+    expect(history).toHaveLength(2);
+    expect(history.map((h) => h.check_id).sort()).toEqual([
+      'cost-optimization.over-provisioning-detection',
+      'cost-optimization.resource-request-limit-ratios',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Implements [issue #106](https://github.com/alto9/kube9-operator/issues/106): over-provisioning detection under the cost-optimization pillar.

## Changes

- New check `cost-optimization.over-provisioning-detection` evaluating Deployment, StatefulSet, and DaemonSet templates against documented CPU/memory thresholds (per-pod and replicas × per-pod totals), using effective requests as max(sum(init), sum(containers)).
- Reuses `isResourceCheckRelevant` so system namespaces and `kube9.io/resource-exempt` behave like other pillars.
- Unit tests for passing, warning, failing, init-container max, and exclusions; runner integration updated for two cost checks.

## Testing

- `npm run lint`
- `npm run test`
- `npm run test:integration -- src/assessment/runner.integration.test.ts`
- `npm run build`

Closes #106