### PR TITLE
Sustainability: resource-efficiency and workload-consolidation checks (#120, #121)

### DIFF
--- a/src/assessment/bootstrap.ts
+++ b/src/assessment/bootstrap.ts
@@ -46,6 +46,7 @@ import {
   kube9OperatorDeploymentStrategyCheck,
   gitopsDeliverySignalsCheck,
 } from './checks/operational-excellence/index.js';
+import { resourceEfficiencySignalsCheck } from './checks/sustainability/index.js';
 
 /** Built-in checks to register at bootstrap (extend as checks are implemented) */
 const BUILT_IN_CHECKS: AssessmentCheck[] = [
@@ -78,6 +79,7 @@ const BUILT_IN_CHECKS: AssessmentCheck[] = [
   kube9OperatorAuditSignalsCheck,
   kube9OperatorDeploymentStrategyCheck,
   gitopsDeliverySignalsCheck,
+  resourceEfficiencySignalsCheck,
 ];
 
 /**

--- a/src/assessment/bootstrap.ts
+++ b/src/assessment/bootstrap.ts
@@ -46,7 +46,10 @@ import {
   kube9OperatorDeploymentStrategyCheck,
   gitopsDeliverySignalsCheck,
 } from './checks/operational-excellence/index.js';
-import { resourceEfficiencySignalsCheck } from './checks/sustainability/index.js';
+import {
+  resourceEfficiencySignalsCheck,
+  workloadConsolidationSignalsCheck,
+} from './checks/sustainability/index.js';
 
 /** Built-in checks to register at bootstrap (extend as checks are implemented) */
 const BUILT_IN_CHECKS: AssessmentCheck[] = [
@@ -80,6 +83,7 @@ const BUILT_IN_CHECKS: AssessmentCheck[] = [
   kube9OperatorDeploymentStrategyCheck,
   gitopsDeliverySignalsCheck,
   resourceEfficiencySignalsCheck,
+  workloadConsolidationSignalsCheck,
 ];
 
 /**

--- a/src/assessment/checks/sustainability/index.ts
+++ b/src/assessment/checks/sustainability/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Sustainability pillar assessment checks (Well-Architected Framework).
+ */
+
+export { resourceEfficiencySignalsCheck } from './resource-efficiency-signals.js';

--- a/src/assessment/checks/sustainability/index.ts
+++ b/src/assessment/checks/sustainability/index.ts
@@ -3,3 +3,4 @@
  */
 
 export { resourceEfficiencySignalsCheck } from './resource-efficiency-signals.js';
+export { workloadConsolidationSignalsCheck } from './workload-consolidation-signals.js';

--- a/src/assessment/checks/sustainability/resource-efficiency-signals.test.ts
+++ b/src/assessment/checks/sustainability/resource-efficiency-signals.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  resourceEfficiencySignalsCheck,
+  IDLE_ALLOCATABLE_UTILIZATION_WARN,
+  MIN_ALLOCATABLE_CPU_CORES_FOR_IDLE_SIGNAL,
+} from './resource-efficiency-signals.js';
+import type { AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus } from '../../types.js';
+
+function createMockCtx(
+  nodes: unknown[] = [],
+  deployments: unknown[] = [],
+  statefulSets: unknown[] = [],
+  daemonSets: unknown[] = [],
+): AssessmentRunContext {
+  return {
+    kubernetes: {
+      coreApi: {
+        listNode: vi.fn().mockResolvedValue({ items: nodes }),
+      },
+      appsApi: {
+        listDeploymentForAllNamespaces: vi.fn().mockResolvedValue({ items: deployments }),
+        listStatefulSetForAllNamespaces: vi.fn().mockResolvedValue({ items: statefulSets }),
+        listDaemonSetForAllNamespaces: vi.fn().mockResolvedValue({ items: daemonSets }),
+      },
+    },
+    config: {} as never,
+    timeoutMs: 30000,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+    runId: 'test-run',
+    mode: 'full',
+  } as unknown as AssessmentRunContext;
+}
+
+const schedulableNode = (cpu: string, memory: string): unknown => ({
+  metadata: { name: 'node-1' },
+  spec: { unschedulable: false },
+  status: { allocatable: { cpu, memory } },
+});
+
+describe('resourceEfficiencySignalsCheck', () => {
+  it('uses sustainability pillar and stable check id', () => {
+    expect(resourceEfficiencySignalsCheck.id).toBe('sustainability.resource-efficiency-signals');
+    expect(resourceEfficiencySignalsCheck.pillar).toBe(Pillar.Sustainability);
+  });
+
+  it('skips when no allocatable CPU or memory on schedulable nodes', async () => {
+    const ctx = createMockCtx(
+      [{ metadata: { name: 'n' }, spec: { unschedulable: true }, status: { allocatable: {} } }],
+      [],
+    );
+    const result = await resourceEfficiencySignalsCheck.run(ctx);
+    expect(result.status).toBe(CheckStatus.Skipped);
+    expect(result.pillar).toBe(Pillar.Sustainability);
+  });
+
+  it('warns when CPU reservation is far below allocatable on a non-trivial cluster', async () => {
+    const nodes = [schedulableNode('8', '32Gi')];
+    const deployments = [
+      {
+        metadata: { namespace: 'default', name: 'tiny' },
+        spec: {
+          replicas: 1,
+          template: {
+            spec: {
+              containers: [
+                {
+                  name: 'main',
+                  resources: { requests: { cpu: '100m', memory: '256Mi' } },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ];
+    const ctx = createMockCtx(nodes, deployments);
+    const result = await resourceEfficiencySignalsCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Warning);
+    expect(result.message).toContain('CPU requests');
+    expect(MIN_ALLOCATABLE_CPU_CORES_FOR_IDLE_SIGNAL).toBeLessThanOrEqual(8);
+    expect(IDLE_ALLOCATABLE_UTILIZATION_WARN).toBeGreaterThan(0.1);
+  });
+
+  it('passes when reservations use a healthy fraction of allocatable', async () => {
+    const nodes = [schedulableNode('8', '16Gi')];
+    const deployments = [
+      {
+        metadata: { namespace: 'default', name: 'app' },
+        spec: {
+          replicas: 2,
+          template: {
+            spec: {
+              containers: [
+                {
+                  name: 'main',
+                  resources: { requests: { cpu: '2', memory: '4Gi' } },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ];
+    const ctx = createMockCtx(nodes, deployments);
+    const result = await resourceEfficiencySignalsCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Passing);
+    expect(result.message).toContain('50.0%');
+  });
+
+  it('excludes kube-system workloads from fleet sum', async () => {
+    const nodes = [schedulableNode('4', '16Gi')];
+    const deployments = [
+      {
+        metadata: { namespace: 'kube-system', name: 'infra' },
+        spec: {
+          replicas: 10,
+          template: {
+            spec: {
+              containers: [
+                { name: 'c', resources: { requests: { cpu: '1', memory: '1Gi' } } },
+              ],
+            },
+          },
+        },
+      },
+    ];
+    const ctx = createMockCtx(nodes, deployments);
+    const result = await resourceEfficiencySignalsCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Warning);
+  });
+});

--- a/src/assessment/checks/sustainability/resource-efficiency-signals.ts
+++ b/src/assessment/checks/sustainability/resource-efficiency-signals.ts
@@ -1,0 +1,225 @@
+/**
+ * Sustainability: resource efficiency signals (declared requests vs allocatable).
+ *
+ * Compares aggregate CPU/memory requests from in-scope workloads to schedulable
+ * node allocatable. Very low reservation ratios suggest idle capacity that often
+ * correlates with higher per-unit-work infrastructure energy — a consolidation /
+ * rightsizing nudge from a sustainability lens (configuration-only; no metrics).
+ */
+
+import * as k8s from '@kubernetes/client-node';
+import type { AssessmentCheck, AssessmentCheckResult, AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus, Severity } from '../../types.js';
+import { isResourceCheckRelevant, type WorkloadMetadata } from '../reliability/heuristics.js';
+import { parseCpuCores, parseMemoryBytes } from '../shared/resource-quantities.js';
+
+const CHECK_ID = 'sustainability.resource-efficiency-signals';
+const CHECK_NAME = 'Resource Efficiency Signals';
+const REMEDIATION =
+  'Increase workload density (fewer/larger nodes where safe), right-size nodes to match steady demand, or raise requests where they are intentionally low so scheduling reflects real need. Pair changes with capacity and reliability review; use kube9.io/resource-exempt=true only when intentional.';
+
+/** Warn when reserved CPU is below this fraction of allocatable (idle signal). */
+export const IDLE_ALLOCATABLE_UTILIZATION_WARN = 0.15;
+/** Warn when reserved memory is below this fraction of allocatable. */
+export const IDLE_MEMORY_UTILIZATION_WARN = 0.15;
+
+/** Only emit idle-capacity warnings when allocatable CPU is at least this many cores. */
+export const MIN_ALLOCATABLE_CPU_CORES_FOR_IDLE_SIGNAL = 4;
+/** Only emit idle-capacity warnings when allocatable memory is at least this many bytes. */
+export const MIN_ALLOCATABLE_MEMORY_BYTES_FOR_IDLE_SIGNAL = 8 * 1024 ** 3;
+
+function toWorkloadMeta(meta: k8s.V1ObjectMeta | undefined, kind: string): WorkloadMetadata {
+  return {
+    namespace: meta?.namespace ?? '',
+    name: meta?.name ?? 'unknown',
+    kind,
+    labels: meta?.labels as Record<string, string> | undefined,
+  };
+}
+
+function sumContainerCpuRequests(containers: k8s.V1Container[] | undefined): number {
+  if (!containers?.length) return 0;
+  let sum = 0;
+  for (const c of containers) {
+    const v = parseCpuCores(c.resources?.requests?.cpu);
+    if (v !== undefined) sum += v;
+  }
+  return sum;
+}
+
+function sumContainerMemoryRequests(containers: k8s.V1Container[] | undefined): number {
+  if (!containers?.length) return 0;
+  let sum = 0;
+  for (const c of containers) {
+    const v = parseMemoryBytes(c.resources?.requests?.memory);
+    if (v !== undefined) sum += v;
+  }
+  return sum;
+}
+
+function effectivePodCpuRequestCores(template: k8s.V1PodTemplateSpec | undefined): number {
+  const init = sumContainerCpuRequests(template?.spec?.initContainers);
+  const app = sumContainerCpuRequests(template?.spec?.containers);
+  return Math.max(init, app);
+}
+
+function effectivePodMemoryRequestBytes(template: k8s.V1PodTemplateSpec | undefined): number {
+  const init = sumContainerMemoryRequests(template?.spec?.initContainers);
+  const app = sumContainerMemoryRequests(template?.spec?.containers);
+  return Math.max(init, app);
+}
+
+function sumSchedulableAllocatable(nodes: k8s.V1Node[]): { cpuCores: number; memoryBytes: number } {
+  let cpuCores = 0;
+  let memoryBytes = 0;
+  for (const n of nodes) {
+    if (n.spec?.unschedulable) continue;
+    const alloc = n.status?.allocatable;
+    const c = parseCpuCores(alloc?.cpu);
+    const m = parseMemoryBytes(alloc?.memory);
+    if (c !== undefined) cpuCores += c;
+    if (m !== undefined) memoryBytes += m;
+  }
+  return { cpuCores, memoryBytes };
+}
+
+function sumFleetRequests(
+  deployments: k8s.V1Deployment[],
+  statefulSets: k8s.V1StatefulSet[],
+  daemonSets: k8s.V1DaemonSet[],
+): { cpuCores: number; memoryBytes: number } {
+  let cpuCores = 0;
+  let memoryBytes = 0;
+
+  for (const d of deployments) {
+    const meta = toWorkloadMeta(d.metadata, 'Deployment');
+    if (!isResourceCheckRelevant(meta)) continue;
+    const replicas = d.spec?.replicas ?? 0;
+    if (replicas <= 0) continue;
+    const tpl = d.spec?.template;
+    cpuCores += effectivePodCpuRequestCores(tpl) * replicas;
+    memoryBytes += effectivePodMemoryRequestBytes(tpl) * replicas;
+  }
+
+  for (const s of statefulSets) {
+    const meta = toWorkloadMeta(s.metadata, 'StatefulSet');
+    if (!isResourceCheckRelevant(meta)) continue;
+    const replicas = s.spec?.replicas ?? 0;
+    if (replicas <= 0) continue;
+    const tpl = s.spec?.template;
+    cpuCores += effectivePodCpuRequestCores(tpl) * replicas;
+    memoryBytes += effectivePodMemoryRequestBytes(tpl) * replicas;
+  }
+
+  for (const ds of daemonSets) {
+    const meta = toWorkloadMeta(ds.metadata, 'DaemonSet');
+    if (!isResourceCheckRelevant(meta)) continue;
+    const replicas = ds.status?.desiredNumberScheduled ?? 0;
+    if (replicas <= 0) continue;
+    const tpl = ds.spec?.template;
+    cpuCores += effectivePodCpuRequestCores(tpl) * replicas;
+    memoryBytes += effectivePodMemoryRequestBytes(tpl) * replicas;
+  }
+
+  return { cpuCores, memoryBytes };
+}
+
+function pct(n: number): string {
+  return `${(n * 100).toFixed(1)}%`;
+}
+
+export const resourceEfficiencySignalsCheck: AssessmentCheck = {
+  id: CHECK_ID,
+  name: CHECK_NAME,
+  pillar: Pillar.Sustainability,
+  description:
+    'Surfaces low declared request utilization versus node allocatable as a sustainability-oriented capacity signal',
+  defaultSeverity: Severity.Medium,
+
+  async run(ctx: AssessmentRunContext): Promise<AssessmentCheckResult> {
+    const [nodesRes, deploymentsRes, statefulSetsRes, daemonSetsRes] = await Promise.all([
+      ctx.kubernetes.coreApi.listNode(),
+      ctx.kubernetes.appsApi.listDeploymentForAllNamespaces(),
+      ctx.kubernetes.appsApi.listStatefulSetForAllNamespaces(),
+      ctx.kubernetes.appsApi.listDaemonSetForAllNamespaces(),
+    ]);
+
+    const nodes = nodesRes.items ?? [];
+    const { cpuCores: allocCpu, memoryBytes: allocMem } = sumSchedulableAllocatable(nodes);
+
+    if (allocCpu <= 0 && allocMem <= 0) {
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.Sustainability,
+        status: CheckStatus.Skipped,
+        severity: Severity.Low,
+        message:
+          'No schedulable nodes with parseable CPU/memory allocatable; cannot evaluate fleet vs capacity signal',
+        remediation: REMEDIATION,
+      };
+    }
+
+    const deployments = deploymentsRes.items ?? [];
+    const statefulSets = statefulSetsRes.items ?? [];
+    const daemonSets = daemonSetsRes.items ?? [];
+    const fleet = sumFleetRequests(deployments, statefulSets, daemonSets);
+
+    const cpuUtil = allocCpu > 0 ? fleet.cpuCores / allocCpu : undefined;
+    const memUtil = allocMem > 0 ? fleet.memoryBytes / allocMem : undefined;
+
+    const idleCpu =
+      allocCpu >= MIN_ALLOCATABLE_CPU_CORES_FOR_IDLE_SIGNAL &&
+      cpuUtil !== undefined &&
+      cpuUtil < IDLE_ALLOCATABLE_UTILIZATION_WARN;
+    const idleMem =
+      allocMem >= MIN_ALLOCATABLE_MEMORY_BYTES_FOR_IDLE_SIGNAL &&
+      memUtil !== undefined &&
+      memUtil < IDLE_MEMORY_UTILIZATION_WARN;
+
+    if (idleCpu || idleMem) {
+      const parts: string[] = [];
+      if (idleCpu) {
+        parts.push(
+          `CPU requests ~${fleet.cpuCores.toFixed(2)} cores vs ${allocCpu.toFixed(2)} cores allocatable (${pct(cpuUtil!)} reserved; threshold ${pct(IDLE_ALLOCATABLE_UTILIZATION_WARN)})`,
+        );
+      }
+      if (idleMem) {
+        parts.push(
+          `memory requests ~${(fleet.memoryBytes / 1024 ** 3).toFixed(1)}Gi vs ${(allocMem / 1024 ** 3).toFixed(1)}Gi allocatable (${pct(memUtil!)} reserved; threshold ${pct(IDLE_MEMORY_UTILIZATION_WARN)})`,
+        );
+      }
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.Sustainability,
+        status: CheckStatus.Warning,
+        severity: Severity.Medium,
+        objectKind: 'Node',
+        message: `Low declared utilization versus allocatable (sustainability / capacity signal): ${parts.join('; ')}`,
+        remediation: REMEDIATION,
+      };
+    }
+
+    const detailParts: string[] = [];
+    if (cpuUtil !== undefined) {
+      detailParts.push(`CPU reserved ${pct(cpuUtil)} of allocatable`);
+    }
+    if (memUtil !== undefined) {
+      detailParts.push(`memory reserved ${pct(memUtil)} of allocatable`);
+    }
+
+    return {
+      checkId: CHECK_ID,
+      checkName: CHECK_NAME,
+      pillar: Pillar.Sustainability,
+      status: CheckStatus.Passing,
+      severity: Severity.Medium,
+      message:
+        detailParts.length > 0
+          ? `Declared requests are within sustainability idle-capacity heuristics (${detailParts.join('; ')})`
+          : 'Declared requests are within sustainability idle-capacity heuristics',
+      remediation: REMEDIATION,
+    };
+  },
+};

--- a/src/assessment/checks/sustainability/workload-consolidation-signals.test.ts
+++ b/src/assessment/checks/sustainability/workload-consolidation-signals.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  workloadConsolidationSignalsCheck,
+  MIN_DEPLOYMENTS_FOR_SPRAWL_SIGNAL,
+  SINGLE_REPLICA_DEPLOYMENT_SHARE_WARN,
+} from './workload-consolidation-signals.js';
+import type { AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus } from '../../types.js';
+
+function createMockCtx(deployments: unknown[]): AssessmentRunContext {
+  return {
+    kubernetes: {
+      appsApi: {
+        listDeploymentForAllNamespaces: vi.fn().mockResolvedValue({ items: deployments }),
+      },
+    },
+    config: {} as never,
+    timeoutMs: 30000,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+    runId: 'test-run',
+    mode: 'full',
+  } as unknown as AssessmentRunContext;
+}
+
+function deployment(ns: string, name: string, replicas: number | undefined): unknown {
+  return {
+    metadata: { namespace: ns, name },
+    spec: replicas === undefined ? {} : { replicas },
+  };
+}
+
+describe('workloadConsolidationSignalsCheck', () => {
+  it('uses sustainability pillar and stable check id', () => {
+    expect(workloadConsolidationSignalsCheck.id).toBe('sustainability.workload-consolidation-signals');
+    expect(workloadConsolidationSignalsCheck.pillar).toBe(Pillar.Sustainability);
+  });
+
+  it('passes when too few in-scope deployments', async () => {
+    const items = Array.from({ length: MIN_DEPLOYMENTS_FOR_SPRAWL_SIGNAL - 1 }, (_, i) =>
+      deployment('default', `app-${i}`, 1),
+    );
+    const ctx = createMockCtx(items);
+    const result = await workloadConsolidationSignalsCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Passing);
+    expect(result.message).toContain(`Only ${MIN_DEPLOYMENTS_FOR_SPRAWL_SIGNAL - 1}`);
+    expect(result.pillar).toBe(Pillar.Sustainability);
+  });
+
+  it('warns when most in-scope deployments are single-replica', async () => {
+    const n = MIN_DEPLOYMENTS_FOR_SPRAWL_SIGNAL;
+    const single = Math.ceil(n * SINGLE_REPLICA_DEPLOYMENT_SHARE_WARN);
+    const multi = n - single;
+    const items: unknown[] = [];
+    for (let i = 0; i < single; i++) items.push(deployment('default', `one-${i}`, 1));
+    for (let i = 0; i < multi; i++) items.push(deployment('default', `many-${i}`, 3));
+    const ctx = createMockCtx(items);
+    const result = await workloadConsolidationSignalsCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Warning);
+    expect(result.message).toContain('single-replica');
+  });
+
+  it('passes when single-replica share is below threshold', async () => {
+    const n = MIN_DEPLOYMENTS_FOR_SPRAWL_SIGNAL;
+    const single = Math.floor(n * SINGLE_REPLICA_DEPLOYMENT_SHARE_WARN) - 1;
+    const multi = n - single;
+    const items: unknown[] = [];
+    for (let i = 0; i < single; i++) items.push(deployment('default', `one-${i}`, 1));
+    for (let i = 0; i < multi; i++) items.push(deployment('default', `many-${i}`, 2));
+    const ctx = createMockCtx(items);
+    const result = await workloadConsolidationSignalsCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Passing);
+    expect(result.message).toContain('nominal');
+  });
+
+  it('excludes kube-system and scaled-to-zero deployments', async () => {
+    const items: unknown[] = [];
+    for (let i = 0; i < 10; i++) items.push(deployment('default', `app-${i}`, 1));
+    for (let i = 0; i < 10; i++) items.push(deployment('kube-system', `sys-${i}`, 1));
+    items.push(deployment('default', 'scaled-down', 0));
+    const ctx = createMockCtx(items);
+    const result = await workloadConsolidationSignalsCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Warning);
+    expect(result.message).toContain('10 of 10');
+  });
+
+  it('treats omitted replicas as one', async () => {
+    const items: unknown[] = [];
+    for (let i = 0; i < MIN_DEPLOYMENTS_FOR_SPRAWL_SIGNAL; i++) {
+      items.push({ metadata: { namespace: 'default', name: `no-replicas-${i}` }, spec: {} });
+    }
+    const ctx = createMockCtx(items);
+    const result = await workloadConsolidationSignalsCheck.run(ctx);
+
+    expect(result.status).toBe(CheckStatus.Warning);
+  });
+});

--- a/src/assessment/checks/sustainability/workload-consolidation-signals.ts
+++ b/src/assessment/checks/sustainability/workload-consolidation-signals.ts
@@ -1,0 +1,97 @@
+/**
+ * Sustainability: workload consolidation / density signals.
+ *
+ * Surfaces replica sprawl among in-scope Deployments (many discrete one-replica
+ * apps), a consolidation hint from a sustainability lens. Does not evaluate
+ * PDBs, anti-affinity, or spread constraints — those stay in reliability checks.
+ */
+
+import * as k8s from '@kubernetes/client-node';
+import type { AssessmentCheck, AssessmentCheckResult, AssessmentRunContext } from '../../types.js';
+import { Pillar, CheckStatus, Severity } from '../../types.js';
+import { isResourceCheckRelevant, type WorkloadMetadata } from '../reliability/heuristics.js';
+
+const CHECK_ID = 'sustainability.workload-consolidation-signals';
+const CHECK_NAME = 'Workload Consolidation Signals';
+const REMEDIATION =
+  'Where SLOs allow, reduce discrete Deployment sprawl (merge services, share runtimes, or scale replicas on hot paths) to cut packaging and scheduling overhead. Treat databases and intentional singletons as exceptions; use kube9.io/resource-exempt=true only when deliberate, and validate with capacity and reliability review.';
+
+/** Minimum active in-scope Deployments before sprawl ratio is meaningful. */
+export const MIN_DEPLOYMENTS_FOR_SPRAWL_SIGNAL = 8;
+/** Warn when this fraction or more of those Deployments run exactly one replica. */
+export const SINGLE_REPLICA_DEPLOYMENT_SHARE_WARN = 0.6;
+
+function toWorkloadMeta(meta: k8s.V1ObjectMeta | undefined, kind: string): WorkloadMetadata {
+  return {
+    namespace: meta?.namespace ?? '',
+    name: meta?.name ?? 'unknown',
+    kind,
+    labels: meta?.labels as Record<string, string> | undefined,
+  };
+}
+
+function deploymentReplicas(spec: k8s.V1DeploymentSpec | undefined): number {
+  return spec?.replicas ?? 1;
+}
+
+export const workloadConsolidationSignalsCheck: AssessmentCheck = {
+  id: CHECK_ID,
+  name: CHECK_NAME,
+  pillar: Pillar.Sustainability,
+  description:
+    'Flags high single-replica Deployment sprawl among in-scope workloads as a consolidation / density signal',
+  defaultSeverity: Severity.Medium,
+
+  async run(ctx: AssessmentRunContext): Promise<AssessmentCheckResult> {
+    const deploymentsRes = await ctx.kubernetes.appsApi.listDeploymentForAllNamespaces();
+    const deployments = deploymentsRes.items ?? [];
+
+    let active = 0;
+    let singleReplica = 0;
+
+    for (const d of deployments) {
+      const meta = toWorkloadMeta(d.metadata, 'Deployment');
+      if (!isResourceCheckRelevant(meta)) continue;
+      const replicas = deploymentReplicas(d.spec);
+      if (replicas <= 0) continue;
+      active++;
+      if (replicas === 1) singleReplica++;
+    }
+
+    if (active < MIN_DEPLOYMENTS_FOR_SPRAWL_SIGNAL) {
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.Sustainability,
+        status: CheckStatus.Passing,
+        severity: Severity.Medium,
+        message: `Only ${active} active in-scope Deployment(s); need at least ${MIN_DEPLOYMENTS_FOR_SPRAWL_SIGNAL} to evaluate replica sprawl heuristics`,
+        remediation: REMEDIATION,
+      };
+    }
+
+    const share = singleReplica / active;
+    if (share >= SINGLE_REPLICA_DEPLOYMENT_SHARE_WARN) {
+      return {
+        checkId: CHECK_ID,
+        checkName: CHECK_NAME,
+        pillar: Pillar.Sustainability,
+        status: CheckStatus.Warning,
+        severity: Severity.Medium,
+        objectKind: 'Deployment',
+        message: `High single-replica Deployment sprawl: ${singleReplica} of ${active} in-scope Deployments run one replica (${(share * 100).toFixed(0)}% ≥ ${(SINGLE_REPLICA_DEPLOYMENT_SHARE_WARN * 100).toFixed(0)}% threshold) — consolidation may improve fleet density`,
+        remediation: REMEDIATION,
+      };
+    }
+
+    return {
+      checkId: CHECK_ID,
+      checkName: CHECK_NAME,
+      pillar: Pillar.Sustainability,
+      status: CheckStatus.Passing,
+      severity: Severity.Medium,
+      message: `Replica sprawl heuristics nominal: ${singleReplica} of ${active} in-scope Deployments are single-replica (${(share * 100).toFixed(0)}%)`,
+      remediation: REMEDIATION,
+    };
+  },
+};

--- a/src/assessment/runner.integration.test.ts
+++ b/src/assessment/runner.integration.test.ts
@@ -345,8 +345,11 @@ describe('AssessmentRunner (integration)', () => {
       pillarFilter: Pillar.Sustainability,
     });
 
-    expect(checks.length).toBe(1);
-    expect(checks.map((c) => c.id)).toEqual(['sustainability.resource-efficiency-signals']);
+    expect(checks.length).toBe(2);
+    expect(checks.map((c) => c.id)).toEqual([
+      'sustainability.resource-efficiency-signals',
+      'sustainability.workload-consolidation-signals',
+    ]);
 
     const sustainabilityMockK8s = {
       coreApi: {
@@ -431,12 +434,15 @@ describe('AssessmentRunner (integration)', () => {
     });
 
     expect(record.run_id).toBe('run-sustainability-pillar');
-    expect(record.total_checks).toBe(1);
-    expect(record.completed_checks).toBe(1);
-    expect(record.passed_checks).toBe(1);
+    expect(record.total_checks).toBe(2);
+    expect(record.completed_checks).toBe(2);
+    expect(record.passed_checks).toBe(2);
 
     const history = storage.queryHistory({ filters: { run_id: 'run-sustainability-pillar' } });
-    expect(history).toHaveLength(1);
-    expect(history[0]?.check_id).toBe('sustainability.resource-efficiency-signals');
+    expect(history).toHaveLength(2);
+    expect(history.map((h) => h.check_id)).toEqual([
+      'sustainability.resource-efficiency-signals',
+      'sustainability.workload-consolidation-signals',
+    ]);
   });
 });

--- a/src/assessment/runner.integration.test.ts
+++ b/src/assessment/runner.integration.test.ts
@@ -335,4 +335,108 @@ describe('AssessmentRunner (integration)', () => {
       'cost-optimization.spot-instance-usage',
     ]);
   });
+
+  it('sustainability pillar checks are discoverable and runnable', async () => {
+    resetRegistry();
+    bootstrapAssessmentRegistry();
+
+    const checks = resolveChecksForRun({
+      mode: AssessmentRunMode.Pillar,
+      pillarFilter: Pillar.Sustainability,
+    });
+
+    expect(checks.length).toBe(1);
+    expect(checks.map((c) => c.id)).toEqual(['sustainability.resource-efficiency-signals']);
+
+    const sustainabilityMockK8s = {
+      coreApi: {
+        listNode: async () => ({
+          items: [
+            {
+              metadata: { name: 'integration-node' },
+              spec: { unschedulable: false },
+              status: {
+                allocatable: { cpu: '8', memory: '16Gi' },
+              },
+            },
+          ],
+        }),
+        listPodForAllNamespaces: async () => ({ items: [] }),
+        listConfigMapForAllNamespaces: async () => ({ items: [] }),
+        listResourceQuotaForAllNamespaces: async () => ({ items: [] }),
+        listLimitRangeForAllNamespaces: async () => ({ items: [] }),
+        listNamespace: async () => ({ items: [] }),
+      },
+      appsApi: {
+        listDeploymentForAllNamespaces: async () => ({
+          items: [
+            {
+              metadata: { namespace: 'default', name: 'integration-app' },
+              spec: {
+                replicas: 2,
+                template: {
+                  spec: {
+                    containers: [
+                      {
+                        name: 'main',
+                        resources: {
+                          requests: { cpu: '2', memory: '4Gi' },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        }),
+        listStatefulSetForAllNamespaces: async () => ({ items: [] }),
+        listDaemonSetForAllNamespaces: async () => ({ items: [] }),
+      },
+      autoscalingApi: {
+        listHorizontalPodAutoscalerForAllNamespaces: async () => ({ items: [] }),
+      },
+      policyApi: {
+        listPodDisruptionBudgetForAllNamespaces: async () => ({ items: [] }),
+      },
+      apiextensionsApi: {
+        readCustomResourceDefinition: async () => ({
+          metadata: { name: 'externalsecrets.external-secrets.io' },
+        }),
+        listCustomResourceDefinition: async () => ({ body: { items: [] }, items: [] }),
+      },
+      customObjectsApi: {
+        listClusterCustomObject: async () => ({ body: { items: [] }, items: [] }),
+      },
+      rbacApi: {
+        listClusterRole: async () => ({ items: [] }),
+        listRoleForAllNamespaces: async () => ({ items: [] }),
+        listClusterRoleBinding: async () => ({ items: [] }),
+        listRoleBindingForAllNamespaces: async () => ({ items: [] }),
+      },
+    } as never;
+
+    const storage = new AssessmentRepository();
+    const runner = new AssessmentRunner({
+      kubernetes: sustainabilityMockK8s,
+      config: mockConfig,
+      logger: mockLogger,
+      storage,
+    });
+
+    const record = await runner.run({
+      runId: 'run-sustainability-pillar',
+      mode: AssessmentRunMode.Pillar,
+      pillarFilter: Pillar.Sustainability,
+    });
+
+    expect(record.run_id).toBe('run-sustainability-pillar');
+    expect(record.total_checks).toBe(1);
+    expect(record.completed_checks).toBe(1);
+    expect(record.passed_checks).toBe(1);
+
+    const history = storage.queryHistory({ filters: { run_id: 'run-sustainability-pillar' } });
+    expect(history).toHaveLength(1);
+    expect(history[0]?.check_id).toBe('sustainability.resource-efficiency-signals');
+  });
 });


### PR DESCRIPTION
## Description

Adds Sustainability pillar assessment checks under `src/assessment/checks/sustainability/`:

- **`sustainability.resource-efficiency-signals`** — Compares aggregate declared CPU/memory requests (in-scope Deployments, StatefulSets, DaemonSets) to schedulable node allocatable and warns on very low reservation versus capacity (idle-capacity signal).
- **`sustainability.workload-consolidation-signals`** — Surfaces high single-replica **Deployment** sprawl among in-scope workloads as a consolidation / density hint (StatefulSets are not scored as single-replica sprawl to avoid false positives on stateful data tiers). Does not duplicate PDB, anti-affinity, or spread checks.

Both checks register in `bootstrapAssessmentRegistry()`; pillar integration smoke covers `Pillar.Sustainability`.

## Motivation and Context

Implements the Sustainability pillar slice from parent [#21](https://github.com/alto9/kube9-operator/issues/21), covering sub-issues [#120](https://github.com/alto9/kube9-operator/issues/120) (resource efficiency) and [#121](https://github.com/alto9/kube9-operator/issues/121) (workload consolidation).

Fixes #120
Fixes #121
Fixes #21

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All new and existing tests pass (`npm test`, `npm run test:integration` for touched suites)
- [x] Linter (`npm run lint`)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)
