### PR TITLE
feat(assessment): operational-excellence kube9-operator checks (#110, #111, #112, #113)

### DIFF
--- a/src/argocd/detection.ts
+++ b/src/argocd/detection.ts
@@ -48,6 +48,21 @@ export interface ArgoCDDetectionConfig {
 }
 
 /**
+ * Parse ArgoCD detection settings from process.env (operator and assessment checks).
+ */
+export function parseArgoCDConfigFromEnv(): ArgoCDDetectionConfig {
+  const enabledEnv = process.env.ARGOCD_ENABLED;
+  return {
+    autoDetect: process.env.ARGOCD_AUTO_DETECT !== 'false',
+    enabled:
+      enabledEnv === 'true' ? true : enabledEnv === 'false' ? false : undefined,
+    namespace: process.env.ARGOCD_NAMESPACE || 'argocd',
+    selector: process.env.ARGOCD_SELECTOR || 'app.kubernetes.io/name=argocd-server',
+    detectionInterval: parseInt(process.env.ARGOCD_DETECTION_INTERVAL || '6', 10),
+  };
+}
+
+/**
  * Check if ArgoCD Application CRD exists in the cluster
  * 
  * @param k8sClient - Kubernetes client for API access

--- a/src/assessment/bootstrap.ts
+++ b/src/assessment/bootstrap.ts
@@ -38,6 +38,10 @@ import {
   overProvisioningDetectionCheck,
   spotInstanceUsageCheck,
 } from './checks/cost-optimization/index.js';
+import {
+  kube9OperatorHealthProbesCheck,
+  kube9OperatorMetricsExposureCheck,
+} from './checks/operational-excellence/index.js';
 
 /** Built-in checks to register at bootstrap (extend as checks are implemented) */
 const BUILT_IN_CHECKS: AssessmentCheck[] = [
@@ -64,6 +68,8 @@ const BUILT_IN_CHECKS: AssessmentCheck[] = [
   resourceRequestLimitRatiosCheck,
   overProvisioningDetectionCheck,
   spotInstanceUsageCheck,
+  kube9OperatorHealthProbesCheck,
+  kube9OperatorMetricsExposureCheck,
 ];
 
 /**

--- a/src/assessment/bootstrap.ts
+++ b/src/assessment/bootstrap.ts
@@ -43,6 +43,7 @@ import {
   kube9OperatorMetricsExposureCheck,
   kube9OperatorLoggingConfigurationCheck,
   kube9OperatorAuditSignalsCheck,
+  kube9OperatorDeploymentStrategyCheck,
 } from './checks/operational-excellence/index.js';
 
 /** Built-in checks to register at bootstrap (extend as checks are implemented) */
@@ -74,6 +75,7 @@ const BUILT_IN_CHECKS: AssessmentCheck[] = [
   kube9OperatorMetricsExposureCheck,
   kube9OperatorLoggingConfigurationCheck,
   kube9OperatorAuditSignalsCheck,
+  kube9OperatorDeploymentStrategyCheck,
 ];
 
 /**

--- a/src/assessment/bootstrap.ts
+++ b/src/assessment/bootstrap.ts
@@ -41,6 +41,8 @@ import {
 import {
   kube9OperatorHealthProbesCheck,
   kube9OperatorMetricsExposureCheck,
+  kube9OperatorLoggingConfigurationCheck,
+  kube9OperatorAuditSignalsCheck,
 } from './checks/operational-excellence/index.js';
 
 /** Built-in checks to register at bootstrap (extend as checks are implemented) */
@@ -70,6 +72,8 @@ const BUILT_IN_CHECKS: AssessmentCheck[] = [
   spotInstanceUsageCheck,
   kube9OperatorHealthProbesCheck,
   kube9OperatorMetricsExposureCheck,
+  kube9OperatorLoggingConfigurationCheck,
+  kube9OperatorAuditSignalsCheck,
 ];
 
 /**

--- a/src/assessment/bootstrap.ts
+++ b/src/assessment/bootstrap.ts
@@ -44,6 +44,7 @@ import {
   kube9OperatorLoggingConfigurationCheck,
   kube9OperatorAuditSignalsCheck,
   kube9OperatorDeploymentStrategyCheck,
+  gitopsDeliverySignalsCheck,
 } from './checks/operational-excellence/index.js';
 
 /** Built-in checks to register at bootstrap (extend as checks are implemented) */
@@ -76,6 +77,7 @@ const BUILT_IN_CHECKS: AssessmentCheck[] = [
   kube9OperatorLoggingConfigurationCheck,
   kube9OperatorAuditSignalsCheck,
   kube9OperatorDeploymentStrategyCheck,
+  gitopsDeliverySignalsCheck,
 ];
 
 /**

--- a/src/assessment/checks/operational-excellence/gitops-delivery-signals.test.ts
+++ b/src/assessment/checks/operational-excellence/gitops-delivery-signals.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { gitopsDeliverySignalsCheck } from './gitops-delivery-signals.js';
+import type { AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus } from '../../types.js';
+
+const notFound = Object.assign(new Error('not found'), {
+  response: { statusCode: 404 },
+});
+
+function createMockCtx(kubernetes: Record<string, unknown>): AssessmentRunContext {
+  return {
+    kubernetes,
+    config: {} as never,
+    timeoutMs: 30000,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as never,
+    runId: 'test-run',
+    mode: 'full',
+  } as unknown as AssessmentRunContext;
+}
+
+describe('gitopsDeliverySignalsCheck', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.ARGOCD_ENABLED;
+    delete process.env.ARGOCD_AUTO_DETECT;
+    delete process.env.ARGOCD_NAMESPACE;
+    delete process.env.ARGOCD_SELECTOR;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('passes when Argo CD is detected (CRD, namespace, server Deployment)', async () => {
+    const readCustomResourceDefinition = vi.fn(async ({ name }: { name: string }) => {
+      if (name === 'applications.argoproj.io') {
+        return { metadata: { name } };
+      }
+      throw notFound;
+    });
+    const readNamespace = vi.fn().mockResolvedValue({ metadata: { name: 'argocd' } });
+    const listNamespacedDeployment = vi.fn().mockResolvedValue({
+      items: [
+        {
+          metadata: { labels: { 'app.kubernetes.io/version': 'v2.10.0' } },
+          spec: { template: { spec: { containers: [{ name: 'argocd-server', image: 'quay.io/argoproj/argocd:v2.10.0' }] } } },
+        },
+      ],
+    });
+
+    const ctx = createMockCtx({
+      apiextensionsApi: { readCustomResourceDefinition },
+      coreApi: { readNamespace },
+      appsApi: { listNamespacedDeployment },
+    });
+
+    const result = await gitopsDeliverySignalsCheck.run(ctx);
+
+    expect(result.checkId).toBe('operational-excellence.gitops-delivery-signals');
+    expect(result.pillar).toBe(Pillar.OperationalExcellence);
+    expect(result.status).toBe(CheckStatus.Passing);
+    expect(result.message).toContain('Argo CD detected');
+  });
+
+  it('passes when Flux GitOps CRD is present without Argo CD', async () => {
+    const readCustomResourceDefinition = vi.fn(async ({ name }: { name: string }) => {
+      if (name === 'kustomizations.kustomize.toolkit.fluxcd.io') {
+        return { metadata: { name } };
+      }
+      throw notFound;
+    });
+
+    const ctx = createMockCtx({
+      apiextensionsApi: { readCustomResourceDefinition },
+      coreApi: { readNamespace: vi.fn() },
+      appsApi: { listNamespacedDeployment: vi.fn() },
+    });
+
+    const result = await gitopsDeliverySignalsCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Passing);
+    expect(result.message).toContain('Flux');
+  });
+
+  it('warns when no GitOps signals are present', async () => {
+    const readCustomResourceDefinition = vi.fn().mockRejectedValue(notFound);
+
+    const ctx = createMockCtx({
+      apiextensionsApi: { readCustomResourceDefinition },
+      coreApi: { readNamespace: vi.fn() },
+      appsApi: { listNamespacedDeployment: vi.fn() },
+    });
+
+    const result = await gitopsDeliverySignalsCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Warning);
+    expect(result.message).toContain('No Argo CD or Flux');
+  });
+
+  it('warns when Argo Application CRD exists but server Deployment is missing', async () => {
+    const readCustomResourceDefinition = vi.fn(async ({ name }: { name: string }) => {
+      if (name === 'applications.argoproj.io') {
+        return { metadata: { name } };
+      }
+      throw notFound;
+    });
+    const readNamespace = vi.fn().mockResolvedValue({ metadata: { name: 'argocd' } });
+    const listNamespacedDeployment = vi.fn().mockResolvedValue({ items: [] });
+
+    const ctx = createMockCtx({
+      apiextensionsApi: { readCustomResourceDefinition },
+      coreApi: { readNamespace },
+      appsApi: { listNamespacedDeployment },
+    });
+
+    const result = await gitopsDeliverySignalsCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Warning);
+    expect(result.message).toContain('incomplete');
+    expect(result.remediation).toContain('ARGOCD_NAMESPACE');
+  });
+
+  it('warns when ARGOCD_ENABLED=true but server Deployment is not found', async () => {
+    process.env.ARGOCD_ENABLED = 'true';
+
+    const readCustomResourceDefinition = vi.fn().mockRejectedValue(notFound);
+    const readNamespace = vi.fn().mockResolvedValue({ metadata: { name: 'argocd' } });
+    const listNamespacedDeployment = vi.fn().mockResolvedValue({ items: [] });
+
+    const ctx = createMockCtx({
+      apiextensionsApi: { readCustomResourceDefinition },
+      coreApi: { readNamespace },
+      appsApi: { listNamespacedDeployment },
+    });
+
+    const result = await gitopsDeliverySignalsCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Warning);
+    expect(result.message).toContain('ARGOCD_ENABLED=true');
+  });
+});

--- a/src/assessment/checks/operational-excellence/gitops-delivery-signals.ts
+++ b/src/assessment/checks/operational-excellence/gitops-delivery-signals.ts
@@ -1,0 +1,140 @@
+/**
+ * Operational Excellence: GitOps delivery signals
+ *
+ * Uses the same Argo CD detection contract as the operator plus Flux CRD probes
+ * to classify declarative GitOps posture and surface drift-prone or incomplete setups.
+ */
+
+import type { KubernetesClient } from '../../../kubernetes/client.js';
+import type { AssessmentCheck, AssessmentCheckResult, AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus, Severity } from '../../types.js';
+import {
+  checkForApplicationCRD,
+  detectArgoCD,
+  parseArgoCDConfigFromEnv,
+} from '../../../argocd/detection.js';
+
+const CHECK_ID = 'operational-excellence.gitops-delivery-signals';
+const CHECK_NAME = 'GitOps delivery signals';
+
+const REMEDIATION_GENERIC =
+  'Install and operate a cluster GitOps controller (Argo CD and/or Flux) so application state is reconciled from Git. For Argo CD, ensure the Application CRD is installed and the argocd-server Deployment is healthy in the expected namespace. See https://argo-cd.readthedocs.io/ and https://fluxcd.io/flux/.';
+
+const REMEDIATION_PARTIAL_ARGO =
+  'The applications.argoproj.io CRD is present but the Argo CD server Deployment was not found with the configured namespace/selector. Reconcile the install or set ARGOCD_NAMESPACE / ARGOCD_SELECTOR to match your deployment.';
+
+const REMEDIATION_ENABLED_NO_SERVER =
+  'ARGOCD_ENABLED=true but no matching Argo CD server Deployment was found. Fix the install or correct ARGOCD_NAMESPACE / ARGOCD_SELECTOR.';
+
+/** Flux GitOps CRDs that indicate Flux is installed (any one is sufficient). */
+const FLUX_GITOPS_CRD_NAMES = [
+  'kustomizations.kustomize.toolkit.fluxcd.io',
+  'helmreleases.helm.toolkit.fluxcd.io',
+  'gitrepositories.source.toolkit.fluxcd.io',
+] as const;
+
+async function crdExists(client: KubernetesClient, name: string): Promise<boolean> {
+  try {
+    await client.apiextensionsApi.readCustomResourceDefinition({ name });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function anyFluxGitOpsCrdPresent(client: KubernetesClient): Promise<boolean> {
+  for (const name of FLUX_GITOPS_CRD_NAMES) {
+    if (await crdExists(client, name)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export const gitopsDeliverySignalsCheck: AssessmentCheck = {
+  id: CHECK_ID,
+  name: CHECK_NAME,
+  pillar: Pillar.OperationalExcellence,
+  description:
+    'Evaluates GitOps readiness using Argo CD detection and Flux CRD signals, including incomplete Argo installs.',
+  defaultSeverity: Severity.Medium,
+
+  async run(ctx: AssessmentRunContext): Promise<AssessmentCheckResult> {
+    const client = ctx.kubernetes;
+    const argoConfig = parseArgoCDConfigFromEnv();
+
+    const [hasArgoCrd, argoStatus, fluxPresent] = await Promise.all([
+      checkForApplicationCRD(client),
+      detectArgoCD(client, argoConfig),
+      anyFluxGitOpsCrdPresent(client),
+    ]);
+
+    if (argoStatus.detected) {
+      const ver = argoStatus.version ? ` (${argoStatus.version})` : '';
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.OperationalExcellence,
+        status: CheckStatus.Passing,
+        severity: Severity.Medium,
+        message: `GitOps: Argo CD detected in namespace ${argoStatus.namespace ?? 'unknown'}${ver}`,
+        remediation: REMEDIATION_GENERIC,
+      };
+    }
+
+    if (fluxPresent) {
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.OperationalExcellence,
+        status: CheckStatus.Passing,
+        severity: Severity.Medium,
+        message:
+          'GitOps: Flux toolkit CRDs present (Kustomization / HelmRelease / GitRepository controller surface)',
+        remediation: REMEDIATION_GENERIC,
+      };
+    }
+
+    if (argoConfig.enabled === true) {
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.OperationalExcellence,
+        status: CheckStatus.Warning,
+        severity: Severity.Medium,
+        message:
+          'GitOps: ARGOCD_ENABLED=true but Argo CD server Deployment was not found with the current namespace and label selector',
+        remediation: REMEDIATION_ENABLED_NO_SERVER,
+      };
+    }
+
+    if (
+      hasArgoCrd &&
+      !argoStatus.detected &&
+      argoConfig.autoDetect !== false &&
+      argoConfig.enabled !== false
+    ) {
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.OperationalExcellence,
+        status: CheckStatus.Warning,
+        severity: Severity.Medium,
+        message:
+          'GitOps: Argo CD Application CRD exists but the Argo CD server Deployment was not found (incomplete or mis-scoped install)',
+        remediation: REMEDIATION_PARTIAL_ARGO,
+      };
+    }
+
+    return {
+      checkId: CHECK_ID,
+      checkName: CHECK_NAME,
+      pillar: Pillar.OperationalExcellence,
+      status: CheckStatus.Warning,
+      severity: Severity.Low,
+      message:
+        'GitOps: No Argo CD or Flux GitOps signals detected; workload delivery may rely on imperative or external CI only',
+      remediation: REMEDIATION_GENERIC,
+    };
+  },
+};

--- a/src/assessment/checks/operational-excellence/index.ts
+++ b/src/assessment/checks/operational-excellence/index.ts
@@ -4,3 +4,5 @@
 
 export { kube9OperatorHealthProbesCheck } from './kube9-operator-health-probes.js';
 export { kube9OperatorMetricsExposureCheck } from './kube9-operator-metrics-exposure.js';
+export { kube9OperatorLoggingConfigurationCheck } from './kube9-operator-logging-configuration.js';
+export { kube9OperatorAuditSignalsCheck } from './kube9-operator-audit-signals.js';

--- a/src/assessment/checks/operational-excellence/index.ts
+++ b/src/assessment/checks/operational-excellence/index.ts
@@ -7,3 +7,4 @@ export { kube9OperatorMetricsExposureCheck } from './kube9-operator-metrics-expo
 export { kube9OperatorLoggingConfigurationCheck } from './kube9-operator-logging-configuration.js';
 export { kube9OperatorAuditSignalsCheck } from './kube9-operator-audit-signals.js';
 export { kube9OperatorDeploymentStrategyCheck } from './kube9-operator-deployment-strategy.js';
+export { gitopsDeliverySignalsCheck } from './gitops-delivery-signals.js';

--- a/src/assessment/checks/operational-excellence/index.ts
+++ b/src/assessment/checks/operational-excellence/index.ts
@@ -6,3 +6,4 @@ export { kube9OperatorHealthProbesCheck } from './kube9-operator-health-probes.j
 export { kube9OperatorMetricsExposureCheck } from './kube9-operator-metrics-exposure.js';
 export { kube9OperatorLoggingConfigurationCheck } from './kube9-operator-logging-configuration.js';
 export { kube9OperatorAuditSignalsCheck } from './kube9-operator-audit-signals.js';
+export { kube9OperatorDeploymentStrategyCheck } from './kube9-operator-deployment-strategy.js';

--- a/src/assessment/checks/operational-excellence/index.ts
+++ b/src/assessment/checks/operational-excellence/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Operational excellence assessment checks
+ */
+
+export { kube9OperatorHealthProbesCheck } from './kube9-operator-health-probes.js';
+export { kube9OperatorMetricsExposureCheck } from './kube9-operator-metrics-exposure.js';

--- a/src/assessment/checks/operational-excellence/kube9-operator-audit-signals.test.ts
+++ b/src/assessment/checks/operational-excellence/kube9-operator-audit-signals.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest';
+import { kube9OperatorAuditSignalsCheck } from './kube9-operator-audit-signals.js';
+import type { AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus } from '../../types.js';
+
+function createMockCtx(deployments: unknown[] = []): AssessmentRunContext {
+  return {
+    kubernetes: {
+      appsApi: {
+        listDeploymentForAllNamespaces: vi.fn().mockResolvedValue({ items: deployments }),
+      },
+    },
+    config: {} as never,
+    timeoutMs: 30000,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as never,
+    runId: 'test-run',
+    mode: 'full',
+  } as unknown as AssessmentRunContext;
+}
+
+function compliantDeployment(overrides: Record<string, unknown> = {}) {
+  return {
+    metadata: {
+      namespace: 'kube9-system',
+      name: 'kube9-operator',
+      labels: { 'app.kubernetes.io/name': 'kube9-operator' },
+    },
+    spec: {
+      template: {
+        spec: {
+          serviceAccountName: 'kube9-operator',
+          containers: [
+            {
+              name: 'operator',
+              env: [
+                {
+                  name: 'POD_NAMESPACE',
+                  valueFrom: { fieldRef: { fieldPath: 'metadata.namespace' } },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('kube9OperatorAuditSignalsCheck', () => {
+  it('skips when no kube9-operator Deployment exists', async () => {
+    const ctx = createMockCtx([]);
+    const result = await kube9OperatorAuditSignalsCheck.run(ctx);
+
+    expect(result.checkId).toBe('operational-excellence.kube9-operator-audit-signals');
+    expect(result.pillar).toBe(Pillar.OperationalExcellence);
+    expect(result.status).toBe(CheckStatus.Skipped);
+  });
+
+  it('passes when POD_NAMESPACE uses the downward API and a dedicated SA is set', async () => {
+    const ctx = createMockCtx([compliantDeployment()]);
+    const result = await kube9OperatorAuditSignalsCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Passing);
+    expect(result.message).toContain('POD_NAMESPACE');
+  });
+
+  it('fails when POD_NAMESPACE is absent', async () => {
+    const dep = compliantDeployment();
+    const c = (dep as { spec: { template: { spec: { containers: unknown[] } } } }).spec.template.spec
+      .containers[0] as { env: unknown[] };
+    c.env = [];
+
+    const ctx = createMockCtx([dep]);
+    const result = await kube9OperatorAuditSignalsCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Failing);
+    expect(result.message).toContain('POD_NAMESPACE');
+  });
+
+  it('fails when POD_NAMESPACE is a literal instead of fieldRef', async () => {
+    const dep = compliantDeployment();
+    const c = (dep as { spec: { template: { spec: { containers: unknown[] } } } }).spec.template.spec
+      .containers[0] as { env: unknown[] };
+    c.env = [{ name: 'POD_NAMESPACE', value: 'kube9-system' }];
+
+    const ctx = createMockCtx([dep]);
+    const result = await kube9OperatorAuditSignalsCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Failing);
+    expect(result.message).toContain('fieldRef');
+  });
+
+  it('fails when serviceAccountName is default', async () => {
+    const dep = compliantDeployment();
+    (dep as { spec: { template: { spec: { serviceAccountName: string } } } }).spec.template.spec.serviceAccountName =
+      'default';
+
+    const ctx = createMockCtx([dep]);
+    const result = await kube9OperatorAuditSignalsCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Failing);
+    expect(result.message).toContain('ServiceAccount');
+  });
+
+  it('fails when serviceAccountName is omitted', async () => {
+    const dep = compliantDeployment();
+    delete (dep as { spec: { template: { spec: { serviceAccountName?: string } } } }).spec.template.spec
+      .serviceAccountName;
+
+    const ctx = createMockCtx([dep]);
+    const result = await kube9OperatorAuditSignalsCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Failing);
+    expect(result.message).toContain('ServiceAccount');
+  });
+});

--- a/src/assessment/checks/operational-excellence/kube9-operator-audit-signals.ts
+++ b/src/assessment/checks/operational-excellence/kube9-operator-audit-signals.ts
@@ -1,0 +1,107 @@
+/**
+ * Operational Excellence: kube9-operator audit and correlation signals
+ *
+ * Validates downward API and workload identity signals that support log correlation
+ * and Kubernetes API audit attribution (namespace context and non-default identity).
+ */
+
+import type { AssessmentCheck, AssessmentCheckResult, AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus, Severity } from '../../types.js';
+import {
+  getContainerEnv,
+  getOperatorContainer,
+  isKube9OperatorDeployment,
+  isPodNamespaceFieldRef,
+} from './kube9-operator-shared.js';
+
+const CHECK_ID = 'operational-excellence.kube9-operator-audit-signals';
+const CHECK_NAME = 'kube9-operator audit signals';
+
+const REMEDIATION =
+  'Inject POD_NAMESPACE via the downward API (valueFrom.fieldRef fieldPath metadata.namespace) and run the operator under a dedicated ServiceAccount (not default). For cluster-level API audit evidence, enable and retain a Kubernetes Audit Policy appropriate to your compliance needs. See charts/kube9-operator/templates/deployment.yaml and Kubernetes documentation on auditing.';
+
+export const kube9OperatorAuditSignalsCheck: AssessmentCheck = {
+  id: CHECK_ID,
+  name: CHECK_NAME,
+  pillar: Pillar.OperationalExcellence,
+  description:
+    'Validates POD_NAMESPACE downward API injection and a dedicated ServiceAccount for the kube9-operator workload.',
+  defaultSeverity: Severity.Medium,
+
+  async run(ctx: AssessmentRunContext): Promise<AssessmentCheckResult> {
+    const res = await ctx.kubernetes.appsApi.listDeploymentForAllNamespaces();
+    const deployments = (res.items ?? []).filter(isKube9OperatorDeployment);
+
+    if (deployments.length === 0) {
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.OperationalExcellence,
+        status: CheckStatus.Skipped,
+        severity: Severity.Info,
+        message:
+          'No kube9-operator Deployment found (label app.kubernetes.io/name=kube9-operator).',
+        remediation:
+          'Deploy kube9-operator with the standard chart labels so this check can validate audit correlation signals.',
+      };
+    }
+
+    const failures: string[] = [];
+
+    for (const d of deployments) {
+      const ns = d.metadata?.namespace ?? 'default';
+      const depName = d.metadata?.name ?? 'unknown';
+      const ref = `${ns}/${depName}`;
+      const podSpec = d.spec?.template?.spec;
+      const container = getOperatorContainer(podSpec);
+      if (!container) {
+        failures.push(`${ref}: no containers in pod template`);
+        continue;
+      }
+      const cname = container.name ?? 'unknown';
+
+      const podNsEnv = getContainerEnv(container, 'POD_NAMESPACE');
+      if (!isPodNamespaceFieldRef(podNsEnv)) {
+        failures.push(
+          `${ref} container ${cname}: POD_NAMESPACE must be set from valueFrom.fieldRef fieldPath metadata.namespace for log and event correlation`
+        );
+      }
+
+      const sa =
+        podSpec?.serviceAccountName?.trim() ||
+        (podSpec as { serviceAccount?: string } | undefined)?.serviceAccount?.trim();
+      if (!sa || sa === 'default') {
+        failures.push(
+          `${ref}: use a dedicated ServiceAccount for the operator workload so Kubernetes API audit logs identify kube9-operator activity distinctly from other default-SA workloads`
+        );
+      }
+    }
+
+    if (failures.length > 0) {
+      const message =
+        failures.length <= 5
+          ? failures.join('; ')
+          : `${failures.length} issue(s): ${failures.slice(0, 3).join('; ')}...`;
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.OperationalExcellence,
+        status: CheckStatus.Failing,
+        severity: Severity.High,
+        objectKind: 'Deployment',
+        message,
+        remediation: REMEDIATION,
+      };
+    }
+
+    return {
+      checkId: CHECK_ID,
+      checkName: CHECK_NAME,
+      pillar: Pillar.OperationalExcellence,
+      status: CheckStatus.Passing,
+      severity: Severity.Medium,
+      message: `kube9-operator audit signals: ${deployments.length} Deployment(s) inject POD_NAMESPACE and use a dedicated ServiceAccount`,
+      remediation: REMEDIATION,
+    };
+  },
+};

--- a/src/assessment/checks/operational-excellence/kube9-operator-deployment-strategy.test.ts
+++ b/src/assessment/checks/operational-excellence/kube9-operator-deployment-strategy.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from 'vitest';
+import { kube9OperatorDeploymentStrategyCheck } from './kube9-operator-deployment-strategy.js';
+import type { AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus } from '../../types.js';
+
+function createMockCtx(deployments: unknown[] = []): AssessmentRunContext {
+  return {
+    kubernetes: {
+      appsApi: {
+        listDeploymentForAllNamespaces: vi.fn().mockResolvedValue({ items: deployments }),
+      },
+    },
+    config: {} as never,
+    timeoutMs: 30000,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as never,
+    runId: 'test-run',
+    mode: 'full',
+  } as unknown as AssessmentRunContext;
+}
+
+function kube9Deployment(overrides: Record<string, unknown> = {}) {
+  return {
+    metadata: {
+      namespace: 'kube9-system',
+      name: 'kube9-operator',
+      labels: { 'app.kubernetes.io/name': 'kube9-operator' },
+    },
+    spec: {
+      replicas: 1,
+      strategy: { type: 'Recreate' },
+      template: { spec: { containers: [{ name: 'operator' }] } },
+    },
+    ...overrides,
+  };
+}
+
+describe('kube9OperatorDeploymentStrategyCheck', () => {
+  it('skips when no kube9-operator Deployment exists', async () => {
+    const ctx = createMockCtx([]);
+    const result = await kube9OperatorDeploymentStrategyCheck.run(ctx);
+
+    expect(result.checkId).toBe('operational-excellence.kube9-operator-deployment-strategy');
+    expect(result.pillar).toBe(Pillar.OperationalExcellence);
+    expect(result.status).toBe(CheckStatus.Skipped);
+    expect(result.message).toContain('No kube9-operator Deployment');
+  });
+
+  it('passes for single-replica Recreate (chart-style PVC-friendly rollout)', async () => {
+    const ctx = createMockCtx([kube9Deployment()]);
+    const result = await kube9OperatorDeploymentStrategyCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Passing);
+    expect(result.message).toContain('acceptable');
+  });
+
+  it('fails for Recreate with multiple replicas', async () => {
+    const dep = kube9Deployment({
+      spec: {
+        replicas: 3,
+        strategy: { type: 'Recreate' },
+        template: { spec: { containers: [{ name: 'operator' }] } },
+      },
+    });
+    const ctx = createMockCtx([dep]);
+    const result = await kube9OperatorDeploymentStrategyCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Failing);
+    expect(result.message).toContain('Recreate');
+    expect(result.message).toContain('3 replicas');
+  });
+
+  it('fails for RollingUpdate when maxUnavailable takes all pods on HA', async () => {
+    const dep = kube9Deployment({
+      spec: {
+        replicas: 2,
+        strategy: {
+          type: 'RollingUpdate',
+          rollingUpdate: { maxUnavailable: '100%', maxSurge: '0' },
+        },
+        template: { spec: { containers: [{ name: 'operator' }] } },
+      },
+    });
+    const ctx = createMockCtx([dep]);
+    const result = await kube9OperatorDeploymentStrategyCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Failing);
+    expect(result.message).toContain('maxUnavailable');
+  });
+
+  it('fails for RollingUpdate when integer maxUnavailable equals replica count', async () => {
+    const dep = kube9Deployment({
+      spec: {
+        replicas: 2,
+        strategy: {
+          type: 'RollingUpdate',
+          rollingUpdate: { maxUnavailable: 2, maxSurge: 1 },
+        },
+        template: { spec: { containers: [{ name: 'operator' }] } },
+      },
+    });
+    const ctx = createMockCtx([dep]);
+    const result = await kube9OperatorDeploymentStrategyCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Failing);
+  });
+
+  it('passes for RollingUpdate with two replicas and default disruption (25%)', async () => {
+    const dep = kube9Deployment({
+      spec: {
+        replicas: 2,
+        strategy: { type: 'RollingUpdate', rollingUpdate: {} },
+        template: { spec: { containers: [{ name: 'operator' }] } },
+      },
+    });
+    const ctx = createMockCtx([dep]);
+    const result = await kube9OperatorDeploymentStrategyCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Passing);
+  });
+
+  it('warns when progressDeadlineSeconds is very low', async () => {
+    const dep = kube9Deployment({
+      spec: {
+        replicas: 1,
+        strategy: { type: 'Recreate' },
+        progressDeadlineSeconds: 60,
+        template: { spec: { containers: [{ name: 'operator' }] } },
+      },
+    });
+    const ctx = createMockCtx([dep]);
+    const result = await kube9OperatorDeploymentStrategyCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Warning);
+    expect(result.message).toContain('progressDeadlineSeconds');
+  });
+});

--- a/src/assessment/checks/operational-excellence/kube9-operator-deployment-strategy.ts
+++ b/src/assessment/checks/operational-excellence/kube9-operator-deployment-strategy.ts
@@ -1,0 +1,175 @@
+/**
+ * Operational Excellence: kube9-operator deployment strategy
+ *
+ * Evaluates rollout strategy and disruption settings on kube9-operator Deployments
+ * to flag configurations that increase outage risk during releases.
+ */
+
+import * as k8s from '@kubernetes/client-node';
+import type { AssessmentCheck, AssessmentCheckResult, AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus, Severity } from '../../types.js';
+import { isKube9OperatorDeployment } from './kube9-operator-shared.js';
+
+const CHECK_ID = 'operational-excellence.kube9-operator-deployment-strategy';
+const CHECK_NAME = 'kube9-operator deployment strategy';
+
+const REMEDIATION =
+  'For HA (replicas >= 2), avoid Recreate (it terminates all pods before new ones run). Prefer RollingUpdate with bounded maxUnavailable (below replica count) and non-zero maxSurge when possible. Set spec.progressDeadlineSeconds high enough for image pulls and startup (often 300–600s). Single-replica Recreate is acceptable when a volume or startup constraint requires it. See charts/kube9-operator/templates/deployment.yaml and Kubernetes Deployment strategy documentation.';
+
+/** Kubernetes defaults when rollingUpdate fields are omitted */
+const DEFAULT_MAX_UNAVAILABLE_PCT = 25;
+const PROGRESS_DEADLINE_WARN_BELOW_SEC = 120;
+
+type ParsedIntOrPercent = { kind: 'int'; value: number } | { kind: 'percent'; value: number };
+
+function parseIntOrString(v: k8s.IntOrString | undefined | null): ParsedIntOrPercent | undefined {
+  if (v === undefined || v === null) return undefined;
+  if (typeof v === 'number' && Number.isFinite(v)) {
+    return { kind: 'int', value: Math.max(0, Math.trunc(v)) };
+  }
+  if (typeof v === 'string') {
+    const s = v.trim();
+    if (s.endsWith('%')) {
+      const n = Number.parseInt(s.slice(0, -1), 10);
+      if (Number.isNaN(n)) return undefined;
+      return { kind: 'percent', value: n };
+    }
+    const n = Number.parseInt(s, 10);
+    if (Number.isNaN(n)) return undefined;
+    return { kind: 'int', value: Math.max(0, n) };
+  }
+  return undefined;
+}
+
+function replicaCount(spec: k8s.V1DeploymentSpec | undefined): number {
+  const r = spec?.replicas;
+  if (typeof r === 'number' && r >= 1) {
+    return r;
+  }
+  return 1;
+}
+
+function strategyIsRecreate(spec: k8s.V1DeploymentSpec | undefined): boolean {
+  return spec?.strategy?.type === 'Recreate';
+}
+
+/**
+ * Effective max unavailable pods for RollingUpdate (Kubernetes percentage rounds down).
+ * When rollingUpdate or maxUnavailable is omitted, defaults match the API (25%).
+ */
+function effectiveMaxUnavailablePods(replicas: number, ru: k8s.V1RollingUpdateDeployment | undefined): number {
+  const parsed =
+    parseIntOrString(ru?.maxUnavailable) ?? ({ kind: 'percent', value: DEFAULT_MAX_UNAVAILABLE_PCT } as const);
+  if (parsed.kind === 'int') {
+    return Math.min(parsed.value, replicas);
+  }
+  return Math.floor((replicas * parsed.value) / 100);
+}
+
+export const kube9OperatorDeploymentStrategyCheck: AssessmentCheck = {
+  id: CHECK_ID,
+  name: CHECK_NAME,
+  pillar: Pillar.OperationalExcellence,
+  description:
+    'Validates kube9-operator Deployment rollout strategy and disruption settings for safer releases.',
+  defaultSeverity: Severity.Medium,
+
+  async run(ctx: AssessmentRunContext): Promise<AssessmentCheckResult> {
+    const res = await ctx.kubernetes.appsApi.listDeploymentForAllNamespaces();
+    const deployments = (res.items ?? []).filter(isKube9OperatorDeployment);
+
+    if (deployments.length === 0) {
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.OperationalExcellence,
+        status: CheckStatus.Skipped,
+        severity: Severity.Info,
+        message:
+          'No kube9-operator Deployment found (label app.kubernetes.io/name=kube9-operator).',
+        remediation:
+          'Deploy kube9-operator with the standard chart labels so this check can validate deployment strategy.',
+      };
+    }
+
+    const failures: string[] = [];
+    const warnings: string[] = [];
+
+    for (const d of deployments) {
+      const ns = d.metadata?.namespace ?? 'default';
+      const depName = d.metadata?.name ?? 'unknown';
+      const ref = `${ns}/${depName}`;
+      const spec = d.spec;
+      const replicas = replicaCount(spec);
+
+      if (strategyIsRecreate(spec)) {
+        if (replicas >= 2) {
+          failures.push(
+            `${ref}: strategy Recreate with ${replicas} replicas stops all pods before new ones run, causing a full outage during rollouts`
+          );
+        }
+      } else {
+        const ru = spec?.strategy?.rollingUpdate;
+        if (replicas >= 2) {
+          const mu = effectiveMaxUnavailablePods(replicas, ru);
+          if (mu >= replicas) {
+            failures.push(
+              `${ref}: RollingUpdate maxUnavailable allows ${mu} of ${replicas} pods to be unavailable at once, so the Service can lose all ready endpoints during a rollout`
+            );
+          }
+        }
+      }
+
+      const pds = spec?.progressDeadlineSeconds;
+      if (typeof pds === 'number' && pds > 0 && pds < PROGRESS_DEADLINE_WARN_BELOW_SEC) {
+        warnings.push(
+          `${ref}: progressDeadlineSeconds is ${pds}s; if rollouts fail with ProgressDeadlineExceeded, increase to at least ${PROGRESS_DEADLINE_WARN_BELOW_SEC}s (or remove for the default 600s)`
+        );
+      }
+    }
+
+    if (failures.length > 0) {
+      const message =
+        failures.length <= 5
+          ? failures.join('; ')
+          : `${failures.length} issue(s): ${failures.slice(0, 3).join('; ')}...`;
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.OperationalExcellence,
+        status: CheckStatus.Failing,
+        severity: Severity.High,
+        objectKind: 'Deployment',
+        message,
+        remediation: REMEDIATION,
+      };
+    }
+
+    if (warnings.length > 0) {
+      const message =
+        warnings.length <= 4
+          ? warnings.join('; ')
+          : `${warnings.length} notice(s): ${warnings.slice(0, 2).join('; ')}...`;
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.OperationalExcellence,
+        status: CheckStatus.Warning,
+        severity: Severity.Low,
+        objectKind: 'Deployment',
+        message,
+        remediation: REMEDIATION,
+      };
+    }
+
+    return {
+      checkId: CHECK_ID,
+      checkName: CHECK_NAME,
+      pillar: Pillar.OperationalExcellence,
+      status: CheckStatus.Passing,
+      severity: Severity.Medium,
+      message: `kube9-operator rollout: ${deployments.length} Deployment(s) use an acceptable strategy and disruption settings`,
+      remediation: REMEDIATION,
+    };
+  },
+};

--- a/src/assessment/checks/operational-excellence/kube9-operator-health-probes.test.ts
+++ b/src/assessment/checks/operational-excellence/kube9-operator-health-probes.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from 'vitest';
+import { kube9OperatorHealthProbesCheck } from './kube9-operator-health-probes.js';
+import type { AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus } from '../../types.js';
+
+function createMockCtx(deployments: unknown[] = []): AssessmentRunContext {
+  return {
+    kubernetes: {
+      appsApi: {
+        listDeploymentForAllNamespaces: vi.fn().mockResolvedValue({ items: deployments }),
+      },
+    },
+    config: {} as never,
+    timeoutMs: 30000,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as never,
+    runId: 'test-run',
+    mode: 'full',
+  } as unknown as AssessmentRunContext;
+}
+
+function compliantDeployment(overrides: Record<string, unknown> = {}) {
+  return {
+    metadata: {
+      namespace: 'kube9-system',
+      name: 'kube9-operator',
+      labels: { 'app.kubernetes.io/name': 'kube9-operator' },
+    },
+    spec: {
+      template: {
+        spec: {
+          containers: [
+            {
+              name: 'operator',
+              ports: [{ name: 'http', containerPort: 8080 }],
+              livenessProbe: {
+                httpGet: { path: '/healthz', port: 8080 },
+              },
+              readinessProbe: {
+                httpGet: { path: '/readyz', port: 8080 },
+              },
+            },
+          ],
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('kube9OperatorHealthProbesCheck', () => {
+  it('skips when no kube9-operator Deployment exists', async () => {
+    const ctx = createMockCtx([]);
+    const result = await kube9OperatorHealthProbesCheck.run(ctx);
+
+    expect(result.checkId).toBe('operational-excellence.kube9-operator-health-probes');
+    expect(result.pillar).toBe(Pillar.OperationalExcellence);
+    expect(result.status).toBe(CheckStatus.Skipped);
+    expect(result.message).toContain('No kube9-operator Deployment found');
+  });
+
+  it('passes when Deployment matches operator health contract', async () => {
+    const ctx = createMockCtx([compliantDeployment()]);
+    const result = await kube9OperatorHealthProbesCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Passing);
+    expect(result.message).toContain('compliant');
+  });
+
+  it('fails when liveness path is wrong', async () => {
+    const dep = compliantDeployment();
+    const containers = (dep as { spec: { template: { spec: { containers: unknown[] } } } }).spec.template
+      .spec.containers;
+    (containers[0] as { livenessProbe: { httpGet: { path: string } } }).livenessProbe.httpGet.path =
+      '/health';
+
+    const ctx = createMockCtx([dep]);
+    const result = await kube9OperatorHealthProbesCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Failing);
+    expect(result.message).toContain('/healthz');
+    expect(result.remediation).toBeDefined();
+  });
+
+  it('fails when readiness probe is missing', async () => {
+    const dep = compliantDeployment();
+    const c = (dep as { spec: { template: { spec: { containers: unknown[] } } } }).spec.template.spec
+      .containers[0] as { readinessProbe?: unknown };
+    delete c.readinessProbe;
+
+    const ctx = createMockCtx([dep]);
+    const result = await kube9OperatorHealthProbesCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Failing);
+    expect(result.message).toContain('readinessProbe');
+  });
+
+  it('fails when liveness and readiness target different ports', async () => {
+    const dep = compliantDeployment();
+    const c = (dep as { spec: { template: { spec: { containers: unknown[] } } } }).spec.template.spec
+      .containers[0] as {
+      readinessProbe: { httpGet: { port: number } };
+    };
+    c.readinessProbe.httpGet.port = 9090;
+
+    const ctx = createMockCtx([dep]);
+    const result = await kube9OperatorHealthProbesCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Failing);
+    expect(result.message).toContain('same HTTP port');
+  });
+});

--- a/src/assessment/checks/operational-excellence/kube9-operator-health-probes.ts
+++ b/src/assessment/checks/operational-excellence/kube9-operator-health-probes.ts
@@ -1,0 +1,124 @@
+/**
+ * Operational Excellence: kube9-operator health probes
+ *
+ * Validates that kube9-operator Deployments expose the baseline HTTP liveness
+ * and readiness endpoints expected by the operator health server contract.
+ */
+
+import type { AssessmentCheck, AssessmentCheckResult, AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus, Severity } from '../../types.js';
+import {
+  getOperatorContainer,
+  isKube9OperatorDeployment,
+  probeHttpPortValue,
+} from './kube9-operator-shared.js';
+
+const CHECK_ID = 'operational-excellence.kube9-operator-health-probes';
+const CHECK_NAME = 'kube9-operator health probes';
+const EXPECTED_LIVENESS_PATH = '/healthz';
+const EXPECTED_READINESS_PATH = '/readyz';
+
+const REMEDIATION =
+  'Configure the operator Deployment pod template so the main container defines livenessProbe and readinessProbe with httpGet path /healthz and /readyz on the HTTP port (default 8080), matching src/health/server.ts. See charts/kube9-operator/templates/deployment.yaml for reference.';
+
+export const kube9OperatorHealthProbesCheck: AssessmentCheck = {
+  id: CHECK_ID,
+  name: CHECK_NAME,
+  pillar: Pillar.OperationalExcellence,
+  description:
+    'Validates kube9-operator Deployments use /healthz and /readyz HTTP probes on the main container.',
+  defaultSeverity: Severity.Medium,
+
+  async run(ctx: AssessmentRunContext): Promise<AssessmentCheckResult> {
+    const res = await ctx.kubernetes.appsApi.listDeploymentForAllNamespaces();
+    const deployments = (res.items ?? []).filter(isKube9OperatorDeployment);
+
+    if (deployments.length === 0) {
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.OperationalExcellence,
+        status: CheckStatus.Skipped,
+        severity: Severity.Info,
+        message:
+          'No kube9-operator Deployment found (label app.kubernetes.io/name=kube9-operator).',
+        remediation:
+          'Deploy kube9-operator with the standard chart labels so this check can validate health probe configuration.',
+      };
+    }
+
+    const problems: string[] = [];
+
+    for (const d of deployments) {
+      const ns = d.metadata?.namespace ?? 'default';
+      const name = d.metadata?.name ?? 'unknown';
+      const ref = `${ns}/${name}`;
+      const container = getOperatorContainer(d.spec?.template?.spec);
+      if (!container) {
+        problems.push(`${ref}: no containers in pod template`);
+        continue;
+      }
+      const cname = container.name ?? 'unknown';
+
+      const liv = container.livenessProbe;
+      const ready = container.readinessProbe;
+      if (!liv?.httpGet) {
+        problems.push(
+          `${ref} container ${cname}: livenessProbe must use httpGet (expected path ${EXPECTED_LIVENESS_PATH})`
+        );
+      } else if (liv.httpGet.path !== EXPECTED_LIVENESS_PATH) {
+        problems.push(
+          `${ref} container ${cname}: liveness httpGet.path must be ${EXPECTED_LIVENESS_PATH}, got ${String(liv.httpGet.path)}`
+        );
+      }
+
+      if (!ready?.httpGet) {
+        problems.push(
+          `${ref} container ${cname}: readinessProbe must use httpGet (expected path ${EXPECTED_READINESS_PATH})`
+        );
+      } else if (ready.httpGet.path !== EXPECTED_READINESS_PATH) {
+        problems.push(
+          `${ref} container ${cname}: readiness httpGet.path must be ${EXPECTED_READINESS_PATH}, got ${String(ready.httpGet.path)}`
+        );
+      }
+
+      if (liv?.httpGet && ready?.httpGet) {
+        const lp = probeHttpPortValue(liv.httpGet.port);
+        const rp = probeHttpPortValue(ready.httpGet.port);
+        if (lp !== undefined && rp !== undefined && String(lp) !== String(rp)) {
+          problems.push(
+            `${ref} container ${cname}: liveness and readiness probes should target the same HTTP port (health and metrics share one listener)`
+          );
+        }
+      }
+    }
+
+    if (problems.length === 0) {
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.OperationalExcellence,
+        status: CheckStatus.Passing,
+        severity: Severity.Medium,
+        message: `kube9-operator observability: ${deployments.length} Deployment(s) have compliant /healthz and /readyz probes`,
+        remediation: REMEDIATION,
+      };
+    }
+
+    const message =
+      problems.length <= 5
+        ? problems.join('; ')
+        : `${problems.length} issue(s): ${problems.slice(0, 3).join('; ')}...`;
+
+    return {
+      checkId: CHECK_ID,
+      checkName: CHECK_NAME,
+      pillar: Pillar.OperationalExcellence,
+      status: CheckStatus.Failing,
+      severity: Severity.High,
+      objectKind: 'Deployment',
+      message,
+      remediation: REMEDIATION,
+    };
+  },
+};

--- a/src/assessment/checks/operational-excellence/kube9-operator-logging-configuration.test.ts
+++ b/src/assessment/checks/operational-excellence/kube9-operator-logging-configuration.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest';
+import { kube9OperatorLoggingConfigurationCheck } from './kube9-operator-logging-configuration.js';
+import type { AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus } from '../../types.js';
+
+function createMockCtx(deployments: unknown[] = []): AssessmentRunContext {
+  return {
+    kubernetes: {
+      appsApi: {
+        listDeploymentForAllNamespaces: vi.fn().mockResolvedValue({ items: deployments }),
+      },
+    },
+    config: {} as never,
+    timeoutMs: 30000,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as never,
+    runId: 'test-run',
+    mode: 'full',
+  } as unknown as AssessmentRunContext;
+}
+
+function compliantDeployment(overrides: Record<string, unknown> = {}) {
+  return {
+    metadata: {
+      namespace: 'kube9-system',
+      name: 'kube9-operator',
+      labels: { 'app.kubernetes.io/name': 'kube9-operator' },
+    },
+    spec: {
+      template: {
+        spec: {
+          serviceAccountName: 'kube9-operator',
+          containers: [
+            {
+              name: 'operator',
+              env: [
+                { name: 'LOG_LEVEL', value: 'info' },
+                {
+                  name: 'POD_NAMESPACE',
+                  valueFrom: { fieldRef: { fieldPath: 'metadata.namespace' } },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('kube9OperatorLoggingConfigurationCheck', () => {
+  it('skips when no kube9-operator Deployment exists', async () => {
+    const ctx = createMockCtx([]);
+    const result = await kube9OperatorLoggingConfigurationCheck.run(ctx);
+
+    expect(result.checkId).toBe('operational-excellence.kube9-operator-logging-configuration');
+    expect(result.pillar).toBe(Pillar.OperationalExcellence);
+    expect(result.status).toBe(CheckStatus.Skipped);
+  });
+
+  it('passes when LOG_LEVEL is a supported value', async () => {
+    const ctx = createMockCtx([compliantDeployment()]);
+    const result = await kube9OperatorLoggingConfigurationCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Passing);
+    expect(result.message).toContain('LOG_LEVEL');
+  });
+
+  it('passes when LOG_LEVEL uses mixed case', async () => {
+    const dep = compliantDeployment();
+    const env = (dep as { spec: { template: { spec: { containers: { env: unknown[] }[] } } } }).spec
+      .template.spec.containers[0].env;
+    (env[0] as { value: string }).value = 'WARN';
+
+    const ctx = createMockCtx([dep]);
+    const result = await kube9OperatorLoggingConfigurationCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Passing);
+  });
+
+  it('warns when LOG_LEVEL is debug', async () => {
+    const dep = compliantDeployment();
+    const env = (dep as { spec: { template: { spec: { containers: { env: unknown[] }[] } } } }).spec
+      .template.spec.containers[0].env;
+    (env[0] as { value: string }).value = 'debug';
+
+    const ctx = createMockCtx([dep]);
+    const result = await kube9OperatorLoggingConfigurationCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Warning);
+    expect(result.message).toContain('debug');
+  });
+
+  it('fails when LOG_LEVEL is missing', async () => {
+    const dep = compliantDeployment();
+    const c = (dep as { spec: { template: { spec: { containers: unknown[] } } } }).spec.template.spec
+      .containers[0] as { env: { name: string }[] };
+    c.env = c.env.filter((e) => e.name !== 'LOG_LEVEL');
+
+    const ctx = createMockCtx([dep]);
+    const result = await kube9OperatorLoggingConfigurationCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Failing);
+    expect(result.message).toContain('LOG_LEVEL');
+  });
+
+  it('fails when LOG_LEVEL is not supported', async () => {
+    const dep = compliantDeployment();
+    const env = (dep as { spec: { template: { spec: { containers: { env: unknown[] }[] } } } }).spec
+      .template.spec.containers[0].env;
+    (env[0] as { value: string }).value = 'trace';
+
+    const ctx = createMockCtx([dep]);
+    const result = await kube9OperatorLoggingConfigurationCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Failing);
+    expect(result.message).toContain('trace');
+  });
+});

--- a/src/assessment/checks/operational-excellence/kube9-operator-logging-configuration.ts
+++ b/src/assessment/checks/operational-excellence/kube9-operator-logging-configuration.ts
@@ -1,0 +1,133 @@
+/**
+ * Operational Excellence: kube9-operator structured logging configuration
+ *
+ * Ensures the workload exposes LOG_LEVEL consistent with Winston JSON logging
+ * in src/logging/logger.ts so operators can tune verbosity for investigations.
+ */
+
+import type { AssessmentCheck, AssessmentCheckResult, AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus, Severity } from '../../types.js';
+import {
+  getContainerEnv,
+  getOperatorContainer,
+  isKube9OperatorDeployment,
+  normalizedLogLevel,
+  VALID_LOG_LEVELS,
+} from './kube9-operator-shared.js';
+
+const CHECK_ID = 'operational-excellence.kube9-operator-logging-configuration';
+const CHECK_NAME = 'kube9-operator logging configuration';
+
+const REMEDIATION =
+  'Set LOG_LEVEL on the operator container to one of error, warn, info, or debug (Helm value logLevel). The operator emits JSON logs to stdout; see src/logging/logger.ts and charts/kube9-operator/templates/deployment.yaml.';
+
+export const kube9OperatorLoggingConfigurationCheck: AssessmentCheck = {
+  id: CHECK_ID,
+  name: CHECK_NAME,
+  pillar: Pillar.OperationalExcellence,
+  description:
+    'Validates kube9-operator Deployments declare a supported LOG_LEVEL for structured logging.',
+  defaultSeverity: Severity.Medium,
+
+  async run(ctx: AssessmentRunContext): Promise<AssessmentCheckResult> {
+    const res = await ctx.kubernetes.appsApi.listDeploymentForAllNamespaces();
+    const deployments = (res.items ?? []).filter(isKube9OperatorDeployment);
+
+    if (deployments.length === 0) {
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.OperationalExcellence,
+        status: CheckStatus.Skipped,
+        severity: Severity.Info,
+        message:
+          'No kube9-operator Deployment found (label app.kubernetes.io/name=kube9-operator).',
+        remediation:
+          'Deploy kube9-operator with the standard chart labels so this check can validate logging configuration.',
+      };
+    }
+
+    const warnings: string[] = [];
+    const failures: string[] = [];
+
+    for (const d of deployments) {
+      const ns = d.metadata?.namespace ?? 'default';
+      const depName = d.metadata?.name ?? 'unknown';
+      const ref = `${ns}/${depName}`;
+      const container = getOperatorContainer(d.spec?.template?.spec);
+      if (!container) {
+        failures.push(`${ref}: no containers in pod template`);
+        continue;
+      }
+      const cname = container.name ?? 'unknown';
+
+      const logEnv = getContainerEnv(container, 'LOG_LEVEL');
+      const raw = logEnv?.value;
+      const level = normalizedLogLevel(raw);
+
+      if (level === undefined) {
+        failures.push(
+          `${ref} container ${cname}: LOG_LEVEL must be set (literal env) so log verbosity is explicit for operators and log pipelines`
+        );
+        continue;
+      }
+
+      if (!VALID_LOG_LEVELS.has(level)) {
+        failures.push(
+          `${ref} container ${cname}: LOG_LEVEL must be one of error, warn, info, debug; got ${String(raw)}`
+        );
+        continue;
+      }
+
+      if (level === 'debug') {
+        warnings.push(
+          `${ref} container ${cname}: LOG_LEVEL is debug; consider info or warn in production to reduce noise and sensitive detail in logs`
+        );
+      }
+    }
+
+    if (failures.length > 0) {
+      const message =
+        failures.length <= 5
+          ? failures.join('; ')
+          : `${failures.length} issue(s): ${failures.slice(0, 3).join('; ')}...`;
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.OperationalExcellence,
+        status: CheckStatus.Failing,
+        severity: Severity.High,
+        objectKind: 'Deployment',
+        message,
+        remediation: REMEDIATION,
+      };
+    }
+
+    if (warnings.length > 0) {
+      const message =
+        warnings.length <= 4
+          ? warnings.join('; ')
+          : `${warnings.length} notice(s): ${warnings.slice(0, 2).join('; ')}...`;
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.OperationalExcellence,
+        status: CheckStatus.Warning,
+        severity: Severity.Low,
+        objectKind: 'Deployment',
+        message,
+        remediation: REMEDIATION,
+      };
+    }
+
+    return {
+      checkId: CHECK_ID,
+      checkName: CHECK_NAME,
+      pillar: Pillar.OperationalExcellence,
+      status: CheckStatus.Passing,
+      severity: Severity.Medium,
+      message: `kube9-operator logging: ${deployments.length} Deployment(s) declare a supported LOG_LEVEL`,
+      remediation: REMEDIATION,
+    };
+  },
+};

--- a/src/assessment/checks/operational-excellence/kube9-operator-metrics-exposure.test.ts
+++ b/src/assessment/checks/operational-excellence/kube9-operator-metrics-exposure.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import { kube9OperatorMetricsExposureCheck } from './kube9-operator-metrics-exposure.js';
+import type { AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus } from '../../types.js';
+
+function createMockCtx(deployments: unknown[] = []): AssessmentRunContext {
+  return {
+    kubernetes: {
+      appsApi: {
+        listDeploymentForAllNamespaces: vi.fn().mockResolvedValue({ items: deployments }),
+      },
+    },
+    config: {} as never,
+    timeoutMs: 30000,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as never,
+    runId: 'test-run',
+    mode: 'full',
+  } as unknown as AssessmentRunContext;
+}
+
+function baseDeployment(annotations?: Record<string, string>) {
+  return {
+    metadata: {
+      namespace: 'kube9-system',
+      name: 'kube9-operator',
+      labels: { 'app.kubernetes.io/name': 'kube9-operator' },
+    },
+    spec: {
+      template: {
+        metadata: annotations ? { annotations } : {},
+        spec: {
+          containers: [
+            {
+              name: 'operator',
+              ports: [{ name: 'http', containerPort: 8080 }],
+              livenessProbe: {
+                httpGet: { path: '/healthz', port: 8080 },
+              },
+              readinessProbe: {
+                httpGet: { path: '/readyz', port: 8080 },
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+describe('kube9OperatorMetricsExposureCheck', () => {
+  it('skips when no kube9-operator Deployment exists', async () => {
+    const ctx = createMockCtx([]);
+    const result = await kube9OperatorMetricsExposureCheck.run(ctx);
+
+    expect(result.checkId).toBe('operational-excellence.kube9-operator-metrics-exposure');
+    expect(result.pillar).toBe(Pillar.OperationalExcellence);
+    expect(result.status).toBe(CheckStatus.Skipped);
+  });
+
+  it('passes when containerPorts align with probe ports', async () => {
+    const ctx = createMockCtx([baseDeployment()]);
+    const result = await kube9OperatorMetricsExposureCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Passing);
+    expect(result.message).toContain('metrics');
+  });
+
+  it('fails when containerPorts omit the probe port', async () => {
+    const dep = baseDeployment();
+    const c = (dep as { spec: { template: { spec: { containers: unknown[] } } } }).spec.template.spec
+      .containers[0] as { ports: unknown[] };
+    c.ports = [];
+
+    const ctx = createMockCtx([dep]);
+    const result = await kube9OperatorMetricsExposureCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Failing);
+    expect(result.message).toContain('containerPorts');
+    expect(result.remediation).toBeDefined();
+  });
+
+  it('warns when prometheus.io/scrape is explicitly false', async () => {
+    const dep = baseDeployment({ 'prometheus.io/scrape': 'false' });
+    const ctx = createMockCtx([dep]);
+    const result = await kube9OperatorMetricsExposureCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Warning);
+    expect(result.message).toContain('prometheus.io/scrape');
+  });
+});

--- a/src/assessment/checks/operational-excellence/kube9-operator-metrics-exposure.ts
+++ b/src/assessment/checks/operational-excellence/kube9-operator-metrics-exposure.ts
@@ -1,0 +1,135 @@
+/**
+ * Operational Excellence: kube9-operator metrics exposure readiness
+ *
+ * Ensures probe ports are declared on the container so the Prometheus /metrics
+ * endpoint (same HTTP listener as /healthz) is discoverable for scraping.
+ */
+
+import type { AssessmentCheck, AssessmentCheckResult, AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus, Severity } from '../../types.js';
+import {
+  containerDeclaresProbePort,
+  getOperatorContainer,
+  isKube9OperatorDeployment,
+} from './kube9-operator-shared.js';
+
+const CHECK_ID = 'operational-excellence.kube9-operator-metrics-exposure';
+const CHECK_NAME = 'kube9-operator metrics exposure';
+
+const REMEDIATION =
+  'Declare containerPorts on the operator container for the HTTP listener used by liveness/readiness (e.g. name http, containerPort 8080) so monitoring can target the same port as /metrics. Add Service and PodMonitor/ServiceMonitor or prometheus.io/* annotations as needed for your stack.';
+
+export const kube9OperatorMetricsExposureCheck: AssessmentCheck = {
+  id: CHECK_ID,
+  name: CHECK_NAME,
+  pillar: Pillar.OperationalExcellence,
+  description:
+    'Validates kube9-operator containerPorts include the liveness/readiness HTTP port (shared with /metrics).',
+  defaultSeverity: Severity.Medium,
+
+  async run(ctx: AssessmentRunContext): Promise<AssessmentCheckResult> {
+    const res = await ctx.kubernetes.appsApi.listDeploymentForAllNamespaces();
+    const deployments = (res.items ?? []).filter(isKube9OperatorDeployment);
+
+    if (deployments.length === 0) {
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.OperationalExcellence,
+        status: CheckStatus.Skipped,
+        severity: Severity.Info,
+        message:
+          'No kube9-operator Deployment found (label app.kubernetes.io/name=kube9-operator).',
+        remediation:
+          'Deploy kube9-operator with the standard chart labels so this check can validate metrics port exposure.',
+      };
+    }
+
+    const warnings: string[] = [];
+    const failures: string[] = [];
+
+    for (const d of deployments) {
+      const ns = d.metadata?.namespace ?? 'default';
+      const depName = d.metadata?.name ?? 'unknown';
+      const ref = `${ns}/${depName}`;
+      const container = getOperatorContainer(d.spec?.template?.spec);
+      if (!container) {
+        failures.push(`${ref}: no containers in pod template`);
+        continue;
+      }
+      const cname = container.name ?? 'unknown';
+
+      const liv = container.livenessProbe?.httpGet;
+      const ready = container.readinessProbe?.httpGet;
+
+      if (!liv || !ready) {
+        failures.push(
+          `${ref} container ${cname}: liveness and readiness httpGet probes required before metrics port alignment can be validated`
+        );
+        continue;
+      }
+
+      if (!containerDeclaresProbePort(liv, container)) {
+        failures.push(
+          `${ref} container ${cname}: containerPorts must include the liveness httpGet port (required for documenting the /metrics listener)`
+        );
+      }
+      if (!containerDeclaresProbePort(ready, container)) {
+        failures.push(
+          `${ref} container ${cname}: containerPorts must include the readiness httpGet port`
+        );
+      }
+
+      const annotations = d.spec?.template?.metadata?.annotations ?? {};
+      if (annotations['prometheus.io/scrape'] === 'false') {
+        warnings.push(
+          `${ref}: prometheus.io/scrape is false; Prometheus may not scrape kube9-operator metrics from pod annotations`
+        );
+      }
+    }
+
+    if (failures.length > 0) {
+      const message =
+        failures.length <= 5
+          ? failures.join('; ')
+          : `${failures.length} issue(s): ${failures.slice(0, 3).join('; ')}...`;
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.OperationalExcellence,
+        status: CheckStatus.Failing,
+        severity: Severity.High,
+        objectKind: 'Deployment',
+        message,
+        remediation: REMEDIATION,
+      };
+    }
+
+    if (warnings.length > 0) {
+      const message =
+        warnings.length <= 4
+          ? warnings.join('; ')
+          : `${warnings.length} notice(s): ${warnings.slice(0, 2).join('; ')}...`;
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.OperationalExcellence,
+        status: CheckStatus.Warning,
+        severity: Severity.Low,
+        objectKind: 'Deployment',
+        message,
+        remediation: REMEDIATION,
+      };
+    }
+
+    return {
+      checkId: CHECK_ID,
+      checkName: CHECK_NAME,
+      pillar: Pillar.OperationalExcellence,
+      status: CheckStatus.Passing,
+      severity: Severity.Medium,
+      message: `kube9-operator metrics: ${deployments.length} Deployment(s) declare containerPorts aligned with HTTP probes`,
+      remediation: REMEDIATION,
+    };
+  },
+};

--- a/src/assessment/checks/operational-excellence/kube9-operator-shared.test.ts
+++ b/src/assessment/checks/operational-excellence/kube9-operator-shared.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { containerDeclaresProbePort } from './kube9-operator-shared.js';
+import type * as k8s from '@kubernetes/client-node';
+
+describe('containerDeclaresProbePort', () => {
+  it('returns true when numeric port matches containerPort', () => {
+    const container: k8s.V1Container = {
+      name: 'operator',
+      ports: [{ name: 'http', containerPort: 8080 }],
+    };
+    expect(
+      containerDeclaresProbePort({ path: '/x', port: 8080 } as k8s.V1HTTPGetAction, container)
+    ).toBe(true);
+  });
+
+  it('returns true when named port matches container port name', () => {
+    const container: k8s.V1Container = {
+      name: 'operator',
+      ports: [{ name: 'http', containerPort: 8080 }],
+    };
+    expect(
+      containerDeclaresProbePort({ path: '/x', port: 'http' } as k8s.V1HTTPGetAction, container)
+    ).toBe(true);
+  });
+
+  it('returns false when port not declared', () => {
+    const container: k8s.V1Container = {
+      name: 'operator',
+      ports: [{ name: 'http', containerPort: 8080 }],
+    };
+    expect(
+      containerDeclaresProbePort({ path: '/x', port: 9090 } as k8s.V1HTTPGetAction, container)
+    ).toBe(false);
+  });
+});

--- a/src/assessment/checks/operational-excellence/kube9-operator-shared.ts
+++ b/src/assessment/checks/operational-excellence/kube9-operator-shared.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared helpers for kube9-operator observability assessment checks.
+ */
+
+import * as k8s from '@kubernetes/client-node';
+
+/** Standard Helm/app label for kube9-operator workloads */
+export const KUBE9_OPERATOR_APP_LABEL_VALUE = 'kube9-operator';
+
+/** Preferred main container name from the official chart */
+export const KUBE9_OPERATOR_CONTAINER_NAME = 'operator';
+
+export function isKube9OperatorDeployment(d: k8s.V1Deployment): boolean {
+  const name = d.metadata?.labels?.['app.kubernetes.io/name'];
+  return name === KUBE9_OPERATOR_APP_LABEL_VALUE;
+}
+
+export function getOperatorContainer(
+  podSpec: k8s.V1PodSpec | undefined
+): k8s.V1Container | undefined {
+  const containers = podSpec?.containers ?? [];
+  if (containers.length === 0) return undefined;
+  return (
+    containers.find((c) => c.name === KUBE9_OPERATOR_CONTAINER_NAME) ?? containers[0]
+  );
+}
+
+/**
+ * Normalize IntOrString from probes (Kubernetes client may use intVal/strVal or a plain number).
+ */
+export function probeHttpPortValue(port: k8s.V1HTTPGetAction['port']): number | string | undefined {
+  if (port === undefined || port === null) return undefined;
+  /** IntOrString in @kubernetes/client-node is `number | string` */
+  if (typeof port === 'number' || typeof port === 'string') return port;
+  return undefined;
+}
+
+/** Whether the container declares a port matching the probe target (number or name). */
+export function containerDeclaresProbePort(
+  httpGet: k8s.V1HTTPGetAction | undefined,
+  container: k8s.V1Container
+): boolean {
+  if (!httpGet?.port) return false;
+  const v = probeHttpPortValue(httpGet.port);
+  if (v === undefined) return false;
+  const ports = container.ports ?? [];
+  if (typeof v === 'number') {
+    return ports.some((cp) => cp.containerPort === v);
+  }
+  const n = Number(v);
+  if (!Number.isNaN(n)) {
+    return ports.some((cp) => cp.containerPort === n);
+  }
+  return ports.some((cp) => cp.name === v);
+}

--- a/src/assessment/checks/operational-excellence/kube9-operator-shared.ts
+++ b/src/assessment/checks/operational-excellence/kube9-operator-shared.ts
@@ -36,6 +36,27 @@ export function probeHttpPortValue(port: k8s.V1HTTPGetAction['port']): number | 
 }
 
 /** Whether the container declares a port matching the probe target (number or name). */
+export function getContainerEnv(container: k8s.V1Container, name: string): k8s.V1EnvVar | undefined {
+  return container.env?.find((e) => e.name === name);
+}
+
+/** Valid LOG_LEVEL values for src/logging/logger.ts (Winston). */
+export const VALID_LOG_LEVELS = new Set(['error', 'warn', 'info', 'debug']);
+
+export function normalizedLogLevel(value: string | undefined): string | undefined {
+  if (value === undefined || value === '') return undefined;
+  return value.trim().toLowerCase();
+}
+
+/**
+ * Whether the env var injects the pod namespace via the standard downward API
+ * (required for correlating structured logs with Kubernetes metadata).
+ */
+export function isPodNamespaceFieldRef(envVar: k8s.V1EnvVar | undefined): boolean {
+  if (!envVar?.valueFrom?.fieldRef) return false;
+  return envVar.valueFrom.fieldRef.fieldPath === 'metadata.namespace';
+}
+
 export function containerDeclaresProbePort(
   httpGet: k8s.V1HTTPGetAction | undefined,
   container: k8s.V1Container

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -17,7 +17,7 @@ import { LocalStorage } from './collection/storage.js';
 import { recordCollection } from './collection/metrics.js';
 import { collectionStatsTracker } from './collection/stats-tracker.js';
 import { logger } from './logging/logger.js';
-import { detectArgoCDWithTimeout, type ArgoCDDetectionConfig } from './argocd/detection.js';
+import { detectArgoCDWithTimeout, parseArgoCDConfigFromEnv } from './argocd/detection.js';
 import { argocdStatusTracker } from './argocd/state.js';
 import { ArgoCDDetectionManager } from './argocd/detection-manager.js';
 import { detectTrivyWithTimeout } from './trivy/detection.js';
@@ -95,22 +95,11 @@ async function testKubernetesClient() {
   }
 }
 
-// Parse ArgoCD configuration from environment variables
-function parseArgoCDConfig(): ArgoCDDetectionConfig {
-  return {
-    autoDetect: process.env.ARGOCD_AUTO_DETECT !== 'false',
-    enabled: process.env.ARGOCD_ENABLED === 'true' ? true : undefined,
-    namespace: process.env.ARGOCD_NAMESPACE || 'argocd',
-    selector: process.env.ARGOCD_SELECTOR || 'app.kubernetes.io/name=argocd-server',
-    detectionInterval: parseInt(process.env.ARGOCD_DETECTION_INTERVAL || '6', 10)
-  };
-}
-
 // Perform initial ArgoCD detection during startup
 async function performInitialArgoCDDetection(): Promise<void> {
   try {
     logger.info('Performing initial ArgoCD detection');
-    const argoCDConfig = parseArgoCDConfig();
+    const argoCDConfig = parseArgoCDConfigFromEnv();
     const argoCDStatus = await detectArgoCDWithTimeout(kubernetesClient, argoCDConfig);
     argocdStatusTracker.setStatus(argoCDStatus);
     
@@ -194,7 +183,7 @@ export async function startOperator() {
     await performInitialArgoCDDetection();
     
     // Start periodic ArgoCD detection manager
-    const argoCDConfig = parseArgoCDConfig();
+    const argoCDConfig = parseArgoCDConfigFromEnv();
     const initialArgoCDStatus = argocdStatusTracker.getStatus();
     const argoCDDetectionManager = new ArgoCDDetectionManager();
     argoCDDetectionManager.start(kubernetesClient, argoCDConfig, initialArgoCDStatus);


### PR DESCRIPTION
## Summary

Implements [Issue #110](https://github.com/alto9/kube9-operator/issues/110) (health probes and metrics exposure) and [Issue #111](https://github.com/alto9/kube9-operator/issues/111) (structured logging and audit signals) under the operational-excellence pillar for kube9-operator workloads.

## Changes

### #110 — Observability readiness

- Add `operational-excellence.kube9-operator-health-probes` to require httpGet liveness/readiness on `/healthz` and `/readyz` for Deployments labeled `app.kubernetes.io/name=kube9-operator`, with matching probe ports.
- Add `operational-excellence.kube9-operator-metrics-exposure` to require `containerPorts` that include the HTTP probe port (same listener as `/metrics`). Warns if `prometheus.io/scrape` is explicitly `false`.

### #111 — Logging and audit trail

- Add `operational-excellence.kube9-operator-logging-configuration` to require an explicit `LOG_LEVEL` env (error, warn, info, or debug) aligned with `src/logging/logger.ts`. Warns when `LOG_LEVEL` is `debug`.
- Add `operational-excellence.kube9-operator-audit-signals` to require `POD_NAMESPACE` from the downward API (`metadata.namespace`) and a dedicated ServiceAccount (not `default`) for correlation and API audit attribution.
- Extend `kube9-operator-shared.ts` with env and log-level helpers; register checks in `bootstrap.ts` and add unit tests for pass, fail, skip, and warning paths.

## Validation

- `npm run lint`
- `npm run test`
- `npm run build`

Closes #110
Closes #111
