### PR TITLE
docs: assessment guides, Prometheus metrics, and scrape hints

### DIFF
--- a/.forge/operations/observability.md
+++ b/.forge/operations/observability.md
@@ -116,6 +116,59 @@ All metrics are exposed at `/metrics` endpoint and follow Prometheus naming conv
 - **Labels**:
   - `type`: Collection type
 
+### Assessment metrics
+
+Assessment runs emit `kube9_operator_assessment_*` series on the same `/metrics` handler as collection and event metrics (`src/assessment/metrics.ts`, wired from `src/assessment/runner.ts`). They use **bounded labels** only (invalid values map to `unknown`) to keep cardinality predictable.
+
+#### `kube9_operator_assessment_runs_total`
+
+- **Type**: Counter
+- **Description**: Count of assessment run **lifecycle observations** by terminal or phase label (each successful run increments `queued`, then `running`, then a terminal `state` such as `completed` or `partial`).
+- **Labels**:
+  - `state`: One of `queued`, `running`, `completed`, `failed`, `partial`, or `unknown` if an unexpected value is passed through safeguards.
+- **Cardinality**: 6 well-known states plus `unknown`; low and stable.
+
+#### `kube9_operator_assessment_checks_total`
+
+- **Type**: Counter
+- **Description**: Total check executions by pillar and outcome.
+- **Labels**:
+  - `pillar`: Well-Architected pillar (`security`, `reliability`, `performance-efficiency`, `cost-optimization`, `operational-excellence`, `sustainability`, or `unknown`).
+  - `status`: Check result (`passing`, `failing`, `warning`, `skipped`, `error`, `timeout`, or `unknown`).
+- **Cardinality**: At most 7 pillar labels × 7 status labels (49 series) for this counter alone; in practice only pillars and statuses that actually run appear.
+
+#### `kube9_operator_assessment_run_duration_seconds`
+
+- **Type**: Histogram
+- **Description**: Wall-clock duration of a full assessment run in seconds (one observation when the run finishes).
+- **Labels**: None.
+- **Buckets**: `[1, 5, 10, 30, 60, 120, 300]` seconds.
+
+#### `kube9_operator_assessment_check_duration_seconds`
+
+- **Type**: Histogram
+- **Description**: Duration of each individual check in seconds.
+- **Labels**:
+  - `pillar`: Same bounded set as `kube9_operator_assessment_checks_total`.
+- **Cardinality**: One histogram per pillar that executed at least one check (up to 6 user-facing pillars plus `unknown`).
+
+#### `kube9_operator_assessment_last_run_timestamp`
+
+- **Type**: Gauge
+- **Description**: Unix epoch seconds when the **last** assessment run completed (updated in `recordRunComplete`).
+- **Labels**: None.
+
+#### `kube9_operator_assessment_last_score`
+
+- **Type**: Gauge
+- **Description**: Score from the last completed run as `100 * passed_checks / total_checks`, or `0` when `total_checks` is 0.
+- **Labels**: None.
+
+**Operational notes**
+
+- After install, scrape the pod’s metrics port (default **8080**, path **`/metrics`**) as documented in the Helm chart README (optional `podAnnotations` for `prometheus.io/*` discovery).
+- To confirm assessment metrics in operated mode, trigger a scheduled or manual assessment, then verify `kube9_operator_assessment_runs_total` increases for `queued` and `running`, `kube9_operator_assessment_checks_total` moves for the pillars you expect, and `kube9_operator_assessment_last_run_timestamp` / `kube9_operator_assessment_last_score` update.
+
 ### Vulnerability scanning metrics (planned, M3)
 
 Exposed only when Trivy-backed scanning is active; when Trivy is absent, these metrics should be zero or omitted per Prometheus registration rules (implementation detail), without failing scrapes.
@@ -127,7 +180,7 @@ Exact metric names and label sets are defined at implementation time and registe
 
 ### Metrics Registry
 - All metrics are registered in a single Prometheus registry
-- Metrics are collected from multiple modules (events, collection, vulnerability scanning when enabled)
+- Metrics are collected from multiple modules (events, collection, assessments, vulnerability scanning when enabled)
 - Registry is exported for use by health server
 
 ## Health Check Logic

--- a/README.md
+++ b/README.md
@@ -602,6 +602,7 @@ kube9-operator/
 - **[Implementation Stories](./ai/sessions/mvp/tickets/)** - Breakdown of implementation work
 - **[API Specifications](./ai/specs/)** - Technical API specs
 - **[Feature Definitions](./ai/features/)** - Feature behavior in Gherkin
+- **[Assessment User Guide](./docs/assessment/user-guide.md)** - End-to-end installation, run modes, CLI usage, and result interpretation
 - **[Built-In Assessment Checks](./docs/assessment/checks.md)** - Reference for all built-in assessment checks, grouped by pillar
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -602,6 +602,7 @@ kube9-operator/
 - **[Implementation Stories](./ai/sessions/mvp/tickets/)** - Breakdown of implementation work
 - **[API Specifications](./ai/specs/)** - Technical API specs
 - **[Feature Definitions](./ai/features/)** - Feature behavior in Gherkin
+- **[Built-In Assessment Checks](./docs/assessment/checks.md)** - Reference for all built-in assessment checks, grouped by pillar
 
 ## Contributing
 

--- a/charts/kube9-operator/README.md
+++ b/charts/kube9-operator/README.md
@@ -2,6 +2,8 @@
 
 This Helm chart installs the kube9-operator, a Kubernetes operator that powers Well-Architected Framework validation and in-cluster status for the [kube9 VS Code extension](https://github.com/alto9/kube9-vscode) and other tooling. It also supports optional integrations (for example ArgoCD awareness and Trivy server detection) configured through values.
 
+Assessment walkthroughs and CLI examples are documented in the repository guide: [`docs/assessment/user-guide.md`](../../docs/assessment/user-guide.md).
+
 ## Overview
 
 The kube9-operator runs in your Kubernetes cluster and publishes status and assessment-related data locally. The VS Code extension uses this to determine whether your cluster is in:

--- a/charts/kube9-operator/README.md
+++ b/charts/kube9-operator/README.md
@@ -63,12 +63,36 @@ kubectl logs -n kube9-system deployment/kube9-operator
 kubectl get configmap kube9-operator-status -n kube9-system -o yaml
 ```
 
+### Prometheus metrics (`/metrics`)
+
+The operator serves Prometheus text exposition on **`http://<pod-ip>:8080/metrics`** on the same port as `/healthz` and `/readyz`. There is no dedicated `Service` in this chart by default; scrape the pod port directly (for example via a `Service`/`ServiceMonitor` you manage, or via the classic pod annotation pattern).
+
+**Optional scrape annotations** — set `podAnnotations` so agents that honor `prometheus.io/*` can discover the target, for example:
+
+```yaml
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "8080"
+  prometheus.io/path: "/metrics"
+```
+
+**Validate assessment metrics** — after the operator has run at least one in-cluster assessment (operated mode), confirm counters move (from your workstation, with `curl` available):
+
+```bash
+kubectl port-forward -n kube9-system deploy/kube9-operator 8080:8080
+# In another terminal:
+curl -s http://127.0.0.1:8080/metrics | grep kube9_operator_assessment_
+```
+
+You should see series such as `kube9_operator_assessment_runs_total`, `kube9_operator_assessment_checks_total`, and gauges/histograms named with the `kube9_operator_assessment_` prefix. Full definitions and label cardinality notes live in `.forge/operations/observability.md` in the application repository.
+
 ## Configuration
 
 The following table lists the configurable parameters and their default values:
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
+| `podAnnotations` | Optional annotations on the operator pod (for example `prometheus.io/scrape`) | `{}` |
 | `image.repository` | Container image repository | `ghcr.io/alto9/kube9-operator` |
 | `image.tag` | Container image tag | `"1.3.0"` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
@@ -533,6 +557,7 @@ Complete reference of all configurable values:
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
+| `podAnnotations` | Optional annotations on the operator pod (for example `prometheus.io/scrape`) | `{}` |
 | `image.repository` | Container image repository | `ghcr.io/alto9/kube9-operator` |
 | `image.tag` | Container image tag | `"1.3.0"` |
 | `image.pullPolicy` | Image pull policy (`IfNotPresent`, `Always`, `Never`) | `IfNotPresent` |

--- a/charts/kube9-operator/templates/deployment.yaml
+++ b/charts/kube9-operator/templates/deployment.yaml
@@ -12,10 +12,14 @@ spec:
   selector:
     matchLabels:
       {{- include "kube9-operator.selectorLabels" . | nindent 6 }}
-  template:
-    metadata:
-      labels:
-        {{- include "kube9-operator.selectorLabels" . | nindent 8 }}
+    template:
+      metadata:
+        labels:
+          {{- include "kube9-operator.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podAnnotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "kube9-operator.serviceAccountName" . }}
       securityContext:

--- a/charts/kube9-operator/templates/deployment.yaml
+++ b/charts/kube9-operator/templates/deployment.yaml
@@ -12,14 +12,14 @@ spec:
   selector:
     matchLabels:
       {{- include "kube9-operator.selectorLabels" . | nindent 6 }}
-    template:
-      metadata:
-        labels:
-          {{- include "kube9-operator.selectorLabels" . | nindent 8 }}
-        {{- with .Values.podAnnotations }}
-        annotations:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "kube9-operator.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "kube9-operator.serviceAccountName" . }}
       securityContext:

--- a/charts/kube9-operator/values.schema.json
+++ b/charts/kube9-operator/values.schema.json
@@ -2,6 +2,11 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "podAnnotations": {
+      "type": "object",
+      "description": "Optional annotations on the operator pod (e.g. prometheus.io/scrape, prometheus.io/port, prometheus.io/path for metrics discovery)",
+      "additionalProperties": { "type": "string" }
+    },
     "argocd": {
       "type": "object",
       "properties": {

--- a/charts/kube9-operator/values.yaml
+++ b/charts/kube9-operator/values.yaml
@@ -20,6 +20,9 @@ serviceAccount:
   create: true
   name: "kube9-operator"
 
+# Optional annotations on the operator pod (e.g. prometheus.io/scrape for metrics discovery)
+podAnnotations: {}
+
 # RBAC configuration
 rbac:
   create: true

--- a/docs/assessment/checks.md
+++ b/docs/assessment/checks.md
@@ -1,0 +1,254 @@
+# Built-In Assessment Checks Reference
+
+This document is the authoritative reference for all checks currently registered in `src/assessment/bootstrap.ts` via `BUILT_IN_CHECKS`.
+
+## Outcome Semantics
+
+- `passing`: The check conditions are satisfied.
+- `warning`: A non-blocking risk or best-practice gap is detected.
+- `failing`: A clear misconfiguration or policy violation is detected.
+- `skipped`: The check cannot run because a required signal/integration is unavailable.
+
+Some checks only emit a subset of these outcomes.
+
+## Security
+
+### `security.run-as-non-root` - Run as Non-Root
+
+- **Purpose:** Ensure workloads do not run containers as root.
+- **Reads:** Pod and container `securityContext.runAsNonRoot` across all namespaces.
+- **Outcomes:** `passing` when all containers inherit or set `runAsNonRoot: true`; `failing` when false or missing.
+- **Prerequisites / optional data sources:** Kubernetes Pod API access.
+- **Example interpretation/remediation:** If a Deployment fails this check, set pod or container `securityContext.runAsNonRoot: true` and use a non-zero `runAsUser`.
+
+### `security.privileged-containers` - No Privileged Containers
+
+- **Purpose:** Detect containers with `privileged: true`.
+- **Reads:** Pod and container security context for all Pods.
+- **Outcomes:** `passing` when no privileged containers are found; `failing` otherwise.
+- **Prerequisites / optional data sources:** Kubernetes Pod API access.
+- **Example interpretation/remediation:** Remove `privileged: true` and grant only specific capabilities required by the workload.
+
+### `security.capabilities-validation` - Capabilities Validation
+
+- **Purpose:** Validate Linux capability usage follows least privilege.
+- **Reads:** Pod/container capability add/drop settings.
+- **Outcomes:** `passing` when dangerous capabilities are not added unsafely; `failing` when dangerous capability patterns are detected.
+- **Prerequisites / optional data sources:** Kubernetes Pod API access.
+- **Example interpretation/remediation:** Add `drop: ["ALL"]` and explicitly re-add only narrowly required capabilities.
+
+### `security.rbac-wildcard-permissions` - RBAC Wildcard Permissions
+
+- **Purpose:** Detect overly broad RBAC grants.
+- **Reads:** Roles and ClusterRoles for wildcard (`*`) resources, verbs, or API groups.
+- **Outcomes:** `passing` when no wildcard grants are found; `failing` when wildcard access is detected.
+- **Prerequisites / optional data sources:** Kubernetes RBAC API access.
+- **Example interpretation/remediation:** Replace wildcard grants with explicit resources and verbs for each service account.
+
+### `security.rbac-cluster-admin-misuse` - RBAC Cluster-Admin Misuse
+
+- **Purpose:** Detect cluster-admin bindings outside expected system contexts.
+- **Reads:** ClusterRoleBindings and namespace scope for subjects bound to `cluster-admin`.
+- **Outcomes:** `passing` when cluster-admin is not misapplied; `failing` when non-system misuse is found.
+- **Prerequisites / optional data sources:** Kubernetes RBAC API access.
+- **Example interpretation/remediation:** Replace cluster-admin bindings with namespace-scoped Roles/RoleBindings and custom least-privilege ClusterRoles.
+
+### `security.secrets-in-configmaps` - Secrets in ConfigMaps
+
+- **Purpose:** Prevent sensitive values being stored in ConfigMaps.
+- **Reads:** ConfigMap keys and values (including `binaryData`) with secret-like heuristics.
+- **Outcomes:** `passing` when no likely secret data exists in ConfigMaps; `failing` when likely secret material is found.
+- **Prerequisites / optional data sources:** Kubernetes ConfigMap API access.
+- **Example interpretation/remediation:** Move values to Kubernetes Secrets or external-secrets and reference them via `valueFrom.secretKeyRef`.
+
+### `security.external-secrets-usage` - External Secrets Usage
+
+- **Purpose:** Encourage secure external secret management adoption.
+- **Reads:** Presence of `externalsecrets.external-secrets.io` CRD.
+- **Outcomes:** `passing` when External Secrets CRD is detected; `warning` when not detected.
+- **Prerequisites / optional data sources:** Kubernetes CRD API access.
+- **Example interpretation/remediation:** Install external-secrets and source secrets from Vault or cloud secret managers.
+
+### `security.hardcoded-secrets` - Hardcoded Secrets in Workloads
+
+- **Purpose:** Detect likely hardcoded credentials in workload env vars.
+- **Reads:** Deployment and StatefulSet container `env` values (`value`, not `valueFrom`), using secret heuristics.
+- **Outcomes:** `passing` when no hardcoded secrets are detected; `failing` when likely secret literals exist.
+- **Prerequisites / optional data sources:** Kubernetes Deployment and StatefulSet API access.
+- **Example interpretation/remediation:** Replace literal env values with `valueFrom.secretKeyRef` or external-secrets references.
+
+### `security.stored-vulnerability-thresholds` - Stored vulnerability severity thresholds
+
+- **Purpose:** Enforce vulnerability count ceilings from stored scanner findings.
+- **Reads:** Stored vulnerability counts by severity and environment thresholds (`VULN_MAX_CRITICAL`, `VULN_MAX_HIGH`, `VULN_MAX_MEDIUM`).
+- **Outcomes:** `passing` when counts are within thresholds; `failing` when thresholds are exceeded; `skipped` when Trivy status is available but scanning is not detected/reachable.
+- **Prerequisites / optional data sources:** Stored image scan findings; optional Trivy status integration (`getTrivyStatus`) and `ImageScanRepository`.
+- **Example interpretation/remediation:** If critical findings exceed policy, patch/replace affected images before raising threshold values.
+
+## Reliability
+
+### `reliability.replica-counts` - High Availability Replica Counts
+
+- **Purpose:** Ensure HA-relevant workloads run enough replicas.
+- **Reads:** Deployment and StatefulSet replica counts, with HA relevance heuristics/labels.
+- **Outcomes:** `passing` when HA-relevant workloads meet minimum replicas; `failing` when below target.
+- **Prerequisites / optional data sources:** Kubernetes Deployment/StatefulSet API; HA heuristics labels such as `kube9.io/ha-required` and `kube9.io/ha-exempt`.
+- **Example interpretation/remediation:** Increase replicas for HA workloads to at least 2 unless explicitly exempted.
+
+### `reliability.spread-anti-affinity` - Pod Spread and Anti-Affinity
+
+- **Purpose:** Reduce correlated failure risk by checking pod placement controls.
+- **Reads:** Workload pod templates for topology spread constraints / anti-affinity.
+- **Outcomes:** `passing` when suitable spread/anti-affinity is present for HA workloads; `warning` when resilience placement controls are missing.
+- **Prerequisites / optional data sources:** Kubernetes workload specs and scheduling policy fields.
+- **Example interpretation/remediation:** Add topology spread constraints across zones/nodes and preferred/required anti-affinity rules.
+
+### `reliability.pod-disruption-budgets` - PodDisruptionBudget Coverage
+
+- **Purpose:** Ensure voluntary disruptions preserve availability.
+- **Reads:** HA-relevant workloads and matching PodDisruptionBudgets.
+- **Outcomes:** `passing` when PDB coverage is present for relevant workloads; `warning` when coverage gaps exist.
+- **Prerequisites / optional data sources:** Kubernetes Deployment/StatefulSet and PDB APIs.
+- **Example interpretation/remediation:** Create a PDB with `minAvailable` or `maxUnavailable` aligned to your SLO.
+
+### `reliability.resource-requests` - Resource Requests
+
+- **Purpose:** Ensure workloads declare scheduler resource intent.
+- **Reads:** Container CPU/memory requests in workload specs.
+- **Outcomes:** `passing` when required requests are configured; `failing` when requests are missing.
+- **Prerequisites / optional data sources:** Kubernetes workload API access.
+- **Example interpretation/remediation:** Add both CPU and memory requests for each container to improve scheduling reliability.
+
+### `reliability.resource-limits` - Resource Limits
+
+- **Purpose:** Flag workloads missing resource guardrails.
+- **Reads:** Container CPU/memory limits in workload specs.
+- **Outcomes:** `passing` when limits are configured; `warning` when limits are missing.
+- **Prerequisites / optional data sources:** Kubernetes workload API access.
+- **Example interpretation/remediation:** Add memory and CPU limits to reduce noisy-neighbor and runaway resource incidents.
+
+### `reliability.liveness-readiness-probes` - Liveness and Readiness Probes
+
+- **Purpose:** Verify workloads expose probe-based health semantics.
+- **Reads:** Container liveness/readiness probes in workload pod specs.
+- **Outcomes:** `passing` when expected probes are configured; `failing` when probes are missing or insufficient.
+- **Prerequisites / optional data sources:** Kubernetes workload API access.
+- **Example interpretation/remediation:** Add readiness probes to protect traffic and liveness probes for self-healing restart behavior.
+
+### `reliability.backup-dr-signals` - Backup and Disaster Recovery Signals
+
+- **Purpose:** Detect presence of backup/DR posture signals.
+- **Reads:** Backup/DR related resources and labels/annotations recognized by the check heuristics.
+- **Outcomes:** `passing` when backup/DR signals are present; `warning` when resilience evidence is weak or absent.
+- **Prerequisites / optional data sources:** Cluster resources used by configured backup/DR tools.
+- **Example interpretation/remediation:** Document and automate backup jobs plus restore tests for stateful workloads.
+
+## Performance Efficiency
+
+### `performance-efficiency.hpa-configuration-sanity` - HPA Configuration Sanity
+
+- **Purpose:** Validate autoscaling configuration quality.
+- **Reads:** HorizontalPodAutoscaler objects and scale target settings.
+- **Outcomes:** `passing` for sane HPA configuration; `warning` for questionable/non-ideal patterns; `failing` for clearly broken/safety-risk settings.
+- **Prerequisites / optional data sources:** Kubernetes autoscaling API (`HPA` objects).
+- **Example interpretation/remediation:** Ensure `minReplicas`, `maxReplicas`, and metric targets are coherent for production load behavior.
+
+### `performance-efficiency.vpa-configuration-sanity` - VPA Configuration Sanity
+
+- **Purpose:** Validate Vertical Pod Autoscaler policy and update behavior.
+- **Reads:** VerticalPodAutoscaler resources and update/resource policy settings.
+- **Outcomes:** `passing` when VPA policies are sane; `warning` for partial/risky settings; `failing` for severe misconfiguration.
+- **Prerequisites / optional data sources:** VPA CRDs/resources installed and readable.
+- **Example interpretation/remediation:** Tune update mode/resource policies to avoid disruptive or unconstrained recommendation application.
+
+### `performance-efficiency.namespace-resource-governance` - Namespace Resource Governance
+
+- **Purpose:** Assess namespace-level quota/limit governance and workload consistency.
+- **Reads:** Namespace `ResourceQuota`, `LimitRange`, and workload request/limit posture.
+- **Outcomes:** `passing` when governance controls are healthy; `warning` for soft governance gaps; `failing` for strong governance violations.
+- **Prerequisites / optional data sources:** Namespace, ResourceQuota, LimitRange, and workload APIs.
+- **Example interpretation/remediation:** Add namespace defaults and quotas so workloads receive bounded, predictable capacity.
+
+### `performance-efficiency.node-affinity-and-placement` - Node Affinity and Placement
+
+- **Purpose:** Detect inefficient or risky scheduling placement rules.
+- **Reads:** Affinity, node selector, topology constraints, and placement-related workload metadata.
+- **Outcomes:** `passing` for balanced placement strategy; `warning` for potential inefficiencies; `failing` for severe placement anti-patterns.
+- **Prerequisites / optional data sources:** Workload scheduling fields and node topology labels.
+- **Example interpretation/remediation:** Use affinity/selectors that match real node pools without over-constraining scheduler options.
+
+## Cost Optimization
+
+### `cost-optimization.resource-request-limit-ratios` - Resource Request/Limit Ratios
+
+- **Purpose:** Detect request-to-limit ratio patterns likely to waste capacity or cause throttling pressure.
+- **Reads:** Container CPU/memory requests and limits with ratio heuristics.
+- **Outcomes:** `passing` for healthy ratios; `warning` for ratio drift; `failing` for severe over/under ratio patterns.
+- **Prerequisites / optional data sources:** Workload resource spec access.
+- **Example interpretation/remediation:** Right-size request/limit pairs from observed usage so requests track baseline and limits cap spikes appropriately.
+
+### `cost-optimization.over-provisioning-detection` - Over-Provisioning Detection
+
+- **Purpose:** Detect likely over-allocation of resources relative to policy heuristics.
+- **Reads:** Workload resource reservations and over-provisioning heuristics.
+- **Outcomes:** `passing` when no over-provisioning signal is detected; `warning` for moderate over-allocation; `failing` for high-confidence over-provisioning.
+- **Prerequisites / optional data sources:** Workload resource spec access.
+- **Example interpretation/remediation:** Reduce inflated requests where sustained utilization is low.
+
+### `cost-optimization.spot-instance-usage` - Spot/Preemptible Capacity Usage
+
+- **Purpose:** Evaluate whether candidate workloads effectively use lower-cost interruption-tolerant capacity.
+- **Reads:** Node labels/taints, scheduling constraints, and workload placement to infer spot/preemptible usage posture.
+- **Outcomes:** `passing` when spot usage posture is healthy (including acceptable edge cases in check logic); `warning` for limited adoption opportunities; `failing` for clear policy misses.
+- **Prerequisites / optional data sources:** Node metadata and workload scheduling configuration.
+- **Example interpretation/remediation:** Route stateless or tolerant workloads to spot/preemptible pools with interruption-aware deployment strategy.
+
+## Operational Excellence
+
+### `operational-excellence.kube9-operator-health-probes` - kube9-operator health probes
+
+- **Purpose:** Validate kube9-operator deployment health probe configuration.
+- **Reads:** kube9-operator Deployment container liveness/readiness/startup probes.
+- **Outcomes:** `passing` when probes are configured correctly; `failing` when misconfigured/missing; `skipped` when kube9-operator Deployment is not discoverable.
+- **Prerequisites / optional data sources:** kube9-operator Deployment metadata and pod template.
+- **Example interpretation/remediation:** Ensure operator container exposes and wires standard health probe endpoints.
+
+### `operational-excellence.kube9-operator-metrics-exposure` - kube9-operator metrics exposure
+
+- **Purpose:** Validate observability metrics endpoint exposure for the operator.
+- **Reads:** kube9-operator Deployment/container port and metrics endpoint configuration.
+- **Outcomes:** `passing` when metrics exposure is correctly configured; `warning` for partial/weak exposure; `failing` for broken exposure; `skipped` when operator deployment is unavailable.
+- **Prerequisites / optional data sources:** kube9-operator Deployment and container port/env configuration.
+- **Example interpretation/remediation:** Expose metrics endpoint on expected port and ensure scrape configuration can reach it.
+
+### `operational-excellence.kube9-operator-logging-configuration` - kube9-operator logging configuration
+
+- **Purpose:** Validate operator logging mode and signal quality.
+- **Reads:** kube9-operator deployment/env configuration affecting log level/format.
+- **Outcomes:** `passing` for healthy logging configuration; `warning` for suboptimal settings; `failing` for clearly problematic logging config; `skipped` when operator deployment is unavailable.
+- **Prerequisites / optional data sources:** kube9-operator Deployment/env configuration.
+- **Example interpretation/remediation:** Set structured logs and a production-appropriate log level to improve incident triage.
+
+### `operational-excellence.kube9-operator-audit-signals` - kube9-operator audit signals
+
+- **Purpose:** Ensure operator emits or can surface audit-relevant operational signals.
+- **Reads:** kube9-operator deployment/runtime configuration and related audit signal hooks.
+- **Outcomes:** `passing` when audit signals are available; `failing` when missing/inadequate; `skipped` when operator deployment is unavailable.
+- **Prerequisites / optional data sources:** kube9-operator deployment presence and audit-related config.
+- **Example interpretation/remediation:** Enable and retain operator events/logging pathways needed for change/audit review.
+
+### `operational-excellence.kube9-operator-deployment-strategy` - kube9-operator deployment strategy
+
+- **Purpose:** Validate operator rollout strategy for safe change management.
+- **Reads:** kube9-operator Deployment strategy and rollout parameters.
+- **Outcomes:** `passing` for safe rollout defaults; `warning` for potentially risky but tolerable strategy; `failing` for unsafe strategy choices; `skipped` when operator deployment is unavailable.
+- **Prerequisites / optional data sources:** kube9-operator Deployment strategy fields.
+- **Example interpretation/remediation:** Use rolling update strategy with bounded unavailable/surge values.
+
+### `operational-excellence.gitops-delivery-signals` - GitOps delivery signals
+
+- **Purpose:** Detect whether declarative GitOps control loops are present.
+- **Reads:** Argo CD detection signals (`applications.argoproj.io` CRD and server discovery) and Flux CRD presence.
+- **Outcomes:** `passing` when Argo CD or Flux signals are present; `warning` when GitOps posture is incomplete or absent.
+- **Prerequisites / optional data sources:** Optional Argo CD env configuration (`ARGOCD_ENABLED`, `ARGOCD_NAMESPACE`, `ARGOCD_SELECTOR`, `ARGOCD_AUTO_DETECT`) and Flux/Argo CRDs.
+- **Example interpretation/remediation:** Install and validate Argo CD or Flux so cluster state is reconciled continuously from Git.

--- a/docs/assessment/user-guide.md
+++ b/docs/assessment/user-guide.md
@@ -1,0 +1,148 @@
+# Well-Architected Assessments User Guide
+
+This guide walks through installing `kube9-operator`, running assessments, and interpreting results without reading TypeScript internals.
+
+## What assessments do
+
+`kube9-operator` evaluates your cluster against built-in Kubernetes Well-Architected checks across six pillars:
+
+- Security
+- Reliability
+- Performance Efficiency
+- Cost Optimization
+- Operational Excellence
+- Sustainability
+
+Assessments run in two common patterns:
+
+- **Scheduled in operated mode**: the operator loop performs recurring assessments in-cluster.
+- **On-demand via CLI**: you run `kube9-operator assess ...` commands, typically through `kubectl exec` against the operator pod.
+
+## Prerequisites
+
+- Kubernetes `1.24+`
+- `kubectl` configured for your target cluster
+- `helm` `3.x`
+- Permission to create namespaces and RBAC resources for installation
+
+## Install and verify the operator
+
+The conventional namespace is `kube9-system` (you can use another namespace if desired).
+
+```bash
+helm repo add kube9 https://charts.kube9.io
+helm repo update
+
+helm install kube9-operator kube9/kube9-operator \
+  --namespace kube9-system \
+  --create-namespace
+```
+
+Verify operator health and status publishing:
+
+```bash
+kubectl get pods -n kube9-system
+kubectl logs -n kube9-system deployment/kube9-operator
+kubectl get configmap kube9-operator-status -n kube9-system -o jsonpath='{.data.status}' | jq .
+```
+
+## Helm values that matter for assessments
+
+Most assessment behavior works with chart defaults. These values are commonly tuned:
+
+- `statusUpdateIntervalSeconds`: controls status publication frequency (helps extension/consumers observe freshness).
+- `trivy.*` values (especially `trivy.serverUrl`, `trivy.autoDetect`, `trivy.detectionInterval`): impact vulnerability-related checks.
+- `argocd.*` values: affect GitOps-related detection signals used by some checks.
+- `rbac.create` / `serviceAccount.*`: must allow the operator to read required resources and write status ConfigMaps.
+
+See chart value details in `charts/kube9-operator/README.md`.
+
+## Run assessments on demand (CLI)
+
+In-cluster usage is typically via `kubectl exec` into the operator pod.
+
+```bash
+POD=$(kubectl get pod -n kube9-system -l app.kubernetes.io/name=kube9-operator -o jsonpath='{.items[0].metadata.name}')
+```
+
+### Run
+
+Full assessment:
+
+```bash
+kubectl exec -n kube9-system "$POD" -- kube9-operator assess run --mode full --format table
+```
+
+Single pillar (example: security):
+
+```bash
+kubectl exec -n kube9-system "$POD" -- kube9-operator assess run --mode pillar --pillar security --format table
+```
+
+Single check:
+
+```bash
+kubectl exec -n kube9-system "$POD" -- kube9-operator assess run --mode single-check --check-id security.run-as-non-root --format table
+```
+
+### List runs
+
+```bash
+kubectl exec -n kube9-system "$POD" -- kube9-operator assess list --limit 20 --format table
+```
+
+### Get one run by ID
+
+```bash
+kubectl exec -n kube9-system "$POD" -- kube9-operator assess get <run-id> --format yaml
+```
+
+### Summary and historical trends
+
+```bash
+kubectl exec -n kube9-system "$POD" -- kube9-operator assess summary --format table
+kubectl exec -n kube9-system "$POD" -- kube9-operator assess history --pillar security --limit 50 --format table
+```
+
+## Run modes explained
+
+The `assess run` command supports three modes:
+
+- `full`: evaluate all registered checks.
+- `pillar`: evaluate checks in one pillar (requires `--pillar`).
+- `single-check`: evaluate one check ID (requires `--check-id`).
+
+If mode-specific required flags are missing, the CLI exits with a clear validation error.
+
+## How to interpret results
+
+Assessment records include run metadata and aggregate counts:
+
+- Run metadata: `run_id`, `mode`, `state`, timestamps.
+- Outcome counts: `passed_checks`, `failed_checks`, `warning_checks`, `skipped_checks`, plus error/timeout counts.
+
+For check-level detail and remediation context, use:
+
+- `assess history` to review recent check outcomes over time.
+- `docs/assessment/checks.md` for check purpose, prerequisites, and remediation guidance.
+
+In operated mode, status and compatibility signals are also exposed via `kube9-operator-status` ConfigMap for extension and other consumers.
+
+## Known limitations and skipped checks
+
+- `skipped` means a check could not execute because a required signal or optional integration was unavailable.
+- Vulnerability-threshold checks can be `skipped` when Trivy is not configured, unreachable, or not detected at run start.
+- Checks that inspect operator deployment details can be `skipped` when the expected deployment signal is unavailable.
+
+Treat `skipped` as actionable observability/configuration debt: either wire the dependency (for example Trivy) or consciously accept the reduced coverage.
+
+## Troubleshooting quick hits
+
+- No operator pod found:
+  - Confirm namespace and Helm release name.
+- Empty/old assessment data:
+  - Re-run `assess run`, then `assess list`.
+- Permission errors:
+  - Verify chart-managed RBAC is enabled and bindings exist.
+- Unexpected skipped checks:
+  - Validate optional integrations and inspect operator logs for detection errors.

--- a/src/assessment/runner.test.ts
+++ b/src/assessment/runner.test.ts
@@ -4,6 +4,15 @@ import { Pillar, CheckStatus, AssessmentRunMode } from './types.js';
 import { AssessmentRunner, resolveChecksForRun } from './runner.js';
 import { getRegistry, resetRegistry } from './registry.js';
 import type { AssessmentRunRecord, AssessmentCheckResult as StorageCheckResult } from './contracts.js';
+import { register } from '../collection/metrics.js';
+
+function parseAssessmentRunCounter(metrics: string, state: string): number {
+  const regex = new RegExp(
+    `kube9_operator_assessment_runs_total\\{state="${state}"\\} (\\d+)`
+  );
+  const match = metrics.match(regex);
+  return match ? parseInt(match[1], 10) : 0;
+}
 
 /** Mock storage that records calls for verification */
 class MockAssessmentStorage {
@@ -151,6 +160,12 @@ describe('AssessmentRunner', () => {
       expect(mockStorage.assessments.length).toBeGreaterThanOrEqual(2);
       expect(mockStorage.checkResults).toHaveLength(1);
       expect(mockStorage.checkResults[0].result.status).toBe('passing');
+
+      const metrics = await register.metrics();
+      expect(parseAssessmentRunCounter(metrics, 'queued')).toBeGreaterThanOrEqual(1);
+      expect(parseAssessmentRunCounter(metrics, 'running')).toBeGreaterThanOrEqual(1);
+      expect(parseAssessmentRunCounter(metrics, 'completed')).toBeGreaterThanOrEqual(1);
+      expect(metrics).toContain('kube9_operator_assessment_checks_total{pillar="security",status="passing"}');
     });
   });
 

--- a/src/assessment/runner.ts
+++ b/src/assessment/runner.ts
@@ -231,6 +231,7 @@ export class AssessmentRunner {
       timeout_checks: 0,
     };
     this.storage.upsertAssessment(initialRecord);
+    recordRunState('queued');
 
     const runningRecord: AssessmentRunRecord = {
       ...initialRecord,
@@ -238,6 +239,7 @@ export class AssessmentRunner {
       started_at: new Date().toISOString(),
     };
     this.storage.upsertAssessment(runningRecord);
+    recordRunState('running');
 
     let passed = 0;
     let failed = 0;


### PR DESCRIPTION
## Description

Expand assessment documentation with a practical user guide and a complete built-in checks reference so operators can run, scope, and interpret assessments end-to-end.

This branch also documents and validates **assessment Prometheus metrics** (`kube9_operator_assessment_*`): forge observability contract, optional Helm `podAnnotations` for scrape discovery, chart guidance for `/metrics`, and lifecycle counters (`queued` / `running` / terminal state) from the assessment runner.

## Motivation and Context

The shared parent branch includes documentation and observability scope from multiple sub-issues:

- #127: built-in checks reference
- #128: framework assessment user guide with install, run mode, CLI, and interpretation guidance
- #129: assessment metrics in `.forge/operations/observability.md`, user-facing scrape validation, and runner metric lifecycle

Fixes #127
Fixes #128
Fixes #129

## Type of Change

- [x] Documentation update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## How Has This Been Tested?

- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run test:integration`
- [x] `npm run build`
- [ ] Manual testing in Extension Development Host (F5)
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Tested with multiple Kubernetes clusters
- [ ] Tested on multiple OS (macOS, Windows, Linux)
- [ ] Tested with different VS Code versions

## How to Test this Work

1. Open `docs/assessment/user-guide.md` and verify it covers:
   - Installation prerequisites and Helm install flow
   - `kubectl exec` assessment command patterns (`assess run`, `assess list`, `assess get`)
   - Run modes (`full`, `pillar`, `single-check`)
   - Result interpretation and skipped-check limitations
2. Open `docs/assessment/checks.md` and verify built-in checks remain documented by pillar.
3. Confirm `README.md` and `charts/kube9-operator/README.md` link to the assessment user guide.
4. Read `.forge/operations/observability.md` → **Assessment metrics** and confirm every `kube9_operator_assessment_*` name from `src/assessment/metrics.ts` is described.
5. Follow chart README **Prometheus metrics** section: optional `podAnnotations`, port-forward, `curl` grep for `kube9_operator_assessment_`.
6. Confirm `helm template` succeeds with default `podAnnotations: {}` and with string scrape annotations.

## How to Validate this Work

1. From the repository `README.md`, click **Assessment User Guide**.
2. Confirm a new user can execute an end-to-end assessment flow without reading source code.
3. Confirm chart users can find the same guide from `charts/kube9-operator/README.md`.
4. After an assessment run in operated mode, confirm `/metrics` shows moving `kube9_operator_assessment_*` series as documented.

## Additional Notes

Runtime change: `AssessmentRunner` now calls `recordRunState` for `queued` and `running` before the terminal state, aligning metrics with `recordRunState` documentation and making lifecycle counters observable during a run.
