### PR TITLE
Remove API key Helm surface from chart docs and automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -120,8 +120,8 @@ body:
       description: What Helm values were used for installation? (redact API keys)
       render: yaml
       placeholder: |
-        apiKey: "***"
         logLevel: "info"
+        serverUrl: "https://api.kube9.io"
 
   - type: textarea
     id: additional

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,6 @@ jobs:
         run: |
           helm template kube9-operator charts/kube9-operator \
             --namespace kube9-system \
-            --set apiKey=test123 \
             --debug
 
   docker-build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,7 +206,6 @@ SERVER_URL=https://api.kube9.dev
 
 # Optional
 LOG_LEVEL=debug
-API_KEY=kdy_prod_...
 STATUS_UPDATE_INTERVAL_SECONDS=60
 
 # Local development: writable directory for SQLite (default in dev scripts: ./.kube9-data)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The operator works with the kube9 VS Code extension and optional Helm-based UI c
 - **Basic mode** (no operator) — VS Code extension provides kubectl-focused workflows
 - **Operated mode** (operator installed) — The operator runs Well-Architected Framework checks on a schedule, persists findings and events in-cluster, and publishes status to a ConfigMap for the extension and other consumers
 
-The operator is installed via Helm and requires no ingress. It is **fully open source and self-contained**: assessments, storage, and status run inside the cluster without credentials or remote sign-in configured through this chart.
+The operator is installed via Helm and requires no ingress. It is **fully open source and self-contained**: assessments, storage, and status run inside the cluster without credentials or remote sign-in configured through this chart. Optional outbound use of `serverUrl` and related behavior are runtime concerns, not Helm-managed API keys.
 
 ## Features
 
@@ -131,6 +131,7 @@ kubectl get configmap kube9-operator-status -n kube9-system -o jsonpath='{.data.
 | `resources.limits.memory` | Memory limit | `256Mi` |
 | `logLevel` | Log level (debug, info, warn, error) | `info` |
 | `statusUpdateIntervalSeconds` | Status update frequency | `60` |
+| `serverUrl` | kube9-server API base URL (outbound; not a Helm credential surface) | `https://api.kube9.io` |
 | `argocd.autoDetect` | Enable automatic ArgoCD detection | `true` |
 | `argocd.enabled` | Explicitly enable or disable ArgoCD integration (optional override) | - |
 | `argocd.namespace` | Custom namespace where ArgoCD is installed | `"argocd"` |
@@ -473,6 +474,10 @@ kubectl get role,rolebinding -n kube9-system
 
 ```bash
 kubectl logs -n kube9-system deployment/kube9-operator
+
+# Optional: registration-related messages
+kubectl logs -n kube9-system deployment/kube9-operator | grep -i registration || true
+
 kubectl get configmap kube9-operator-status -n kube9-system -o jsonpath='{.data.status}' | jq .
 ```
 

--- a/charts/kube9-operator/IMPLEMENTATION_SUMMARY.md
+++ b/charts/kube9-operator/IMPLEMENTATION_SUMMARY.md
@@ -1,159 +1,21 @@
-# Helm Chart Testing Implementation Summary
+# Helm chart implementation summary
 
 > **Note (2026):** The chart **no longer** exposes Helm values or templates for operator API keys or Pro-tier Secrets. Default validation is **single-path**: install the chart, confirm no chart-managed credential Secret, and verify `helm template` output stays free of `API_KEY`. Historical bullets below that reference `apiKey` / Pro tier describe an earlier design iteration.
 
-## Overview
+## Chart contents
 
-This document summarizes the implementation of the Helm chart testing task (19-package-and-test-chart.task.md). The task originally covered manual testing for default and optional credential configurations, followed by packaging for distribution.
+- **Deployment**: operator pod with health probes, configurable env from values (no install-time credential keys in Helm values).
+- **ServiceAccount** and **RBAC**: optional creation via `serviceAccount.create` and `rbac.create`.
+- **PVC**: optional event persistence via `events.persistence`.
+- **NOTES.txt**: post-install guidance (ArgoCD awareness and operational commands).
 
-## Decision Verification ✅
+## Validation
 
-**Status**: All decisions verified as CORRECT
+- `node scripts/validate-chart.js` — structure and policy checks (no `secret.yaml`, no API key wiring in templates).
+- `helm lint charts/kube9-operator`
+- `./scripts/test-helm-chart.sh` — lint, template, package, and optional Kind install for default values.
 
-The implementation correctly handles:
-- **Free Tier**: No API key → mode="operated", tier="free", health="healthy"
-- **Pro Tier**: With API key → mode="enabled", tier="free" (until registered), health="degraded" when not registered
+## Testing notes
 
-### Key Verification Points
-
-1. ✅ Secret template conditionally creates Secret only when `apiKey` is provided
-2. ✅ Deployment template conditionally sets `API_KEY` env var only when `apiKey` is present
-3. ✅ Config loader gracefully handles missing Secret (404) for free tier
-4. ✅ Status calculator correctly determines mode, tier, and health based on API key and registration status
-5. ✅ Main logic only initializes RegistrationManager when API key is present
-
-## Artifacts Created
-
-### 1. Automated Test Script
-**File**: `scripts/test-helm-chart.sh`
-
-Comprehensive bash script that:
-- Validates prerequisites (helm, kubectl, kind)
-- Runs `helm lint` validation
-- Tests template rendering for both free and pro tiers
-- Validates package creation
-- Optionally runs full cluster tests with Kind
-- Provides colored output and clear success/failure indicators
-
-**Usage**:
-```bash
-./scripts/test-helm-chart.sh
-```
-
-### 2. Chart Validation Script
-**File**: `scripts/validate-chart.js`
-
-Node.js script that validates chart structure without requiring Helm:
-- Checks Chart.yaml and values.yaml existence and content
-- Validates all required templates exist
-- Verifies conditional logic in templates
-- Checks helper functions
-- Provides detailed validation output
-
-**Usage**:
-```bash
-node scripts/validate-chart.js
-```
-
-**Status**: ✅ All validations passed
-
-### 3. Manual Testing Guide
-**File**: `charts/kube9-operator/TESTING.md`
-
-Comprehensive step-by-step guide for manual testing:
-- Phase-by-phase testing instructions
-- Expected results for each scenario
-- Troubleshooting section
-- Completion checklist
-
-### 4. Verification Summary
-**File**: `charts/kube9-operator/VERIFICATION.md`
-
-Documentation of decision verification:
-- Detailed analysis of each implementation decision
-- Code references for verification
-- Testing artifacts overview
-- Next steps for completion
-
-## Current Status
-
-### Completed ✅
-- [x] Decision verification (all decisions confirmed correct)
-- [x] Chart structure validation (all templates verified)
-- [x] Template conditional logic verification
-- [x] Automated test script created
-- [x] Chart validation script created
-- [x] Manual testing guide created
-- [x] Verification documentation created
-
-### Completed with Helm ✅
-- [x] `helm lint charts/kube9-operator` - Chart linting (passed, 1 info about icon recommendation)
-- [x] `helm template` - Template rendering validation (both free and pro tier verified)
-- [x] Package creation (`helm package`) - Created `kube9-operator-1.0.0.tgz`
-- [x] Package installation testing - Package validated and ready
-
-### Pending (Requires Kind Cluster) ⏳
-- [ ] Free tier cluster testing (requires Kind)
-- [ ] Pro tier cluster testing (requires Kind)
-
-## Testing Results
-
-### Helm Validation ✅
-- **helm lint**: Passed (1 info: icon is recommended)
-- **helm template (free tier)**: Rendered successfully, Secret correctly omitted
-- **helm template (pro tier)**: Rendered successfully, Secret correctly included
-- **Package creation**: Successfully created `kube9-operator-1.0.0.tgz` (11KB)
-- **Package validation**: Package can be used for installation
-
-### Template Verification ✅
-- Free tier: No Secret created, no API_KEY env var ✓
-- Pro tier: Secret created, API_KEY env var set from Secret ✓
-
-## Next Steps
-
-To complete cluster testing (optional):
-
-1. **Run full test suite with Kind**:
-   ```bash
-   ./scripts/test-helm-chart.sh
-   ```
-
-2. **Or follow manual testing guide**:
-   - See `charts/kube9-operator/TESTING.md` for detailed cluster testing steps
-
-## Files Modified/Created
-
-### Created Files
-- `scripts/test-helm-chart.sh` - Automated test script
-- `scripts/validate-chart.js` - Chart validation script
-- `charts/kube9-operator/TESTING.md` - Manual testing guide
-- `charts/kube9-operator/VERIFICATION.md` - Verification summary
-
-### Verified Files (No Changes)
-- `charts/kube9-operator/Chart.yaml`
-- `charts/kube9-operator/values.yaml`
-- `charts/kube9-operator/templates/*.yaml`
-- `src/config/loader.ts`
-- `src/status/calculator.ts`
-- `src/index.ts`
-
-## Conclusion
-
-The Helm chart has been thoroughly tested and validated. All decision points have been confirmed correct, and the chart is ready for distribution.
-
-**Testing Summary:**
-- ✅ Chart structure validated
-- ✅ Template rendering verified (free and pro tier)
-- ✅ Helm lint passed
-- ✅ Package created and validated
-- ✅ All conditional logic working correctly
-
-The chart correctly implements:
-- Conditional Secret creation for pro tier
-- Conditional API_KEY environment variable
-- Proper free tier operation (no API key)
-- Proper pro tier operation (with API key)
-- Graceful error handling for registration failures
-
-**Package Ready**: `kube9-operator-1.0.0.tgz` is ready for distribution.
-
+- Default `helm template` / `helm install` must not create a Secret for install-time credentials or inject a legacy credential environment variable on the Deployment.
+- Registration and tier transitions are operator runtime concerns; they are not configured through Helm values in this chart.

--- a/charts/kube9-operator/README.md
+++ b/charts/kube9-operator/README.md
@@ -1,6 +1,6 @@
 # kube9-operator Helm Chart
 
-This Helm chart installs the kube9-operator, a Kubernetes operator that powers Well-Architected Framework validation and in-cluster status for the [kube9 VS Code extension](https://github.com/alto9/kube9-vscode) and other tooling.
+This Helm chart installs the kube9-operator, a Kubernetes operator that powers Well-Architected Framework validation and in-cluster status for the [kube9 VS Code extension](https://github.com/alto9/kube9-vscode) and other tooling. It also supports optional integrations (for example ArgoCD awareness and Trivy server detection) configured through values.
 
 ## Overview
 
@@ -8,6 +8,7 @@ The kube9-operator runs in your Kubernetes cluster and publishes status and asse
 
 - **Basic mode** (no operator) — kubectl-focused workflows
 - **Operated mode** (operator installed) — scheduled assessments, local persistence, and ConfigMap status for the extension
+- **Enabled mode** — richer server-connected experiences when registration succeeds (not configured through Helm API key values in this chart)
 
 The operator is installed via Helm and requires no ingress for the control plane path this chart installs. The chart does not configure API keys, credentials, or remote product sign-in.
 
@@ -78,6 +79,8 @@ The following table lists the configurable parameters and their default values:
 | `rbac.create` | Create RBAC resources (ClusterRole and ClusterRoleBinding) | `true` |
 | `logLevel` | Log level for the operator. Options: `debug`, `info`, `warn`, `error` | `"info"` |
 | `statusUpdateIntervalSeconds` | How often the operator updates the status ConfigMap (in seconds) | `60` |
+| `reregistrationIntervalHours` | How often the operator re-registers with kube9-server (hours) | `24` |
+| `serverUrl` | URL of the kube9-server API | `"https://api.kube9.io"` |
 | `metrics.intervals.clusterMetadata` | Cluster metadata collection interval (seconds). Default 86400 (24h), minimum 3600 (1h) | `86400` |
 | `metrics.intervals.resourceInventory` | Resource inventory collection interval (seconds). Default 21600 (6h), minimum 1800 (30m) | `21600` |
 | `metrics.intervals.resourceConfigurationPatterns` | Resource configuration patterns collection interval (seconds). Default 43200 (12h), minimum 3600 (1h) | `43200` |
@@ -143,6 +146,8 @@ The operator uses Guaranteed QoS for stable performance:
 #### Status interval
 
 - **statusUpdateIntervalSeconds**: How frequently the operator writes status to the ConfigMap (default: 60 seconds). Lower values provide more real-time status but increase API calls; higher values reduce API load but status may be slightly stale.
+- **reregistrationIntervalHours**: How often to re-register with kube9-server (default: 24 hours)
+- **serverUrl**: The kube9-server API endpoint used by the operator (default: https://api.kube9.io)
 
 #### Metrics Collection Intervals (`metrics.intervals`)
 
@@ -538,6 +543,8 @@ Complete reference of all configurable values:
 | `rbac.create` | Create RBAC resources (ClusterRole and ClusterRoleBinding) | `true` |
 | `logLevel` | Log level (`debug`, `info`, `warn`, `error`) | `"info"` |
 | `statusUpdateIntervalSeconds` | Status ConfigMap update interval (seconds) | `60` |
+| `reregistrationIntervalHours` | Re-registration interval with kube9-server (hours) | `24` |
+| `serverUrl` | kube9-server API URL | `"https://api.kube9.io"` |
 | `metrics.intervals.clusterMetadata` | Cluster metadata collection interval (seconds). Default 86400 (24h), minimum 3600 (1h) | `86400` |
 | `metrics.intervals.resourceInventory` | Resource inventory collection interval (seconds). Default 21600 (6h), minimum 1800 (30m) | `21600` |
 | `metrics.intervals.resourceConfigurationPatterns` | Resource configuration patterns collection interval (seconds). Default 43200 (12h), minimum 3600 (1h) | `43200` |

--- a/charts/kube9-operator/TESTING.md
+++ b/charts/kube9-operator/TESTING.md
@@ -116,7 +116,7 @@ The operator detects its namespace via the downward API and advertises it in the
    grep -E 'kind: Secret|API_KEY' /tmp/rendered.yaml && echo 'Unexpected Secret or API_KEY' && exit 1 || true
    ```
 
-3. **Test with custom values.yaml:**
+3. **Test with custom values.yaml (no apiKey):**
    ```bash
    cat > /tmp/test-values.yaml <<EOF
    logLevel: debug
@@ -164,7 +164,7 @@ The operator detects its namespace via the downward API and advertises it in the
    helm package charts/kube9-operator
    ```
 
-2. **Verify .tgz file is created:**
+2. **Verify package artifact:**
    ```bash
    ls -lh kube9-operator-*.tgz
    ```
@@ -185,21 +185,21 @@ The operator detects its namespace via the downward API and advertises it in the
 
 ### Phase 4: Cleanup
 
-1. **Delete Kind cluster:**
-   ```bash
-   kind delete cluster --name kube9-test
-   ```
+```bash
+kind delete cluster --name kube9-test
+```
 
 ## Expected results summary
 
-- No chart-managed Secret named `kube9-operator-config`
-- No `API_KEY` environment variable in rendered manifests for default values
-- Status ConfigMap reports `mode="operated"` and `tier="free"` for default install
+- No chart-managed Secret named `kube9-operator-config` and no `API_KEY` environment variable in rendered manifests for default values
+- Status ConfigMap reports `mode="operated"` and `tier="free"` for default install when healthy
 - Pod reaches Ready without crash loops
+- `helm lint` passes; upgrade with `--reuse-values` preserves prior values
 
 ## Troubleshooting
 
 ### Operator pod not starting
+
 - Check logs: `kubectl logs -n kube9-system deployment/kube9-operator`
 - Verify RBAC: `kubectl get role,rolebinding,clusterrole,clusterrolebinding -n kube9-system`
 - Check image: `kubectl describe pod -n kube9-system -l app.kubernetes.io/name=kube9-operator`
@@ -214,7 +214,7 @@ The operator detects its namespace via the downward API and advertises it in the
 - [ ] Default installation works
 - [ ] `helm lint` passes with no errors
 - [ ] `helm template` renders with no operator credential Secret and no `API_KEY` env var for default values
-- [ ] Upgrade works correctly
+- [ ] Upgrade with `--reuse-values` works correctly
 - [ ] Uninstall removes chart-owned workload objects
 - [ ] Package created successfully
 - [ ] Package install works correctly

--- a/scripts/test-helm-chart.sh
+++ b/scripts/test-helm-chart.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Helm Chart Testing Script
-# This script tests the kube9-operator Helm chart with both free and pro tier configurations
+# This script tests the kube9-operator Helm chart (default install; no Helm apiKey surface)
 
 set -e
 
@@ -8,7 +8,6 @@ CHART_DIR="charts/kube9-operator"
 RELEASE_NAME="kube9-operator"
 NAMESPACE="kube9-system"
 KIND_CLUSTER="kube9-test"
-TEST_API_KEY="kdy_test_12345"
 
 echo "=========================================="
 echo "kube9-operator Helm Chart Testing"
@@ -83,58 +82,28 @@ echo ""
 echo "Phase 2: Helm Template Validation"
 echo "----------------------------------"
 
-echo "Testing free tier (no API key)..."
-FREE_TIER_OUTPUT=$(helm template "$RELEASE_NAME" "$CHART_DIR" \
-    --namespace "$NAMESPACE" \
-    --set apiKey="")
+echo "Testing default install (no API key Secret, no API_KEY env)..."
+TEMPLATE_OUTPUT=$(helm template "$RELEASE_NAME" "$CHART_DIR" \
+    --namespace "$NAMESPACE")
 
-if echo "$FREE_TIER_OUTPUT" | grep -q "kind: Secret"; then
-    error "Secret should NOT be created in free tier"
+if echo "$TEMPLATE_OUTPUT" | grep -q "kind: Secret"; then
+    error "Chart must not render a Secret for API keys"
     exit 1
 else
-    success "Secret correctly NOT created in free tier"
+    success "No Secret rendered for default install"
 fi
 
-if echo "$FREE_TIER_OUTPUT" | grep -q "API_KEY"; then
-    error "API_KEY env var should NOT be set in free tier"
+if echo "$TEMPLATE_OUTPUT" | grep -q "API_KEY"; then
+    error "API_KEY env var must not appear in rendered manifests"
     exit 1
 else
-    success "API_KEY env var correctly NOT set in free tier"
+    success "API_KEY env var correctly absent"
 fi
 
-if echo "$FREE_TIER_OUTPUT" | grep -q "kind: Deployment"; then
+if echo "$TEMPLATE_OUTPUT" | grep -q "kind: Deployment"; then
     success "Deployment template renders correctly"
 else
     error "Deployment template failed to render"
-    exit 1
-fi
-
-echo ""
-echo "Testing pro tier (with API key)..."
-PRO_TIER_OUTPUT=$(helm template "$RELEASE_NAME" "$CHART_DIR" \
-    --namespace "$NAMESPACE" \
-    --set apiKey="$TEST_API_KEY")
-
-if echo "$PRO_TIER_OUTPUT" | grep -q "kind: Secret"; then
-    success "Secret correctly created in pro tier"
-else
-    error "Secret should be created in pro tier"
-    exit 1
-fi
-
-if echo "$PRO_TIER_OUTPUT" | grep -q "API_KEY"; then
-    success "API_KEY env var correctly set in pro tier"
-else
-    error "API_KEY env var should be set in pro tier"
-    exit 1
-fi
-
-# Verify Secret name
-SECRET_NAME=$(echo "$PRO_TIER_OUTPUT" | grep -A 5 "kind: Secret" | grep "name:" | awk '{print $2}')
-if [ "$SECRET_NAME" = "${RELEASE_NAME}-config" ]; then
-    success "Secret name is correct: $SECRET_NAME"
-else
-    error "Secret name mismatch. Expected: ${RELEASE_NAME}-config, Got: $SECRET_NAME"
     exit 1
 fi
 
@@ -144,11 +113,7 @@ echo ""
 echo "Phase 3: NOTES.txt Validation"
 echo "------------------------------"
 
-FREE_NOTES=$(helm template "$RELEASE_NAME" "$CHART_DIR" --namespace "$NAMESPACE" | grep -A 20 "NOTES.txt" || echo "")
-PRO_NOTES=$(helm template "$RELEASE_NAME" "$CHART_DIR" --namespace "$NAMESPACE" --set apiKey="$TEST_API_KEY" | grep -A 20 "NOTES.txt" || echo "")
-
-# Check NOTES.txt content (this is tricky since NOTES.txt is rendered separately)
-info "NOTES.txt will be validated during actual installation"
+info "NOTES.txt output is validated on helm install (helm get notes)"
 echo ""
 
 # Phase 4: Package Creation
@@ -257,60 +222,6 @@ if [ "$SKIP_CLUSTER" = false ]; then
     kubectl logs -n "$NAMESPACE" deployment/"$RELEASE_NAME" --tail=20 || true
     
     echo ""
-    echo "Testing Pro Tier Upgrade..."
-    echo "---------------------------"
-    
-    helm upgrade "$RELEASE_NAME" "$CHART_DIR" \
-        --namespace "$NAMESPACE" \
-        --set apiKey="$TEST_API_KEY" \
-        --reuse-values \
-        --wait \
-        --timeout 5m
-    
-    success "Pro tier upgrade completed"
-    
-    # Verify Secret IS created
-    if kubectl get secret "${RELEASE_NAME}-config" -n "$NAMESPACE" &>/dev/null; then
-        success "Secret correctly exists in pro tier"
-    else
-        error "Secret should exist in pro tier"
-        exit 1
-    fi
-    
-    # Wait for pod restart
-    echo "Waiting for operator pod to restart..."
-    sleep 15
-    kubectl wait --for=condition=ready pod \
-        -l app.kubernetes.io/name=kube9-operator \
-        -n "$NAMESPACE" \
-        --timeout=120s
-    success "Operator pod restarted and ready"
-    
-    # Verify status shows enabled mode
-    echo "Checking updated status..."
-    sleep 10
-    
-    STATUS_MODE=$(kubectl get configmap kube9-operator-status -n "$NAMESPACE" -o jsonpath='{.data.status}' | jq -r '.mode' 2>/dev/null || echo "")
-    STATUS_REGISTERED=$(kubectl get configmap kube9-operator-status -n "$NAMESPACE" -o jsonpath='{.data.status}' | jq -r '.registered' 2>/dev/null || echo "")
-    
-    if [ "$STATUS_MODE" = "enabled" ]; then
-        success "Status mode is correct: $STATUS_MODE"
-    else
-        error "Status mode incorrect. Expected: enabled, Got: $STATUS_MODE"
-    fi
-    
-    if [ "$STATUS_REGISTERED" = "false" ]; then
-        success "Status registered is correct: $STATUS_REGISTERED (test key will fail)"
-    else
-        warning "Status registered: $STATUS_REGISTERED (may have succeeded unexpectedly)"
-    fi
-    
-    # Check operator logs for registration attempt
-    echo ""
-    echo "Operator logs after upgrade (last 30 lines):"
-    kubectl logs -n "$NAMESPACE" deployment/"$RELEASE_NAME" --tail=30 || true
-    
-    echo ""
     echo "Testing Uninstall..."
     echo "-------------------"
     
@@ -348,7 +259,7 @@ echo "=========================================="
 echo ""
 echo "Summary:"
 echo "  ✓ Helm lint passed"
-echo "  ✓ Template rendering validated (free & pro tier)"
+echo "  ✓ Template rendering validated (default install)"
 echo "  ✓ Package created and validated"
 if [ "$SKIP_CLUSTER" = false ]; then
     echo "  ✓ Cluster testing completed"

--- a/scripts/test-helm-chart.sh
+++ b/scripts/test-helm-chart.sh
@@ -164,7 +164,7 @@ if [ "$SKIP_CLUSTER" = false ]; then
     success "Cluster is ready"
     
     echo ""
-    echo "Testing Free Tier Installation..."
+    echo "Testing Default Install..."
     echo "----------------------------------"
     
     helm install "$RELEASE_NAME" "$CHART_DIR" \
@@ -173,7 +173,7 @@ if [ "$SKIP_CLUSTER" = false ]; then
         --wait \
         --timeout 5m
     
-    success "Free tier installation completed"
+    success "Default install completed"
     
     # Verify operator pod
     echo "Waiting for operator pod to be ready..."
@@ -185,10 +185,10 @@ if [ "$SKIP_CLUSTER" = false ]; then
     
     # Verify Secret is NOT created
     if kubectl get secret "${RELEASE_NAME}-config" -n "$NAMESPACE" &>/dev/null; then
-        error "Secret should NOT exist in free tier"
+        error "Secret should NOT exist for default install"
         exit 1
     else
-        success "Secret correctly does NOT exist in free tier"
+        success "Secret correctly does NOT exist for default install"
     fi
     
     # Verify status ConfigMap

--- a/scripts/validate-chart.js
+++ b/scripts/validate-chart.js
@@ -33,10 +33,6 @@ function warning(msg) {
   console.log(`${YELLOW}⚠${RESET} ${msg}`);
 }
 
-function info(msg) {
-  console.log(`ℹ  ${msg}`);
-}
-
 let hasErrors = false;
 
 console.log('Helm Chart Structure Validation');
@@ -53,7 +49,7 @@ if (fs.existsSync(chartYaml)) {
     error('Chart.yaml does not use apiVersion: v2');
     hasErrors = true;
   }
-  
+
   if (content.includes('name: kube9-operator')) {
     success('Chart name is correct');
   } else {
@@ -71,10 +67,15 @@ const valuesYaml = path.join(CHART_DIR, 'values.yaml');
 if (fs.existsSync(valuesYaml)) {
   const content = fs.readFileSync(valuesYaml, 'utf8');
   success('values.yaml exists');
-  
-  // Check for required values
+
+  if (/\bapiKey\b/i.test(content) || content.includes('API_KEY')) {
+    error('values.yaml must not define apiKey / API_KEY Helm surface');
+    hasErrors = true;
+  } else {
+    success('values.yaml has no apiKey / API_KEY keys');
+  }
+
   const requiredValues = [
-    'apiKey:',
     'image:',
     'resources:',
     'serviceAccount:',
@@ -83,7 +84,7 @@ if (fs.existsSync(valuesYaml)) {
     'statusUpdateIntervalSeconds:',
     'serverUrl:'
   ];
-  
+
   for (const value of requiredValues) {
     if (content.includes(value)) {
       success(`  Contains: ${value}`);
@@ -113,7 +114,7 @@ const requiredTemplates = [
   'rolebinding.yaml',
   'clusterrole.yaml',
   'clusterrolebinding.yaml',
-  'secret.yaml',
+  'persistentvolumeclaim.yaml',
   'NOTES.txt'
 ];
 
@@ -128,64 +129,40 @@ for (const template of requiredTemplates) {
   }
 }
 
-// Validate secret.yaml conditional logic
-console.log('\nValidating secret.yaml conditional logic...');
-const secretYaml = path.join(TEMPLATES_DIR, 'secret.yaml');
-if (fs.existsSync(secretYaml)) {
-  const content = fs.readFileSync(secretYaml, 'utf8');
-  
-  if (content.includes('{{- if .Values.apiKey }}')) {
-    success('Secret template uses conditional: {{- if .Values.apiKey }}');
-  } else {
-    error('Secret template missing conditional check');
-    hasErrors = true;
-  }
-  
-  if (content.includes('{{- end }}')) {
-    success('Secret template properly closes conditional');
-  } else {
-    error('Secret template missing closing {{- end }}');
-    hasErrors = true;
-  }
-  
-  if (content.includes('kube9-operator.fullname')) {
-    success('Secret uses fullname helper');
-  } else {
-    warning('Secret may not use fullname helper');
-  }
-} else {
-  error('secret.yaml not found');
+if (existingTemplates.includes('secret.yaml')) {
+  error('secret.yaml must not exist (chart does not ship an API key Secret)');
   hasErrors = true;
+} else {
+  success('No secret.yaml template (expected)');
 }
 
-// Validate deployment.yaml conditional logic
-console.log('\nValidating deployment.yaml conditional logic...');
+// Validate deployment.yaml
+console.log('\nValidating deployment.yaml...');
 const deploymentYaml = path.join(TEMPLATES_DIR, 'deployment.yaml');
 if (fs.existsSync(deploymentYaml)) {
   const content = fs.readFileSync(deploymentYaml, 'utf8');
-  
-  if (content.includes('{{- if .Values.apiKey }}')) {
-    success('Deployment template uses conditional for API_KEY env');
-  } else {
-    error('Deployment template missing conditional for API_KEY');
-    hasErrors = true;
-  }
-  
+
   if (content.includes('API_KEY')) {
-    success('Deployment template includes API_KEY environment variable');
-  } else {
-    error('Deployment template missing API_KEY environment variable');
+    error('Deployment must not reference API_KEY');
     hasErrors = true;
+  } else {
+    success('Deployment has no API_KEY environment variable');
   }
-  
+
+  if (content.includes('apiKey') || content.includes('.Values.apiKey')) {
+    error('Deployment must not reference apiKey values');
+    hasErrors = true;
+  } else {
+    success('Deployment has no apiKey / .Values.apiKey references');
+  }
+
   if (content.includes('secretKeyRef')) {
-    success('Deployment uses secretKeyRef for API_KEY');
-  } else {
-    error('Deployment missing secretKeyRef for API_KEY');
+    error('Deployment must not use secretKeyRef for credentials from this chart');
     hasErrors = true;
+  } else {
+    success('Deployment has no secretKeyRef');
   }
-  
-  // Check health probes
+
   if (content.includes('/healthz') && content.includes('/readyz')) {
     success('Deployment includes health probes');
   } else {
@@ -197,24 +174,24 @@ if (fs.existsSync(deploymentYaml)) {
   hasErrors = true;
 }
 
-// Validate NOTES.txt conditional logic
-console.log('\nValidating NOTES.txt conditional logic...');
+// Validate NOTES.txt
+console.log('\nValidating NOTES.txt...');
 const notesTxt = path.join(TEMPLATES_DIR, 'NOTES.txt');
 if (fs.existsSync(notesTxt)) {
   const content = fs.readFileSync(notesTxt, 'utf8');
-  
-  if (content.includes('{{- if .Values.apiKey }}')) {
-    success('NOTES.txt uses conditional for pro tier message');
-  } else {
-    error('NOTES.txt missing conditional check');
+  const lower = content.toLowerCase();
+
+  if (lower.includes('apikey') || content.includes('API_KEY')) {
+    error('NOTES.txt must not reference apiKey / API_KEY');
     hasErrors = true;
+  } else {
+    success('NOTES.txt has no apiKey / API_KEY references');
   }
-  
-  if (content.includes('{{- else }}')) {
-    success('NOTES.txt includes else clause for free tier');
+
+  if (content.includes('{{ .Chart.Name }}') || content.includes('{{ .Release.Name }}')) {
+    success('NOTES.txt includes standard Helm placeholders');
   } else {
-    error('NOTES.txt missing else clause');
-    hasErrors = true;
+    warning('NOTES.txt may be missing expected Helm placeholders');
   }
 } else {
   error('NOTES.txt not found');
@@ -226,7 +203,7 @@ console.log('\nValidating helper templates...');
 const helpersTpl = path.join(TEMPLATES_DIR, '_helpers.tpl');
 if (fs.existsSync(helpersTpl)) {
   const content = fs.readFileSync(helpersTpl, 'utf8');
-  
+
   const requiredHelpers = [
     'kube9-operator.name',
     'kube9-operator.fullname',
@@ -234,9 +211,9 @@ if (fs.existsSync(helpersTpl)) {
     'kube9-operator.selectorLabels',
     'kube9-operator.serviceAccountName'
   ];
-  
+
   for (const helper of requiredHelpers) {
-    if (content.includes(`"${helper}"`)) {
+    if (content.includes(helper)) {
       success(`Helper exists: ${helper}`);
     } else {
       error(`Helper missing: ${helper}`);
@@ -261,4 +238,3 @@ if (hasErrors) {
   console.log('  3. Run: ./scripts/test-helm-chart.sh');
   process.exit(0);
 }
-


### PR DESCRIPTION
## Description

Updates chart validation (`scripts/validate-chart.js`), the Helm test script, CI, and documentation so they match the chart as implemented: no Helm `apiKey` value, no API key Secret template, and no `API_KEY` env injection from templates. Root and chart READMEs, CONTRIBUTING, chart testing guides, and the bug report template no longer instruct `--set apiKey` or equivalent.

## Motivation and Context

Implements [#26](https://github.com/alto9/kube9-operator/issues/26) (Helm slice of epic [#11](https://github.com/alto9/kube9-operator/issues/11)).

Closes #26

## Type of Change

- [x] Documentation update
- [x] Test update

## How Has This Been Tested?

- [x] All new and existing tests pass (`npm test`)
- [x] `npm run lint`
- [x] `node scripts/validate-chart.js`
- [x] `helm lint charts/kube9-operator`
- [x] `./scripts/test-helm-chart.sh` (Kind phase skipped when kind is not installed)

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)

## How to Test this Work

```bash
node scripts/validate-chart.js
./scripts/test-helm-chart.sh
helm template kube9-operator charts/kube9-operator --namespace kube9-system | grep -iE 'apiKey|API_KEY' || echo OK
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation and Helm chart validation/test/CI scripts, but they may break existing install/upgrade instructions for users who previously relied on `--set apiKey` examples.
> 
> **Overview**
> Updates CI, validation, and test automation to **enforce that the Helm chart never renders an API-key `Secret` or injects `API_KEY`**, and removes the pro-tier `--set apiKey` paths from `helm template` checks.
> 
> Documentation is rewritten to match this policy: root/chart READMEs, `CONTRIBUTING.md`, testing guides, and the bug-report template drop `apiKey` examples and reposition server connectivity/registration as *runtime concerns outside Helm values*, with minor wording tweaks (e.g., `serverUrl` defaults/examples and troubleshooting headings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e4696ece2f1cd95777934e1840db54320efbb26. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->