### PR TITLE
docs: align user-facing docs with self-contained operator (#28)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,8 @@
 # out/kubeconfig, or any context that reaches the API—including kubectl proxy,
 # SSH tunnels, or VPN). The operator uses @kubernetes/client-node loadFromDefault().
 
-# Required at runtime (npm dev scripts default SERVER_URL if unset)
-SERVER_URL=https://api.kube9.dev
+# Optional override — npm dev scripts default SERVER_URL when unset (see package.json)
+# SERVER_URL=https://api.kube9.io
 
 # Optional
 LOG_LEVEL=info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# [Unreleased]
+
+### BREAKING CHANGES (documentation)
+
+Documentation for installing and configuring the operator no longer describes API keys, Pro-tier registration, or centralized server communication as part of the default Helm chart path. Users who followed older guides should treat the operator as **fully open source and in-cluster**: follow the current [README](README.md) and [charts/kube9-operator/README.md](charts/kube9-operator/README.md) for supported configuration.
+
+### Documentation
+
+* **docs:** remove API key and remote-server install flows from README and Helm chart guide; align status and troubleshooting with self-contained operation ([#28](https://github.com/alto9/kube9-operator/issues/28))
+
 # [1.9.0](https://github.com/alto9/kube9-operator/compare/v1.8.0...v1.9.0) (2026-04-15)
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -327,8 +327,7 @@ helm lint charts/kube9-operator
 
 # Test template rendering
 helm template kube9-operator charts/kube9-operator \
-  --namespace kube9-system \
-  --set apiKey=test123
+  --namespace kube9-system
 
 # Test installation in minikube
 npm run deploy:minikube

--- a/README.md
+++ b/README.md
@@ -12,34 +12,22 @@ The kube9-operator is the foundation of the kube9 ecosystem. It performs Kuberne
 
 The operator works with the kube9 VS Code extension and optional Helm-based UI components to provide cluster management capabilities:
 
-- **Basic mode** (no operator) - VS Code extension provides kubectl-only operations
-- **Free tier** (operated mode) - Operator performs Well-Architected Framework checks and generates point-in-time reports. VS Code extension provides local webviews and basic resource management
-- **Pro tier** (enabled mode) - Operator establishes scheduled data reporting to kube9-server. AI-powered insights, advanced dashboards, and rich UIs are enabled
+- **Basic mode** (no operator) — VS Code extension provides kubectl-focused workflows
+- **Operated mode** (operator installed) — The operator runs Well-Architected Framework checks on a schedule, persists findings and events in-cluster, and publishes status to a ConfigMap for the extension and other consumers
 
-The operator is installed via Helm and requires no ingress - all communication is outbound to kube9-server for Pro tier features.
+The operator is installed via Helm and requires no ingress. It is **fully open source and self-contained**: assessments, storage, and status run inside the cluster without credentials or remote sign-in configured through this chart.
 
 ## Features
 
-### Free Tier (No API Key)
+### Core capabilities
 ✅ Kubernetes Well-Architected Framework validation on schedule  
-✅ Point-in-time framework assessment reports  
-✅ Status exposure via ConfigMap  
-✅ Cluster tier detection for VS Code extension and UI components  
-✅ Health monitoring  
-✅ Minimal resource footprint (~100m CPU, 128Mi RAM)  
-✅ No external communication
+✅ Assessment results and operator state stored in-cluster (SQLite)  
+✅ Status exposure via ConfigMap for the VS Code extension  
+✅ Health and metrics endpoints for the pod  
+✅ Minimal configurable resource footprint (see Helm defaults)  
+✅ Optional ArgoCD and Trivy awareness when you configure those integrations  
 
-### Pro Tier (With API Key)
-✨ All Free tier features  
-✨ Registration with kube9-server  
-✨ Scheduled data reporting (sanitized metrics transmission)  
-✨ Server responses include updated insights and recommendations  
-✨ Enables AI-powered features in VS Code extension  
-✨ Enhanced dashboards and insights  
-✨ Advanced cluster analytics  
-✨ Continuous framework compliance tracking
-
-### ArgoCD Awareness
+### ArgoCD awareness
 🔍 Automatic ArgoCD detection  
 🔍 Configurable detection behavior  
 🔍 Status exposed via OperatorStatus ConfigMap  
@@ -53,7 +41,7 @@ The operator automatically detects if ArgoCD is installed in your cluster and ex
 ┌─────────────────────────────────────┐
 │  VS Code Extension                  │
 │  - Reads operator status            │
-│  - Enables features based on tier   │
+│  - Surfaces in-cluster insights     │
 └─────────────────────────────────────┘
               │ reads
               ↓
@@ -63,22 +51,14 @@ The operator automatically detects if ArgoCD is installed in your cluster and ex
 │  │ kube9-system namespace        │  │
 │  │  ┌─────────────────────────┐  │  │
 │  │  │ kube9-operator          │  │  │
-│  │  │ - Mode: operated/enabled│  │  │
-│  │  │ - Writes status         │  │  │
+│  │  │ - Assessments + storage │  │  │
+│  │  │ - Writes status CM      │  │  │
 │  │  └─────────────────────────┘  │  │
 │  │  ┌─────────────────────────┐  │  │
 │  │  │ Status ConfigMap        │  │  │
-│  │  │ - tier: free/pro        │  │  │
-│  │  │ - health: healthy       │  │  │
+│  │  │ - mode / tier / health  │  │  │
 │  │  └─────────────────────────┘  │  │
 │  └───────────────────────────────┘  │
-└─────────────────────────────────────┘
-              │ (Pro tier only)
-              ↓ registers
-┌─────────────────────────────────────┐
-│  kube9-server (api.kube9.dev)       │
-│  - Validates API keys               │
-│  - Enables Pro features             │
 └─────────────────────────────────────┘
 ```
 
@@ -96,27 +76,13 @@ The operator automatically detects if ArgoCD is installed in your cluster and ex
 
 The operator is conventionally installed in the `kube9-system` namespace:
 
-**Install Free Tier:**
-
 ```bash
 # Add Helm repository
 helm repo add kube9 https://charts.kube9.io
 helm repo update
 
-# Install operator (no API key = free tier)
+# Install operator
 helm install kube9-operator kube9/kube9-operator \
-  --namespace kube9-system \
-  --create-namespace
-```
-
-**Install Pro Tier:**
-
-1. **Get your API key** from [portal.kube9.dev](https://portal.kube9.dev)
-
-2. **Install with API key:**
-```bash
-helm install kube9-operator kube9/kube9-operator \
-  --set apiKey=kdy_prod_YOUR_KEY_HERE \
   --namespace kube9-system \
   --create-namespace
 ```
@@ -126,14 +92,7 @@ helm install kube9-operator kube9/kube9-operator \
 The operator can be installed in any namespace. It will automatically detect its location:
 
 ```bash
-# Install in custom namespace (free tier example)
 helm install kube9-operator kube9/kube9-operator \
-  --namespace my-custom-namespace \
-  --create-namespace
-
-# Install in custom namespace (pro tier example)
-helm install kube9-operator kube9/kube9-operator \
-  --set apiKey=kdy_prod_YOUR_KEY_HERE \
   --namespace my-custom-namespace \
   --create-namespace
 ```
@@ -164,7 +123,6 @@ kubectl get configmap kube9-operator-status -n kube9-system -o jsonpath='{.data.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `apiKey` | Optional API key for Pro tier | `""` |
 | `image.repository` | Operator image repository | `ghcr.io/alto9/kube9-operator` |
 | `image.tag` | Operator image tag | `1.0.0` |
 | `resources.requests.cpu` | CPU request | `100m` |
@@ -173,7 +131,6 @@ kubectl get configmap kube9-operator-status -n kube9-system -o jsonpath='{.data.
 | `resources.limits.memory` | Memory limit | `256Mi` |
 | `logLevel` | Log level (debug, info, warn, error) | `info` |
 | `statusUpdateIntervalSeconds` | Status update frequency | `60` |
-| `serverUrl` | kube9-server URL (Pro tier) | `https://api.kube9.dev` |
 | `argocd.autoDetect` | Enable automatic ArgoCD detection | `true` |
 | `argocd.enabled` | Explicitly enable or disable ArgoCD integration (optional override) | - |
 | `argocd.namespace` | Custom namespace where ArgoCD is installed | `"argocd"` |
@@ -185,8 +142,6 @@ kubectl get configmap kube9-operator-status -n kube9-system -o jsonpath='{.data.
 Create a `values.yaml`:
 
 ```yaml
-apiKey: kdy_prod_YOUR_KEY_HERE
-
 resources:
   requests:
     memory: "256Mi"
@@ -246,17 +201,6 @@ argocd:
 
 ## Upgrading
 
-### Add API Key (Free → Pro)
-
-```bash
-helm upgrade kube9-operator kube9/kube9-operator \
-  --namespace kube9-system \
-  --set apiKey=kdy_prod_YOUR_KEY_HERE \
-  --reuse-values
-```
-
-### Update to New Version
-
 ```bash
 helm repo update
 helm upgrade kube9-operator kube9/kube9-operator \
@@ -304,7 +248,7 @@ The operator will:
 1. **Cluster**: [kube9-localcluster](https://github.com/alto9/kube9-localcluster) `scripts/start.sh` (or any cluster you trust)
 2. **`export KUBECONFIG=.../kube9-localcluster/out/kubeconfig`** (or equivalent)
 3. **`kubectl config current-context`** should match the cluster you intend (e.g. `kube9-demo` when using the localcluster profile)
-4. **Environment variables**: Defaults are set in npm scripts. Override `SERVER_URL`, `LOG_LEVEL`, `DB_PATH`, `POD_NAMESPACE`, `HEALTH_PORT`, etc. in your shell. See [`.env.example`](.env.example) for a template. This process does **not** load `.env` files automatically; export variables in your shell, use [direnv](https://direnv.net/), or another loader so they are present before `npm run dev`.
+4. **Environment variables**: Defaults are set in npm scripts. Override `LOG_LEVEL`, `DB_PATH`, `POD_NAMESPACE`, `HEALTH_PORT`, etc. in your shell. See [`.env.example`](.env.example) for a template. This process does **not** load `.env` files automatically; export variables in your shell, use [direnv](https://direnv.net/), or another loader so they are present before `npm run dev`.
 
 #### Local data directory (`DB_PATH`)
 
@@ -323,11 +267,10 @@ You can run the operator on your machine against **any** cluster your kubeconfig
 
 #### Environment Variables
 
-The operator requires `SERVER_URL` to be set. The npm scripts provide defaults for `SERVER_URL`, `LOG_LEVEL`, and (for dev scripts only) `DB_PATH`, but you can override:
+For local development, `npm run dev` / `npm run dev:watch` set sensible defaults (including `SERVER_URL` for process compatibility). Override as needed:
 
 ```bash
-# Set in your shell
-export SERVER_URL=https://api.kube9.dev
+# Typical local overrides
 export LOG_LEVEL=debug
 export DB_PATH="$PWD/.kube9-data"
 export POD_NAMESPACE=kube9-system
@@ -445,8 +388,7 @@ helm lint charts/kube9-operator
 
 # Test template rendering
 helm template kube9-operator charts/kube9-operator \
-  --namespace kube9-system \
-  --set apiKey=test123
+  --namespace kube9-system
 
 # Test installation in minikube
 npm run deploy:minikube
@@ -468,12 +410,12 @@ metadata:
 data:
   status: |
     {
-      "mode": "enabled",
-      "tier": "pro",
+      "mode": "operated",
+      "tier": "free",
       "version": "1.0.0",
       "health": "healthy",
       "lastUpdate": "2025-11-10T15:30:00Z",
-      "registered": true,
+      "registered": false,
       "error": null,
       "argocd": {
         "detected": true,
@@ -484,27 +426,23 @@ data:
     }
 ```
 
-The VS Code extension reads this ConfigMap to:
-- Determine which features to enable
-- Show appropriate UI (local vs rich web UIs)
-- Display cluster status to the user
+The VS Code extension reads this ConfigMap to discover where the operator runs, surface status, and enable optional experiences that depend on in-cluster signals (for example ArgoCD awareness).
 
-### Tier Modes
+### Operating modes (summary)
 
-| Mode | API Key | Registered | Extension Behavior |
-|------|---------|------------|--------------------|
-| **basic** | No operator | - | kubectl-only operations, show installation prompts |
-| **operated** | Installed, no key | No | Local webviews, basic features, show upgrade prompts |
-| **enabled** | Installed, has key | Yes | Rich UIs from server, AI features, advanced dashboards |
-| **degraded** | Installed, has key | No | Temporary fallback, registration failed |
+| Mode | Operator | Typical extension behavior |
+|------|----------|---------------------------|
+| **basic** | Not installed | kubectl-focused workflows; prompts to install the operator when appropriate |
+| **operated** | Installed | Extension reads local status and cluster signals published by the operator |
+
+Published `mode` / `tier` fields exist for compatibility with older clients; the open-source chart path is fully in-cluster.
 
 ### Security
 
-- **No Ingress Required**: Operator only makes outbound HTTPS connections
-- **API Key Storage**: Stored in Kubernetes Secrets, never logged
-- **Minimal Permissions**: ClusterRole for read-only cluster metadata, Role for ConfigMap writes
-- **Non-Root**: Runs as non-root user with read-only filesystem
-- **No Sensitive Data**: Status exposes no credentials or sensitive cluster information
+- **No ingress required** for the control-plane path this chart installs
+- **Minimal permissions**: ClusterRole for read-only cluster metadata, Role for ConfigMap writes in the release namespace
+- **Non-root**: Runs as non-root user with read-only filesystem where configured
+- **No sensitive credentials in status**: Follow your own secret-management practices for any credentials you use elsewhere in the cluster
 
 ## Troubleshooting
 
@@ -531,16 +469,10 @@ kubectl auth can-i create configmaps --namespace=kube9-system --as=system:servic
 kubectl get role,rolebinding -n kube9-system
 ```
 
-### Pro tier not working
+### Operator unhealthy or status shows errors
 
 ```bash
-# Verify API key Secret exists
-kubectl get secret kube9-operator-config -n kube9-system
-
-# Check registration status in logs
-kubectl logs -n kube9-system deployment/kube9-operator | grep -i registration
-
-# View status with error details
+kubectl logs -n kube9-system deployment/kube9-operator
 kubectl get configmap kube9-operator-status -n kube9-system -o jsonpath='{.data.status}' | jq .
 ```
 
@@ -643,7 +575,7 @@ kube9-operator/
 │   ├── health/                  # Health endpoints
 │   ├── kubernetes/              # Kubernetes client
 │   ├── logging/                 # Structured logging
-│   ├── registration/            # Server registration
+│   ├── registration/            # Legacy module (not used by default Helm install path)
 │   ├── shutdown/                # Graceful shutdown
 │   └── status/                  # Status calculator & writer
 ├── tests/                       # Tests
@@ -657,8 +589,7 @@ kube9-operator/
 ## Related Projects
 
 - **[kube9-vscode](https://github.com/alto9/kube9-vscode)** - VS Code extension (primary consumer)
-- **[kube9-server](https://github.com/alto9/kube9-server)** - Backend server for Pro features
-- **[kube9-portal](https://github.com/alto9/kube9-portal)** - User portal for account management
+- **[kube9-localcluster](https://github.com/alto9/kube9-localcluster)** - Local Kubernetes demo environment for development
 
 ## Documentation
 
@@ -712,8 +643,6 @@ MIT License - see [LICENSE](LICENSE) file for details
 - **Contributing Guide**: [CONTRIBUTING.md](CONTRIBUTING.md) - How to contribute
 - **Security Policy**: [SECURITY.md](SECURITY.md) - Security reporting
 - **Code of Conduct**: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) - Community guidelines
-- **Portal Support**: https://portal.kube9.dev/support
-
 ---
 
 **Built with ❤️ by Alto9 - Making Kubernetes management intelligent**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,57 +45,41 @@ When deploying kube9-operator:
 ### Installation
 - **Review RBAC**: Check ClusterRole and Role permissions before installation
 - **Minimal permissions**: Operator uses least-privilege RBAC
-- **Namespace isolation**: Operator runs in `kube9-system` namespace
+- **Namespace isolation**: Install into a dedicated namespace (for example `kube9-system`)
 - **Non-root**: Operator runs as non-root user
 
 ### Configuration
-- **API key storage**: Store API keys in Kubernetes Secrets (never in ConfigMaps)
-- **Secret management**: Use proper secret management (Sealed Secrets, External Secrets, etc.)
-- **Network policies**: Consider NetworkPolicy to restrict operator egress
-- **Resource limits**: Set appropriate CPU/memory limits
+- **Secret management**: Store any cluster credentials you manage (for example kubeconfigs, cloud tokens) using your platform’s secret tooling—never commit them to the repository
+- **Helm values**: Treat values files like configuration; avoid embedding long-lived secrets in plain text where your policy requires encryption
+- **Network policies**: Consider NetworkPolicy if you need to restrict pod egress
+- **Resource limits**: Set appropriate CPU and memory limits for your environment
 
-### Pro Tier
-- **HTTPS only**: All communication with kube9-server uses HTTPS
-- **API key validation**: Server validates API keys before accepting data
-- **Data sanitization**: Operator sanitizes data before transmission
-- **No sensitive data**: Operator never collects secrets, credentials, or sensitive information
-
-### Free Tier
-- **No external communication**: Operator makes no outbound connections
-- **Local only**: Status exposed via ConfigMap only
-- **No data collection**: No metrics or data collected
+### Runtime
+- **Kubernetes API**: The operator talks to the Kubernetes API like other controllers; protect API access and rotate credentials per your organization’s standards
+- **Optional integrations**: When you enable optional probes (for example Trivy), scope URLs and RBAC to the minimum required
 
 ## Known Security Considerations
 
 ### RBAC Permissions
 The operator requires:
-- **Read-only cluster metadata** (ClusterRole)
-- **ConfigMap write** in kube9-system namespace (Role)
-- **Secret read** in kube9-system namespace (Role, Pro tier only)
+- **Read-only cluster metadata** (ClusterRole) for discovery and assessments
+- **ConfigMap write** in the release namespace (Role) for status
 
 Review the RBAC manifests in `charts/kube9-operator/templates/` before installation.
 
-### Data Collection (Pro Tier)
-- Operator collects sanitized metrics only
-- No secrets, credentials, or sensitive data
-- Resource names are obfuscated before transmission
-- User controls what operator can access via RBAC
+### Data collection and storage
+- Assessment and event data are stored **in-cluster** (for example SQLite on a PVC or emptyDir depending on values)
+- Follow your retention and backup policies for volumes that hold operator data
 
-### Network Security
-- **Egress-only**: Operator initiates all external connections
-- **No ingress**: No cluster ingress required
-- **HTTPS**: All external communication uses TLS
-- **Certificate validation**: Validates server certificates
-
-### Container Security
-- **Non-root**: Runs as non-root user (UID 1000)
-- **Read-only filesystem**: Container filesystem is read-only
-- **Minimal base image**: Uses minimal Node.js base image
+### Container security
+- **Non-root**: Runs as non-root user (UID 1000) where configured
+- **Read-only filesystem**: Container filesystem is read-only where configured
+- **Minimal base image**: Uses a minimal Node.js base image
 - **No shell**: No shell access in production image
 
 ## Security Audit
 
-We welcome security audits and reviews. If you're planning a security audit:
+We welcome security audits and reviews. If you are planning a security audit:
 
 1. Email security@alto9.com to coordinate
 2. We can provide:
@@ -115,7 +99,7 @@ We currently do not have a formal bug bounty program, but we greatly appreciate 
 ## Security Updates
 
 Security updates will be:
-- Released as patch versions (e.g., 1.0.1)
+- Released as patch versions (for example 1.0.1)
 - Documented in CHANGELOG.md
 - Announced via GitHub releases
 - Tagged with security label
@@ -132,4 +116,3 @@ For vulnerabilities, always use: **security@alto9.com**
 ---
 
 **Thank you for helping keep kube9-operator secure!**
-

--- a/charts/kube9-operator/IMPLEMENTATION_SUMMARY.md
+++ b/charts/kube9-operator/IMPLEMENTATION_SUMMARY.md
@@ -1,8 +1,10 @@
 # Helm Chart Testing Implementation Summary
 
+> **Note (2026):** The chart **no longer** exposes Helm values or templates for operator API keys or Pro-tier Secrets. Default validation is **single-path**: install the chart, confirm no chart-managed credential Secret, and verify `helm template` output stays free of `API_KEY`. Historical bullets below that reference `apiKey` / Pro tier describe an earlier design iteration.
+
 ## Overview
 
-This document summarizes the implementation of the Helm chart testing task (19-package-and-test-chart.task.md). The task required manual testing of the Helm chart with both free and pro tier configurations, followed by packaging for distribution.
+This document summarizes the implementation of the Helm chart testing task (19-package-and-test-chart.task.md). The task originally covered manual testing for default and optional credential configurations, followed by packaging for distribution.
 
 ## Decision Verification ✅
 

--- a/charts/kube9-operator/README.md
+++ b/charts/kube9-operator/README.md
@@ -1,16 +1,15 @@
 # kube9-operator Helm Chart
 
-This Helm chart installs the kube9-operator, a Kubernetes operator that enables enhanced features in the [kube9 VS Code extension](https://github.com/alto9/kube9-vscode). The operator provides tier detection, status reporting, and optional Pro tier features with AI-powered insights.
+This Helm chart installs the kube9-operator, a Kubernetes operator that powers Well-Architected Framework validation and in-cluster status for the [kube9 VS Code extension](https://github.com/alto9/kube9-vscode) and other tooling.
 
 ## Overview
 
-The kube9-operator runs in your Kubernetes cluster and bridges your cluster with the kube9 VS Code extension. It enables the extension to determine whether your cluster is in:
+The kube9-operator runs in your Kubernetes cluster and publishes status and assessment-related data locally. The VS Code extension uses this to determine whether your cluster is in:
 
-- **Basic mode** (no operator) - kubectl-only operations
-- **Free tier** (operated mode) - Local webviews and basic resource management
-- **Pro tier** (enabled mode) - AI-powered insights, advanced dashboards, and rich UIs
+- **Basic mode** (no operator) — kubectl-focused workflows
+- **Operated mode** (operator installed) — scheduled assessments, local persistence, and ConfigMap status for the extension
 
-The operator is installed via Helm and requires no ingress - all communication is outbound to kube9-server for Pro tier features.
+The operator is installed via Helm and requires no ingress for the control plane path this chart installs. The chart does not configure API keys, credentials, or remote product sign-in.
 
 ### What This Chart Installs
 
@@ -79,8 +78,6 @@ The following table lists the configurable parameters and their default values:
 | `rbac.create` | Create RBAC resources (ClusterRole and ClusterRoleBinding) | `true` |
 | `logLevel` | Log level for the operator. Options: `debug`, `info`, `warn`, `error` | `"info"` |
 | `statusUpdateIntervalSeconds` | How often the operator updates the status ConfigMap (in seconds) | `60` |
-| `reregistrationIntervalHours` | How often the operator re-registers with kube9-server (in hours, Pro tier only) | `24` |
-| `serverUrl` | URL of the kube9-server API | `"https://api.kube9.io"` |
 | `metrics.intervals.clusterMetadata` | Cluster metadata collection interval (seconds). Default 86400 (24h), minimum 3600 (1h) | `86400` |
 | `metrics.intervals.resourceInventory` | Resource inventory collection interval (seconds). Default 21600 (6h), minimum 1800 (30m) | `21600` |
 | `metrics.intervals.resourceConfigurationPatterns` | Resource configuration patterns collection interval (seconds). Default 43200 (12h), minimum 3600 (1h) | `43200` |
@@ -143,11 +140,9 @@ The operator uses Guaranteed QoS for stable performance:
 - **warn**: Only warnings and errors
 - **error**: Only errors
 
-#### Status Intervals and Server URL
+#### Status interval
 
 - **statusUpdateIntervalSeconds**: How frequently the operator writes status to the ConfigMap (default: 60 seconds). Lower values provide more real-time status but increase API calls; higher values reduce API load but status may be slightly stale.
-- **reregistrationIntervalHours**: How often to re-register with kube9-server (default: 24 hours)
-- **serverUrl**: The kube9-server API endpoint (default: https://api.kube9.io)
 
 #### Metrics Collection Intervals (`metrics.intervals`)
 
@@ -484,28 +479,18 @@ kubectl get role,rolebinding -n kube9-system | grep kube9-operator
 - Check operator logs for permission errors
 - Reinstall with `rbac.create: true` if needed
 
-### Registration Failing
+### Operator reports unhealthy or errors in status
 
-**Symptoms**: Status shows `registered: false` or `mode: degraded`
+**Symptoms**: Status ConfigMap `health` is not `healthy`, or `error` is set
 
 **Diagnosis**:
 
 ```bash
-# Check registration status in logs
-kubectl logs -n kube9-system deployment/kube9-operator | grep -i registration
-
-# View status ConfigMap with error details
+kubectl logs -n kube9-system deployment/kube9-operator
 kubectl get configmap kube9-operator-status -n kube9-system -o jsonpath='{.data.status}' | jq .
 ```
 
-**Common Causes**:
-- Network connectivity: Cluster cannot reach the kube9-server API
-- Server URL incorrect: Wrong `serverUrl` value
-
-**Solutions**:
-- Test connectivity: `kubectl run -it --rm debug --image=curlimages/curl --restart=Never -- curl -v https://api.kube9.io/health`
-- Verify `serverUrl` is set to `https://api.kube9.io`
-- Review operator logs for specific error messages
+**Common causes**: RBAC preventing ConfigMap writes, insufficient CPU/memory, optional integrations (for example Trivy) timing out.
 
 ### RBAC Permission Issues
 
@@ -553,8 +538,6 @@ Complete reference of all configurable values:
 | `rbac.create` | Create RBAC resources (ClusterRole and ClusterRoleBinding) | `true` |
 | `logLevel` | Log level (`debug`, `info`, `warn`, `error`) | `"info"` |
 | `statusUpdateIntervalSeconds` | Status ConfigMap update interval (seconds) | `60` |
-| `reregistrationIntervalHours` | Re-registration interval with kube9-server (hours, Pro tier) | `24` |
-| `serverUrl` | kube9-server API URL | `"https://api.kube9.io"` |
 | `metrics.intervals.clusterMetadata` | Cluster metadata collection interval (seconds). Default 86400 (24h), minimum 3600 (1h) | `86400` |
 | `metrics.intervals.resourceInventory` | Resource inventory collection interval (seconds). Default 21600 (6h), minimum 1800 (30m) | `21600` |
 | `metrics.intervals.resourceConfigurationPatterns` | Resource configuration patterns collection interval (seconds). Default 43200 (12h), minimum 3600 (1h) | `43200` |
@@ -581,5 +564,4 @@ Complete reference of all configurable values:
 
 - **Issues**: https://github.com/alto9/kube9-operator/issues
 - **Discussions**: https://github.com/alto9/kube9/discussions
-- **Portal Support**: https://portal.kube9.dev/support
 

--- a/charts/kube9-operator/TESTING.md
+++ b/charts/kube9-operator/TESTING.md
@@ -19,14 +19,14 @@ Run the automated test script:
 
 ## Manual Testing Steps
 
-### Phase 1: Free Tier Testing
+### Phase 1: Default install
 
 1. **Start a local Kind cluster:**
    ```bash
    kind create cluster --name kube9-test
    ```
 
-2. **Install chart without API key:**
+2. **Install chart:**
    ```bash
    helm install kube9-operator charts/kube9-operator \
      --namespace kube9-system \
@@ -43,23 +43,20 @@ Run the automated test script:
 
 4. **Verify status ConfigMap is created with mode="operated":**
    ```bash
-   # Wait a few seconds for operator to create ConfigMap
    sleep 10
-   
+
    kubectl get configmap kube9-operator-status -n kube9-system -o yaml
-   
-   # Verify mode
+
    kubectl get configmap kube9-operator-status -n kube9-system \
      -o jsonpath='{.data.status}' | jq -r '.mode'
    # Expected: "operated"
-   
-   # Verify tier
+
    kubectl get configmap kube9-operator-status -n kube9-system \
      -o jsonpath='{.data.status}' | jq -r '.tier'
    # Expected: "free"
    ```
 
-5. **Verify Secret is NOT created:**
+5. **Verify no chart-managed operator credential Secret:**
    ```bash
    kubectl get secret kube9-operator-config -n kube9-system
    # Expected: Error: secrets "kube9-operator-config" not found
@@ -68,19 +65,16 @@ Run the automated test script:
 6. **Check operator logs for any errors:**
    ```bash
    kubectl logs -n kube9-system deployment/kube9-operator
-   # Should see: "Configuration loaded" with tier: "free"
-   # Should see: "Secret not found - running in free tier mode"
    ```
 
-7. **Verify NOTES.txt displays correctly:**
+7. **Verify post-install notes:**
    ```bash
    helm get notes kube9-operator -n kube9-system
-   # Should show free tier message with upgrade instructions
    ```
 
-### Testing Custom Namespace Installation
+### Testing custom namespace installation
 
-You can test the operator in any namespace. The operator automatically detects its namespace and advertises it in the status ConfigMap:
+The operator detects its namespace via the downward API and advertises it in the status ConfigMap:
 
 1. **Install in custom namespace:**
    ```bash
@@ -91,18 +85,15 @@ You can test the operator in any namespace. The operator automatically detects i
 
 2. **Verify namespace detection:**
    ```bash
-   # Wait for operator to create ConfigMap
    sleep 10
-   
-   # Verify namespace field in status
+
    kubectl get configmap kube9-operator-status -n test-operator -o json | \
      jq -r '.data.status' | jq '.namespace'
    # Should output: "test-operator"
-   
-   # Verify operator is working correctly
+
    kubectl get configmap kube9-operator-status -n test-operator \
      -o jsonpath='{.data.status}' | jq -r '.mode'
-   # Expected: "operated" (for free tier)
+   # Expected: "operated"
    ```
 
 3. **Clean up custom namespace installation:**
@@ -110,139 +101,67 @@ You can test the operator in any namespace. The operator automatically detects i
    helm uninstall kube9-operator --namespace test-operator
    ```
 
-**Note:** All test phases (Free Tier, Pro Tier, Helm Commands, etc.) can be run in custom namespaces by replacing `kube9-system` with your chosen namespace in the commands. The operator will automatically detect and use the namespace where it's deployed.
-
-### Phase 2: Pro Tier Testing
-
-1. **Upgrade with test API key:**
-   ```bash
-   helm upgrade kube9-operator charts/kube9-operator \
-     --set apiKey=kdy_test_12345 \
-     --namespace kube9-system \
-     --reuse-values
-   ```
-
-2. **Verify Secret is created:**
-   ```bash
-   kubectl get secret kube9-operator-config -n kube9-system -o yaml
-   # Should exist and contain apiKey
-   ```
-
-3. **Wait for pod restart and verify operator attempts registration:**
-   ```bash
-   kubectl wait --for=condition=ready pod \
-     -l app.kubernetes.io/name=kube9-operator \
-     -n kube9-system \
-     --timeout=120s
-   
-   sleep 10  # Give operator time to attempt registration
-   
-   kubectl logs -n kube9-system deployment/kube9-operator --tail=50
-   # Should see registration attempts (will fail with test key)
-   ```
-
-4. **Verify status shows mode="enabled" but registered=false:**
-   ```bash
-   kubectl get configmap kube9-operator-status -n kube9-system \
-     -o jsonpath='{.data.status}' | jq '.'
-   
-   # Expected values:
-   # - mode: "enabled"
-   # - tier: "free" (not registered yet)
-   # - registered: false
-   # - health: "degraded" (API key present but not registered)
-   ```
-
-5. **Check error handling is graceful:**
-   ```bash
-   kubectl get pods -n kube9-system
-   # Pod should be running (not crashing)
-   
-   kubectl get configmap kube9-operator-status -n kube9-system \
-     -o jsonpath='{.data.status}' | jq -r '.error'
-   # Should show error about registration failure (not null)
-   ```
-
-### Phase 3: Helm Commands Testing
+### Phase 2: Helm commands
 
 1. **Run helm lint:**
    ```bash
    helm lint charts/kube9-operator
-   # Should pass with no errors
    ```
 
-2. **Run helm template:**
+2. **Run helm template (no operator credential Secret, no `API_KEY` env):**
    ```bash
-   # Free tier
    helm template kube9-operator charts/kube9-operator \
-     --namespace kube9-system > /tmp/free-tier.yaml
-   
-   # Pro tier
-   helm template kube9-operator charts/kube9-operator \
-     --namespace kube9-system \
-     --set apiKey=kdy_test_12345 > /tmp/pro-tier.yaml
-   
-   # Verify differences
-   diff <(grep -A 5 "kind: Secret" /tmp/free-tier.yaml || echo "No Secret") \
-        <(grep -A 5 "kind: Secret" /tmp/pro-tier.yaml)
-   # Free tier should have no Secret, pro tier should have Secret
+     --namespace kube9-system > /tmp/rendered.yaml
+
+   grep -E 'kind: Secret|API_KEY' /tmp/rendered.yaml && echo 'Unexpected Secret or API_KEY' && exit 1 || true
    ```
 
 3. **Test with custom values.yaml:**
    ```bash
    cat > /tmp/test-values.yaml <<EOF
-   apiKey: kdy_test_12345
    logLevel: debug
    statusUpdateIntervalSeconds: 30
    EOF
-   
+
    helm template kube9-operator charts/kube9-operator \
      --namespace kube9-system \
      -f /tmp/test-values.yaml
-   # Verify custom values are applied
    ```
 
 4. **Test upgrade preserves configuration:**
    ```bash
-   # Install with custom values
    helm install kube9-operator charts/kube9-operator \
      --namespace kube9-system \
      --create-namespace \
      --set logLevel=debug
-   
-   # Upgrade with only apiKey
+
    helm upgrade kube9-operator charts/kube9-operator \
      --namespace kube9-system \
-     --set apiKey=kdy_test_12345 \
      --reuse-values
-   
-   # Verify logLevel is still debug
+
    kubectl get deployment kube9-operator -n kube9-system \
      -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="LOG_LEVEL")].value}'
    # Expected: "debug"
    ```
 
-5. **Test uninstall removes all resources:**
+5. **Test uninstall removes chart-owned resources:**
    ```bash
    helm uninstall kube9-operator --namespace kube9-system
-   
-   # Verify resources are gone
+
    kubectl get deployment kube9-operator -n kube9-system
    # Expected: Error: deployments.apps "kube9-operator" not found
-   
+
    kubectl get secret kube9-operator-config -n kube9-system
    # Expected: Error: secrets "kube9-operator-config" not found
-   
-   kubectl get configmap kube9-operator-status -n kube9-system
-   # Expected: Error: configmaps "kube9-operator-status" not found
    ```
 
-### Phase 4: Packaging
+   The status ConfigMap may remain until deleted manually (created by the operator).
+
+### Phase 3: Packaging
 
 1. **Package the chart:**
    ```bash
    helm package charts/kube9-operator
-   # Should create: kube9-operator-1.0.0.tgz
    ```
 
 2. **Verify .tgz file is created:**
@@ -252,40 +171,31 @@ You can test the operator in any namespace. The operator automatically detects i
 
 3. **Test installing from package:**
    ```bash
-   helm install kube9-operator kube9-operator-1.0.0.tgz \
+   helm install kube9-operator kube9-operator-*.tgz \
      --namespace kube9-system \
      --create-namespace
-   
-   # Verify it works the same as direct install
+
    kubectl wait --for=condition=ready pod \
      -l app.kubernetes.io/name=kube9-operator \
      -n kube9-system \
      --timeout=120s
-   
+
    helm uninstall kube9-operator --namespace kube9-system
    ```
 
-### Phase 5: Cleanup
+### Phase 4: Cleanup
 
 1. **Delete Kind cluster:**
    ```bash
    kind delete cluster --name kube9-test
    ```
 
-## Expected Results Summary
+## Expected results summary
 
-### Free Tier (No API Key)
-- ✅ Secret: **NOT created**
-- ✅ Deployment: **Created** with no API_KEY env var
-- ✅ Status ConfigMap: **mode="operated"**, **tier="free"**, **health="healthy"**
-- ✅ NOTES.txt: **Shows free tier message** with upgrade instructions
-
-### Pro Tier (With API Key)
-- ✅ Secret: **Created** with apiKey
-- ✅ Deployment: **Created** with API_KEY env var from Secret
-- ✅ Status ConfigMap: **mode="enabled"**, **tier="free"** (until registered), **registered=false**, **health="degraded"**
-- ✅ NOTES.txt: **Shows pro tier message**
-- ✅ Registration: **Attempts registration** (fails gracefully with test key)
+- No chart-managed Secret named `kube9-operator-config`
+- No `API_KEY` environment variable in rendered manifests for default values
+- Status ConfigMap reports `mode="operated"` and `tier="free"` for default install
+- Pod reaches Ready without crash loops
 
 ## Troubleshooting
 
@@ -295,23 +205,16 @@ You can test the operator in any namespace. The operator automatically detects i
 - Check image: `kubectl describe pod -n kube9-system -l app.kubernetes.io/name=kube9-operator`
 
 ### Status ConfigMap not created
-- Wait longer (operator updates every 60 seconds by default)
+- Wait longer (operator updates on the configured interval)
 - Check operator logs for errors
-- Verify RBAC permissions allow ConfigMap creation
+- Verify RBAC permissions allow ConfigMap creation in the release namespace
 
-### Registration failing
-- Expected with test API key (`kdy_test_12345`)
-- Check logs for registration attempts
-- Verify SERVER_URL is correct (default: https://api.kube9.dev)
+## Completion checklist
 
-## Completion Checklist
-
-- [ ] Free tier installation works
-- [ ] Pro tier installation works
-- [ ] helm lint passes with no errors
-- [ ] helm template renders correctly
+- [ ] Default installation works
+- [ ] `helm lint` passes with no errors
+- [ ] `helm template` renders with no operator credential Secret and no `API_KEY` env var for default values
 - [ ] Upgrade works correctly
-- [ ] Uninstall removes all resources
+- [ ] Uninstall removes chart-owned workload objects
 - [ ] Package created successfully
 - [ ] Package install works correctly
-

--- a/charts/kube9-operator/values.yaml
+++ b/charts/kube9-operator/values.yaml
@@ -33,7 +33,7 @@ statusUpdateIntervalSeconds: 60
 # Re-registration interval (hours)
 reregistrationIntervalHours: 24
 
-# kube9-server URL (for pro tier)
+# Default SERVER_URL string injected into the pod (chart default; open-source path is in-cluster)
 serverUrl: "https://api.kube9.io"
 
 # ArgoCD integration configuration

--- a/vision.md
+++ b/vision.md
@@ -2,11 +2,11 @@
 
 ## Mission
 
-kube9-operator is the core component of the kube9 open source toolkit, providing Kubernetes Well-Architected Framework validation and cluster insights. The operator runs in clusters, performing scheduled framework assessments and enabling integration with the kube9 VS Code extension and optional Helm-based UI components through secure, outbound communication.
+kube9-operator is the core component of the kube9 open source toolkit, providing Kubernetes Well-Architected Framework validation and cluster insights. The operator runs in clusters, performing scheduled framework assessments and publishing status for the kube9 VS Code extension and optional Helm-based UI components. **Product scope today** is fully self-contained: no API keys or remote sign-in are required for the default open-source install path.
 
 ## Core Purpose
 
-**Why kube9-operator exists**: Kubernetes clusters need continuous Well-Architected Framework validation and intelligent cluster management. The operator performs framework checks on a schedule, generating point-in-time reports in free tier mode and establishing scheduled data reporting to kube9-server when an API key is configured. It serves as the foundation for the kube9 ecosystem, enabling VS Code extension and UI components to provide cluster management capabilities while maintaining strict security boundaries and minimal resource footprint.
+**Why kube9-operator exists**: Kubernetes clusters need continuous Well-Architected Framework validation and intelligent cluster management. The operator performs framework checks on a schedule, persists results in-cluster, and exposes status for tools like the VS Code extension—without requiring credentials bundled in the Helm chart. It serves as the foundation of the kube9 open source experience while maintaining strict security boundaries and a minimal resource footprint.
 
 ## Long-Term Vision
 
@@ -18,7 +18,7 @@ kube9-operator will become the **standard way for clusters to participate in the
 2. **Zero-Trust Security**: No ingress required, all communication is outbound
 3. **Tier Detection**: Enables VS Code extension and UI components to adapt features based on cluster capabilities
 4. **Health Monitoring**: Continuous cluster health assessment and status reporting
-5. **Desktop Pro Gateway**: Secure bridge to kube9-server for Desktop Pro features via historical data storage and operator registration
+5. **Ecosystem integration**: Deep, optional integration with kube9 desktop tooling while keeping the default cluster footprint self-contained
 6. **Minimal Footprint**: Lightweight operator that doesn't impact cluster performance
 
 ### Strategic Goals
@@ -27,7 +27,7 @@ kube9-operator will become the **standard way for clusters to participate in the
 - Establish operator as the standard for kube9 cluster integration
 - Achieve 1,000+ operator installations across diverse cluster types
 - Build trust through transparent security model and minimal resource usage
-- Enable seamless Desktop Pro activation through operator registration and API key configuration
+- Keep default installs frictionless: Helm + RBAC + storage, no external accounts required
 
 **Medium-Term (1-2 years)**
 - Complete remaining data collectors (performance metrics, config patterns, security posture)
@@ -59,7 +59,7 @@ kube9-operator will become the **standard way for clusters to participate in the
 ### 3. Tier-Aware Architecture
 - Supports multiple tiers (basic, operated, enabled, degraded)
 - Clear status exposure for VS Code extension
-- Graceful fallback when Desktop Pro unavailable (free tier continues to work)
+- Graceful degradation when optional integrations are unavailable
 - Transparent tier detection and reporting
 
 ### 4. Operational Excellence
@@ -82,8 +82,8 @@ kube9-operator will become the **standard way for clusters to participate in the
 2. **Tier Detection**: Enables progressive enhancement in VS Code extension based on cluster capabilities
 3. **Minimal Footprint**: Lightweight design that doesn't impact cluster performance
 4. **Security Model**: Transparent security model with minimal permissions and no sensitive data collection
-5. **Progressive Enhancement**: Works in free tier mode, unlocks Pro features when API key provided
-6. **Data Collection Foundation**: Secure, sanitized metrics collection for AI training and insights
+5. **Progressive Enhancement**: Works with the operator alone; optional integrations add richer signals when present
+6. **Data collection foundation**: Structured in-cluster telemetry for assessments and operator-driven insights
 
 ### Differentiation from Competitors
 
@@ -96,13 +96,13 @@ kube9-operator will become the **standard way for clusters to participate in the
 
 ### Free Tier Framework Validation
 
-**Role**: The kube9-operator is the foundation for implementing the Kubernetes Well-Architected Framework, providing validation for all 6 framework pillars. Free tier checks run without an API key, while Desktop Pro features require operator registration with API key for historical data storage.
+**Role**: The kube9-operator is the foundation for implementing the Kubernetes Well-Architected Framework, providing validation for all 6 framework pillars in-cluster for every supported install path.
 
 **Framework Documentation**: Complete framework documentation with all criteria: https://alto9.github.io/kube9/well-architected-framework.html
 
 **Free Tier Responsibilities:**
 
-The operator performs validation checks that require real resource names and cluster access. These checks are available without an API key:
+The operator performs validation checks that require real resource names and cluster access:
 
 **Security Pillar:**
 - Image CVE vulnerability scanning (Trivy/Grype integration)
@@ -137,13 +137,9 @@ The operator performs validation checks that require real resource names and clu
 - Resource efficiency metrics (planned)
 - Workload consolidation opportunities (planned)
 
-**Dual-Tier Architecture:**
+**Architecture (open source):**
 
-The operator works in conjunction with kube9-server for Desktop Pro features:
-- **Free Tier**: Validates configurations requiring real names (CVE scanning, compliance checks). Available without API key.
-- **Desktop Pro**: Stores historical data for Desktop Pro AI agent access. Requires API key for operator registration and historical data storage.
-
-This dual-tier approach provides comprehensive framework coverage while maintaining data privacy.
+The operator stores assessment inputs, events, and derived data **inside the cluster** (for example SQLite on a volume). The VS Code extension and other consumers read published status and query local interfaces—there is no separate “unlock” step configured through this repository’s Helm chart.
 
 ## ArgoCD Integration Vision
 
@@ -173,8 +169,8 @@ This dual-tier approach provides comprehensive framework coverage while maintain
 - View sync status, drift alerts, and deployment history
 - Access basic drift detection summaries
 
-**Intelligence Phase (Desktop Pro)**:
-- AI analysis of drift patterns and root causes
+**Intelligence Phase (future tooling)**:
+- Deeper analysis of drift patterns and root causes
 - Predictive deployment failure detection
 - Configuration optimization recommendations
 - GitOps best practice suggestions
@@ -184,7 +180,7 @@ This dual-tier approach provides comprehensive framework coverage while maintain
 **For Developers**:
 - View ArgoCD Applications directly in VS Code kube9 tree view
 - See drift alerts and sync status without leaving IDE
-- Desktop Pro users can use AI agent with historical context for deployment analysis
+- Power users can combine local operator data with their own AI workflows for deployment analysis
 - Unified interface for both cluster resources and GitOps deployments
 
 **For Platform Teams**:
@@ -199,17 +195,17 @@ This dual-tier approach provides comprehensive framework coverage while maintain
 - **Easy Integration**: Simple Helm install to enable kube9 features
 - **Security Confidence**: Transparent security model with minimal permissions
 - **Performance Assurance**: Lightweight operator that doesn't impact cluster performance
-- **Tier Flexibility**: Choose free tier or Desktop Pro based on needs
+- **Tier Flexibility**: Start with the open-source operator path; add optional integrations when you need them
 
 ### For Developers
 - **Seamless Experience**: Operator enables VS Code extension features automatically
-- **Desktop Pro Activation**: Simple API key configuration enables operator registration and historical data storage for Desktop Pro AI agent
+- **Fast activation**: Helm install plus RBAC-aware namespace placement is enough to light up core VS Code experiences
 - **Health Visibility**: Clear status reporting for cluster health
 - **Multi-Cluster Support**: Manage multiple clusters with consistent operator behavior
 
 ### For Alto9
-- **Ecosystem Foundation**: Operator enables Desktop Pro features and monetization through historical data storage
-- **Data Collection**: Foundation built for secure, sanitized metrics collection for AI training
+- **Ecosystem foundation**: Operator anchors kube9’s open-source cluster experience
+- **Data collection**: Foundation for structured, in-cluster telemetry that powers assessments and dashboards
 - **Market Differentiation**: Unique zero-ingress architecture sets kube9 apart
 - **Scalability**: Operator scales to thousands of clusters efficiently
 
@@ -217,7 +213,7 @@ This dual-tier approach provides comprehensive framework coverage while maintain
 
 ### Adoption
 - 1,000+ operator installations in first year
-- 50%+ of Desktop Pro users have operator installed
+- 50%+ of active kube9 VS Code users run with the operator installed
 - < 5 minute average installation time
 - 4.5+ star rating in Helm charts
 
@@ -236,7 +232,7 @@ This dual-tier approach provides comprehensive framework coverage while maintain
 ### Reliability
 - < 1% operator failure rate
 - < 60 second status update latency
-- 99.9%+ successful Desktop Pro operator registrations
+- 99.9%+ successful operator pod readiness across supported clusters
 - Graceful degradation under all failure scenarios
 
 ## Data Collection Status
@@ -257,152 +253,23 @@ This dual-tier approach provides comprehensive framework coverage while maintain
 - Performance Metrics with Prometheus integration (15min intervals)
 - Security Posture indicators (24h intervals)
 
-**❌ Future: PII Sanitization & Server Integration (Post-Collection):**
-- Obfuscation library (maintains real name → mock name mappings)
-- Outgoing sanitization (replaces real names with mocks before transmission)
-- Transmission client for Pro tier with retry logic and exponential backoff
-- Incoming reconciliation (reverses mocking on AI responses from server)
-- Validation framework ensuring no sensitive data escapes
+**📋 Future work (optional / exploratory):** Additional collectors, stronger anonymization helpers, and richer export paths may land over time. Anything that moves data out of the cluster must remain **explicit, policy-driven, and outside the default Helm values** documented for open-source installs.
 
-**📋 Status**: Collection infrastructure is solid. Two collectors implemented with raw data collection. Sanitization and server transmission are separate future phases.
+## Data lifecycle (in-cluster first)
 
-## Data Lifecycle: Collection → Sanitization → AI → Reconciliation
+### Collection (current and near-term)
+- Collectors gather cluster signals needed for Well-Architected assessments and supporting features
+- Raw operational data stays on operator-attached storage (PVC or emptyDir, depending on chart values)
+- Status snapshots publish to a ConfigMap for lightweight consumers (for example the VS Code extension)
 
-The kube9-operator manages data through four distinct phases:
+### Query and retention
+- SQLite (and related CLIs) provide structured query interfaces for assessments and events
+- Retention knobs in Helm values control how long event history is kept on disk
 
-### Phase 1: Raw Data Collection (Current)
-- Collectors gather raw, unsanitized data from cluster resources
-- Data includes actual resource names, labels, configurations
-- Stored locally in operator pod for verification and future processing
-- No data leaves the cluster at this phase
-- **Status**: Partially implemented (2/5 collectors complete)
-
-### Phase 2: Obfuscation Library (Future)
-- Maintains bidirectional mappings: real name ↔ mock name
-- Example: `my-app-deployment` → `deployment-a7f3b9`
-- Mappings persist across collections for consistency
-- Library stored locally in operator pod
-- Enables reversible sanitization
-- **Status**: Not yet implemented
-
-### Phase 3: Outgoing Sanitization (Future - Desktop Pro Only)
-- Applies obfuscation library to raw collected data
-- Replaces real names with mock equivalents before transmission
-- Ensures no PII or sensitive data leaves the cluster
-- Validates sanitized payload before transmission
-- Transmits to kube9-server via HTTPS POST with API key
-- **Status**: Not yet implemented
-
-### Phase 4: Historical Data Storage (Desktop Pro)
-- Server stores sanitized historical data for Desktop Pro AI agent access
-- Desktop Pro AI agent retrieves historical data to enhance prompts
-- Historical data contains obfuscated names (e.g., `deployment-a7f3b9`)
-- Desktop Pro AI agent uses historical data to build context-rich prompts
-- Prompts sent to customer's AI provider (OpenAI, Anthropic, etc.)
-- No AI processing happens on server - all AI runs client-side via customer's provider
-- **Status**: Not yet implemented
-
-### Design Principles
-
-**Separation of Concerns**: Each phase has a distinct responsibility, enabling independent development and testing.
-
-**Privacy by Default**: Raw data never leaves the cluster. Sanitization is mandatory before any external transmission.
-
-**Reversible Obfuscation**: Mock names can be mapped back to real names, enabling AI insights to reference actual cluster resources.
-
-**Free Tier Benefits**: Collection and local storage work without Desktop Pro, providing value without external connectivity.
-
-**Desktop Pro Enhancement**: Sanitization and server integration enable historical data storage for Desktop Pro AI agent access.
-
-## Historical Data Architecture (Desktop Pro)
-
-### Overview
-
-The operator participates in historical data collection and storage for Desktop Pro. Desktop Pro includes a client-side AI agent that retrieves historical data to enhance prompts sent to the customer's AI provider. The operator does NOT generate proactive insights - it stores historical data for Desktop Pro AI agent access.
-
-### Insights Flow (Egress Only)
-
-**1. Metrics Upload (Every 15-60 minutes)**
-- Operator collects and sanitizes metrics
-- POST to kube9-server `/api/metrics`
-- Server stores for analysis and processes AI insights
-- Server response includes updated insights and recommendations
-- Operator receives and stores updated data from response
-
-**2. Historical Data Storage**
-- Server stores historical data for Desktop Pro AI agent access
-- Historical data contains obfuscated object names
-- Operator maintains obfuscation mappings locally
-
-**3. Desktop Pro AI Agent Access**
-- Desktop Pro AI agent queries server for historical data
-- Server returns historical data with obfuscated names
-- Desktop Pro AI agent uses historical data to enhance prompts
-- Prompts sent to customer's AI provider (OpenAI, Anthropic, etc.)
-- Customer's AI provider returns analysis with historical context
-
-### Historical Data Model
-
-Historical data stored for Desktop Pro AI agent access includes:
-
-**Cluster Metrics:**
-- Resource usage patterns over time
-- Event history and trends
-- Configuration changes
-- Performance metrics
-
-**Data Format:**
-- All data obfuscated before storage
-- Time-series data for trend analysis
-- Structured format for Desktop Pro AI agent queries
-- Efficient storage for quick retrieval
-
-### Security & Privacy
-
-**Name Obfuscation:**
-- All resource names obfuscated before leaving cluster
-- Server never sees real names: `my-app` → `app-x7f3`
-- Bidirectional mapping maintained only in operator
-- De-obfuscation happens only at operator after receiving insights
-
-**Zero-Trust Communication:**
-- All communication is outbound (egress only)
-- No ingress to cluster required
-- Operator polls server on schedule
-- Server cannot push to operator
-
-**Data Minimization:**
-- Only sanitized metrics sent to server
-- No secrets, credentials, or sensitive data
-- User controls what operator can access via RBAC
-
-### Graceful Degradation
-
-**If server unreachable:**
-- Operator continues collecting metrics locally
-- Cached insights remain available to VS Code
-- Polling retries with exponential backoff
-- No impact on cluster operations
-
-**If API key invalid:**
-- Falls back to free tier behavior
-- Local metrics collection continues
-- No insights from server
-- Clear status indication in VS Code
-
-### Performance Characteristics
-
-**Resource Usage:**
-- Insights polling: <10ms CPU, <1MB memory
-- Local storage: ~100KB per 50 insights
-- De-obfuscation: <5ms per insight batch
-- Network: ~50KB per insights fetch
-
-**Latency:**
-- Insights appear within 1 hour of generation
-- Acknowledgements sync within 5 minutes
-- No impact on cluster performance
-- Efficient caching minimizes overhead
+### Design principles
+- **Separation of concerns**: collection, persistence, and status publication evolve independently
+- **Privacy by default**: assume sensitive names and configurations exist; do not document “phone home” paths as part of the default chart
+- **Explicit egress**: any future optional export must be obvious in configuration and security review
 
 ## Data Storage & Query Architecture
 
@@ -492,8 +359,8 @@ kube9-operator
 │   └── (reconcile loop, collectors, server sync, assessments)
 │
 └── query                    # CLI mode: query stored data
-    ├── status               # Operator status, health, registration
-    ├── insights             # AI insights from kube9-server
+    ├── status               # Operator status and health
+    ├── insights             # Derived insights (in-cluster sources)
     │   ├── list             # List with filters (severity, namespace, since)
     │   └── get <id>         # Get specific insight by ID
     ├── assessments          # Framework assessment results
@@ -574,7 +441,7 @@ CREATE TABLE operator_status (
   last_update TEXT NOT NULL
 );
 
--- AI insights from kube9-server
+-- Cached or derived insights (local store)
 CREATE TABLE insights (
   id TEXT PRIMARY KEY,
   cluster_id TEXT NOT NULL,


### PR DESCRIPTION
## Description

Updates user-facing documentation to match the open-source, in-cluster operator: removes Helm/API key install flows, Pro-tier registration narratives, and centralized-server framing from README, Helm chart README, chart testing docs, CHANGELOG, SECURITY, vision, `.env.example`, and CONTRIBUTING.

## Motivation and Context

Closes https://github.com/alto9/kube9-operator/issues/28

## Type of Change

- [x] Documentation update
- [x] Breaking change (documentation): prior docs described API keys and Pro registration; users should follow the updated README and chart README.

## How Has This Been Tested?

- [x] All new and existing tests pass (`npm test`)

## Checklist

- [x] I have updated the documentation accordingly
- [x] All new and existing tests pass (`npm test`)
- [x] I have updated the CHANGELOG.md (if applicable)

Closes #28