### PR TITLE
feat(assessment): schedule, operator wiring, status ConfigMap summary (#22)

### DIFF
--- a/charts/kube9-operator/templates/deployment.yaml
+++ b/charts/kube9-operator/templates/deployment.yaml
@@ -99,6 +99,18 @@ spec:
           value: {{ .Values.trivy.vulnMaxMedium | quote }}
         - name: WORKLOAD_IMAGE_SCAN_INTERVAL_SECONDS
           value: {{ .Values.metrics.intervals.workloadImageScan | default 86400 | quote }}
+        # Periodic assessment schedule (see assessment.* in values.yaml)
+        {{- $assessment := .Values.assessment | default dict }}
+        - name: ASSESSMENT_ENABLED
+          value: {{ $assessment.enabled | default false | quote }}
+        - name: ASSESSMENT_INTERVAL_SECONDS
+          value: {{ $assessment.intervalSeconds | default 86400 | quote }}
+        - name: ASSESSMENT_MODE
+          value: {{ $assessment.mode | default "full" | quote }}
+        {{- if $assessment.timeoutSeconds }}
+        - name: ASSESSMENT_TIMEOUT_SECONDS
+          value: {{ $assessment.timeoutSeconds | quote }}
+        {{- end }}
         # Event retention configuration
         - name: EVENT_RETENTION_INFO_WARNING_DAYS
           value: {{ .Values.events.retention.infoWarning | default 7 | quote }}

--- a/charts/kube9-operator/values.yaml
+++ b/charts/kube9-operator/values.yaml
@@ -86,6 +86,16 @@ metrics:
     # Minimum: 3600 seconds (1 hour)
     workloadImageScan: 86400
 
+# Periodic Well-Architected assessment scheduling (operator reads these at startup)
+assessment:
+  enabled: false
+  # Interval between scheduled runs when enabled (seconds). Minimum: 3600
+  intervalSeconds: 86400
+  # Default mode for scheduled runs: full | pillar | single-check
+  mode: full
+  # Optional per-run timeout in seconds (omit to use runner defaults)
+  # timeoutSeconds: 3600
+
 # Event storage configuration
 events:
   # PersistentVolume configuration for event database

--- a/src/assessment/bootstrap.ts
+++ b/src/assessment/bootstrap.ts
@@ -83,7 +83,8 @@ const BUILT_IN_CHECKS: AssessmentCheck[] = [
 /**
  * Bootstrap the assessment check registry with built-in checks.
  * Validates all checks and fails fast on first invalid or duplicate.
- * Safe to call multiple times; duplicate registration will throw.
+ * Calling this when checks are already registered throws; the operator uses
+ * `ensureAssessmentRegistryBootstrapped` in `scheduled-tick.ts` for idempotent wiring.
  */
 export function bootstrapAssessmentRegistry(): void {
   const registry = getRegistry();

--- a/src/assessment/runner.integration.test.ts
+++ b/src/assessment/runner.integration.test.ts
@@ -79,6 +79,9 @@ const mockConfig = {
   workloadImageScanIntervalSeconds: 86400,
   eventRetentionInfoWarningDays: 7,
   eventRetentionErrorCriticalDays: 30,
+  assessmentEnabled: false,
+  assessmentIntervalSeconds: 86400,
+  assessmentMode: 'full',
 } as never;
 const mockLogger = {
   info: () => {},

--- a/src/assessment/scheduled-tick.test.ts
+++ b/src/assessment/scheduled-tick.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, rmSync } from 'fs';
+import path from 'path';
+import { AssessmentRunner } from './runner.js';
+import { getRegistry, resetRegistry } from './registry.js';
+import {
+  ensureAssessmentRegistryBootstrapped,
+  runScheduledAssessmentTick,
+  getScheduledAssessmentLastRunSnapshot,
+  resetScheduledAssessmentStateForTests,
+} from './scheduled-tick.js';
+import type { Config } from '../config/types.js';
+import type { Logger } from 'winston';
+import { DatabaseManager } from '../database/manager.js';
+import { SchemaManager } from '../database/schema.js';
+
+const baseConfig = {
+  serverUrl: 'https://test',
+  logLevel: 'info',
+  statusUpdateIntervalSeconds: 60,
+  reregistrationIntervalHours: 24,
+  clusterMetadataIntervalSeconds: 86400,
+  resourceInventoryIntervalSeconds: 21600,
+  resourceConfigurationPatternsIntervalSeconds: 43200,
+  workloadImageScanIntervalSeconds: 86400,
+  eventRetentionInfoWarningDays: 7,
+  eventRetentionErrorCriticalDays: 30,
+  assessmentEnabled: true,
+  assessmentIntervalSeconds: 86400,
+  assessmentMode: 'full' as const,
+} satisfies Config;
+
+const mockKubernetes = {
+  coreApi: {
+    listNode: async () => ({ items: [] }),
+    listPodForAllNamespaces: async () => ({ items: [] }),
+  },
+} as never;
+
+const mockLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+} as unknown as Logger;
+
+const testDbDir = path.join(process.cwd(), 'test-scheduled-tick-temp');
+
+describe('scheduled assessment tick', () => {
+  beforeAll(() => {
+    if (existsSync(testDbDir)) {
+      rmSync(testDbDir, { recursive: true, force: true });
+    }
+    mkdirSync(testDbDir, { recursive: true });
+    process.env.DB_PATH = testDbDir;
+  });
+
+  afterAll(() => {
+    DatabaseManager.reset();
+    if (existsSync(testDbDir)) {
+      rmSync(testDbDir, { recursive: true, force: true });
+    }
+    delete process.env.DB_PATH;
+  });
+
+  beforeEach(() => {
+    resetRegistry();
+    resetScheduledAssessmentStateForTests();
+    DatabaseManager.reset();
+    new SchemaManager().initialize();
+    vi.restoreAllMocks();
+    vi.mocked(mockLogger.error).mockClear();
+    vi.mocked(mockLogger.info).mockClear();
+    vi.mocked(mockLogger.warn).mockClear();
+    vi.mocked(mockLogger.debug).mockClear();
+  });
+
+  afterEach(() => {
+    resetRegistry();
+    resetScheduledAssessmentStateForTests();
+  });
+
+  it('ensureAssessmentRegistryBootstrapped registers once and is stable on repeat', () => {
+    expect(getRegistry().size).toBe(0);
+    ensureAssessmentRegistryBootstrapped();
+    const afterFirst = getRegistry().size;
+    expect(afterFirst).toBeGreaterThan(0);
+    ensureAssessmentRegistryBootstrapped();
+    expect(getRegistry().size).toBe(afterFirst);
+  });
+
+  it('runScheduledAssessmentTick records failed snapshot when runner.run throws', async () => {
+    ensureAssessmentRegistryBootstrapped();
+    vi.spyOn(AssessmentRunner.prototype, 'run').mockRejectedValue(new Error('simulated runner failure'));
+
+    await runScheduledAssessmentTick({
+      kubernetes: mockKubernetes,
+      config: baseConfig,
+      logger: mockLogger,
+    });
+
+    const snap = getScheduledAssessmentLastRunSnapshot();
+    expect(snap?.outcome).toBe('failed');
+    expect(snap?.errorMessage).toContain('simulated runner failure');
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+
+  it('runScheduledAssessmentTick records success snapshot when runner completes', async () => {
+    ensureAssessmentRegistryBootstrapped();
+    vi.spyOn(AssessmentRunner.prototype, 'run').mockResolvedValue({
+      run_id: 'scheduled-test-run',
+      mode: 'full',
+      state: 'completed',
+      requested_at: new Date().toISOString(),
+      started_at: new Date().toISOString(),
+      completed_at: new Date().toISOString(),
+      total_checks: 3,
+      completed_checks: 3,
+      passed_checks: 2,
+      failed_checks: 0,
+      warning_checks: 1,
+      skipped_checks: 0,
+      error_checks: 0,
+      timeout_checks: 0,
+    } as Awaited<ReturnType<AssessmentRunner['run']>>);
+
+    await runScheduledAssessmentTick({
+      kubernetes: mockKubernetes,
+      config: baseConfig,
+      logger: mockLogger,
+    });
+
+    const snap = getScheduledAssessmentLastRunSnapshot();
+    expect(snap?.outcome).toBe('success');
+    expect(snap?.runId).toBe('scheduled-test-run');
+    expect(snap?.passedChecks).toBe(2);
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/assessment/scheduled-tick.ts
+++ b/src/assessment/scheduled-tick.ts
@@ -1,0 +1,139 @@
+/**
+ * Periodic scheduled assessment execution (operator CollectionScheduler task).
+ *
+ * On each tick: ensures the global check registry is bootstrapped, runs {@link AssessmentRunner}
+ * with the same persistence stack as `assess run` ({@link AssessmentRepository},
+ * {@link ImageScanRepository} via runner defaults), and records a lightweight in-memory
+ * snapshot for status consumers.
+ */
+
+import type { Config } from '../config/types.js';
+import type { KubernetesClient } from '../kubernetes/client.js';
+import type { Logger } from 'winston';
+import type { TrivyStatus } from '../status/types.js';
+import { AssessmentRunner } from './runner.js';
+import { bootstrapAssessmentRegistry } from './bootstrap.js';
+import { getRegistry } from './registry.js';
+import { AssessmentRunMode, isPillar, type Pillar } from './types.js';
+import { AssessmentRepository } from '../database/assessment-repository.js';
+import { ImageScanRepository } from '../database/image-scan-repository.js';
+
+export type ScheduledAssessmentRunOutcome = 'success' | 'failed';
+
+/** Last completed scheduled tick; safe to read from the Node main thread between ticks. */
+export interface ScheduledAssessmentLastRunSnapshot {
+  startedAt: string;
+  completedAt: string;
+  outcome: ScheduledAssessmentRunOutcome;
+  runId?: string;
+  state?: string;
+  totalChecks?: number;
+  completedChecks?: number;
+  passedChecks?: number;
+  failedChecks?: number;
+  warningChecks?: number;
+  errorMessage?: string;
+}
+
+let lastRunSnapshot: ScheduledAssessmentLastRunSnapshot | null = null;
+
+/** @internal */
+export function resetScheduledAssessmentStateForTests(): void {
+  lastRunSnapshot = null;
+}
+
+export function getScheduledAssessmentLastRunSnapshot(): ScheduledAssessmentLastRunSnapshot | null {
+  return lastRunSnapshot;
+}
+
+/**
+ * Idempotent registry wiring: bootstraps built-in checks when the registry is empty.
+ */
+export function ensureAssessmentRegistryBootstrapped(): void {
+  if (getRegistry().size === 0) {
+    bootstrapAssessmentRegistry();
+  }
+}
+
+function mapConfigModeToRunInput(config: Config): {
+  mode: AssessmentRunMode;
+  pillarFilter?: Pillar;
+} {
+  switch (config.assessmentMode) {
+    case 'full':
+      return { mode: AssessmentRunMode.Full };
+    case 'pillar': {
+      const raw = config.assessmentPillar;
+      if (!raw || !isPillar(raw)) {
+        throw new Error(
+          'assessmentPillar must be set to a valid pillar when assessmentMode is "pillar"'
+        );
+      }
+      return { mode: AssessmentRunMode.Pillar, pillarFilter: raw };
+    }
+    default:
+      throw new Error(`Unsupported scheduled assessment mode: ${String(config.assessmentMode)}`);
+  }
+}
+
+export interface ScheduledAssessmentTickDeps {
+  kubernetes: KubernetesClient;
+  config: Config;
+  logger: Logger;
+  getTrivyStatus?: () => TrivyStatus;
+}
+
+/**
+ * Executes one scheduled assessment run. Swallows errors so scheduler callbacks never throw.
+ */
+export async function runScheduledAssessmentTick(deps: ScheduledAssessmentTickDeps): Promise<void> {
+  const startedAt = new Date().toISOString();
+  try {
+    ensureAssessmentRegistryBootstrapped();
+
+    const { mode, pillarFilter } = mapConfigModeToRunInput(deps.config);
+    const timeoutMs =
+      deps.config.assessmentTimeoutSeconds !== undefined
+        ? deps.config.assessmentTimeoutSeconds * 1000
+        : undefined;
+
+    const storage = new AssessmentRepository();
+    const imageScanRepository = new ImageScanRepository();
+    const runner = new AssessmentRunner({
+      kubernetes: deps.kubernetes,
+      config: deps.config,
+      logger: deps.logger,
+      storage,
+      getTrivyStatus: deps.getTrivyStatus,
+      imageScanRepository,
+    });
+
+    const record = await runner.run({
+      mode,
+      pillarFilter,
+      timeoutMs,
+    });
+
+    lastRunSnapshot = {
+      startedAt,
+      completedAt: new Date().toISOString(),
+      outcome: 'success',
+      runId: record.run_id,
+      state: record.state,
+      totalChecks: record.total_checks,
+      completedChecks: record.completed_checks,
+      passedChecks: record.passed_checks,
+      failedChecks: record.failed_checks,
+      warningChecks: record.warning_checks,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    deps.logger.error('Scheduled assessment tick failed', { error: errorMessage });
+    lastRunSnapshot = {
+      startedAt,
+      completedAt: new Date().toISOString(),
+      outcome: 'failed',
+      errorMessage,
+    };
+  }
+}

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -6,6 +6,7 @@ const trackedKeys = [
   'ASSESSMENT_ENABLED',
   'ASSESSMENT_INTERVAL_SECONDS',
   'ASSESSMENT_MODE',
+  'ASSESSMENT_PILLAR',
   'ASSESSMENT_TIMEOUT_SECONDS',
 ] as const;
 
@@ -35,6 +36,7 @@ describe('loadConfig — assessment schedule', () => {
     delete process.env.ASSESSMENT_ENABLED;
     delete process.env.ASSESSMENT_INTERVAL_SECONDS;
     delete process.env.ASSESSMENT_MODE;
+    delete process.env.ASSESSMENT_PILLAR;
     delete process.env.ASSESSMENT_TIMEOUT_SECONDS;
   });
 
@@ -54,10 +56,25 @@ describe('loadConfig — assessment schedule', () => {
     process.env.ASSESSMENT_ENABLED = 'true';
     process.env.ASSESSMENT_INTERVAL_SECONDS = '7200';
     process.env.ASSESSMENT_MODE = 'pillar';
+    process.env.ASSESSMENT_PILLAR = 'security';
     const config = await loadConfig();
     expect(config.assessmentEnabled).toBe(true);
     expect(config.assessmentIntervalSeconds).toBe(7200);
     expect(config.assessmentMode).toBe('pillar');
+    expect(config.assessmentPillar).toBe('security');
+  });
+
+  it('rejects pillar mode when enabled without ASSESSMENT_PILLAR', async () => {
+    process.env.ASSESSMENT_ENABLED = 'true';
+    process.env.ASSESSMENT_MODE = 'pillar';
+    await expect(loadConfig()).rejects.toThrow(/ASSESSMENT_PILLAR/);
+  });
+
+  it('rejects invalid ASSESSMENT_PILLAR', async () => {
+    process.env.ASSESSMENT_ENABLED = 'true';
+    process.env.ASSESSMENT_MODE = 'pillar';
+    process.env.ASSESSMENT_PILLAR = 'not-a-pillar';
+    await expect(loadConfig()).rejects.toThrow(/ASSESSMENT_PILLAR/);
   });
 
   it('rejects interval below minimum', async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { loadConfig } from './loader.js';
+
+const trackedKeys = [
+  'SERVER_URL',
+  'ASSESSMENT_ENABLED',
+  'ASSESSMENT_INTERVAL_SECONDS',
+  'ASSESSMENT_MODE',
+  'ASSESSMENT_TIMEOUT_SECONDS',
+] as const;
+
+const snapshots: Partial<Record<(typeof trackedKeys)[number], string | undefined>> = {};
+
+function stashEnv(): void {
+  for (const key of trackedKeys) {
+    snapshots[key] = process.env[key];
+  }
+}
+
+function restoreEnv(): void {
+  for (const key of trackedKeys) {
+    const v = snapshots[key];
+    if (v === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = v;
+    }
+  }
+}
+
+describe('loadConfig — assessment schedule', () => {
+  beforeEach(() => {
+    stashEnv();
+    process.env.SERVER_URL = 'https://config-test.example';
+    delete process.env.ASSESSMENT_ENABLED;
+    delete process.env.ASSESSMENT_INTERVAL_SECONDS;
+    delete process.env.ASSESSMENT_MODE;
+    delete process.env.ASSESSMENT_TIMEOUT_SECONDS;
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('applies defaults when assessment env vars are omitted', async () => {
+    const config = await loadConfig();
+    expect(config.assessmentEnabled).toBe(false);
+    expect(config.assessmentIntervalSeconds).toBe(86400);
+    expect(config.assessmentMode).toBe('full');
+    expect(config.assessmentTimeoutSeconds).toBeUndefined();
+  });
+
+  it('parses enabled schedule with pillar mode', async () => {
+    process.env.ASSESSMENT_ENABLED = 'true';
+    process.env.ASSESSMENT_INTERVAL_SECONDS = '7200';
+    process.env.ASSESSMENT_MODE = 'pillar';
+    const config = await loadConfig();
+    expect(config.assessmentEnabled).toBe(true);
+    expect(config.assessmentIntervalSeconds).toBe(7200);
+    expect(config.assessmentMode).toBe('pillar');
+  });
+
+  it('rejects interval below minimum', async () => {
+    process.env.ASSESSMENT_INTERVAL_SECONDS = '3599';
+    await expect(loadConfig()).rejects.toThrow(/ASSESSMENT_INTERVAL_SECONDS/);
+  });
+
+  it('rejects invalid mode string', async () => {
+    process.env.ASSESSMENT_MODE = 'nope';
+    await expect(loadConfig()).rejects.toThrow(/ASSESSMENT_MODE/);
+  });
+
+  it('allows single-check mode when scheduling is disabled', async () => {
+    process.env.ASSESSMENT_ENABLED = 'false';
+    process.env.ASSESSMENT_MODE = 'single-check';
+    const config = await loadConfig();
+    expect(config.assessmentMode).toBe('single-check');
+  });
+
+  it('rejects single-check when scheduling is enabled', async () => {
+    process.env.ASSESSMENT_ENABLED = '1';
+    process.env.ASSESSMENT_MODE = 'single-check';
+    await expect(loadConfig()).rejects.toThrow(/single-check/);
+  });
+
+  it('parses optional timeout seconds', async () => {
+    process.env.ASSESSMENT_TIMEOUT_SECONDS = '120';
+    const config = await loadConfig();
+    expect(config.assessmentTimeoutSeconds).toBe(120);
+  });
+
+  it('rejects timeout out of range', async () => {
+    process.env.ASSESSMENT_TIMEOUT_SECONDS = '30';
+    await expect(loadConfig()).rejects.toThrow(/ASSESSMENT_TIMEOUT_SECONDS/);
+  });
+
+  it('rejects invalid ASSESSMENT_ENABLED', async () => {
+    process.env.ASSESSMENT_ENABLED = 'sure';
+    await expect(loadConfig()).rejects.toThrow(/ASSESSMENT_ENABLED/);
+  });
+});

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,5 +1,6 @@
 import type { Config } from './types.js';
 import { logger } from '../logging/logger.js';
+import { isPillar } from '../assessment/types.js';
 
 const ASSESSMENT_MODES = ['full', 'pillar', 'single-check'] as const;
 type AssessmentMode = (typeof ASSESSMENT_MODES)[number];
@@ -117,6 +118,22 @@ export async function loadConfig(): Promise<Config> {
     );
   }
 
+  let assessmentPillar: string | undefined;
+  if (assessmentEnabled && assessmentMode === 'pillar') {
+    const raw = process.env.ASSESSMENT_PILLAR?.trim();
+    if (!raw) {
+      throw new Error(
+        'ASSESSMENT_PILLAR is required when ASSESSMENT_ENABLED=true and ASSESSMENT_MODE=pillar'
+      );
+    }
+    if (!isPillar(raw)) {
+      throw new Error(
+        `Invalid ASSESSMENT_PILLAR "${raw}" (must be a Well-Architected pillar id)`
+      );
+    }
+    assessmentPillar = raw;
+  }
+
   const config: Config = {
     serverUrl,
     logLevel,
@@ -131,6 +148,7 @@ export async function loadConfig(): Promise<Config> {
     assessmentEnabled,
     assessmentIntervalSeconds,
     assessmentMode,
+    ...(assessmentPillar !== undefined ? { assessmentPillar } : {}),
     ...(assessmentTimeoutSeconds !== undefined
       ? { assessmentTimeoutSeconds }
       : {}),
@@ -152,10 +170,12 @@ export async function loadConfig(): Promise<Config> {
     assessmentEnabled: config.assessmentEnabled,
     assessmentIntervalSeconds: config.assessmentIntervalSeconds,
     assessmentMode: config.assessmentMode,
+    assessmentPillar: config.assessmentPillar ?? null,
     assessmentTimeoutSeconds: config.assessmentTimeoutSeconds ?? null,
     assessmentEnabledOverridden: process.env.ASSESSMENT_ENABLED !== undefined,
     assessmentIntervalOverridden: process.env.ASSESSMENT_INTERVAL_SECONDS !== undefined,
     assessmentModeOverridden: process.env.ASSESSMENT_MODE !== undefined,
+    assessmentPillarOverridden: process.env.ASSESSMENT_PILLAR !== undefined,
     assessmentTimeoutOverridden: process.env.ASSESSMENT_TIMEOUT_SECONDS !== undefined,
   });
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,6 +1,39 @@
 import type { Config } from './types.js';
 import { logger } from '../logging/logger.js';
 
+const ASSESSMENT_MODES = ['full', 'pillar', 'single-check'] as const;
+type AssessmentMode = (typeof ASSESSMENT_MODES)[number];
+
+const ASSESSMENT_INTERVAL_MIN_SECONDS = 3600;
+const ASSESSMENT_TIMEOUT_MIN_SECONDS = 60;
+const ASSESSMENT_TIMEOUT_MAX_SECONDS = 7 * 24 * 3600;
+
+function parseEnvBool(raw: string | undefined, defaultValue: boolean): boolean {
+  if (raw === undefined || raw === '') {
+    return defaultValue;
+  }
+  const v = raw.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(v)) {
+    return true;
+  }
+  if (['0', 'false', 'no', 'off'].includes(v)) {
+    return false;
+  }
+  throw new Error(
+    `Invalid boolean for ASSESSMENT_ENABLED: "${raw}" (use true/false, 1/0, yes/no)`
+  );
+}
+
+function parseAssessmentMode(raw: string | undefined): AssessmentMode {
+  const v = (raw ?? 'full').trim().toLowerCase();
+  if ((ASSESSMENT_MODES as readonly string[]).includes(v)) {
+    return v as AssessmentMode;
+  }
+  throw new Error(
+    `ASSESSMENT_MODE must be one of ${ASSESSMENT_MODES.join(', ')}; got "${raw ?? ''}"`
+  );
+}
+
 /**
  * Load configuration from environment variables
  *
@@ -43,10 +76,45 @@ export async function loadConfig(): Promise<Config> {
     process.env.EVENT_RETENTION_ERROR_CRITICAL_DAYS || '30',
     10
   );
+  const assessmentEnabled = parseEnvBool(process.env.ASSESSMENT_ENABLED, false);
+  const assessmentIntervalSeconds = parseInt(
+    process.env.ASSESSMENT_INTERVAL_SECONDS || '86400',
+    10
+  );
+  const assessmentMode = parseAssessmentMode(process.env.ASSESSMENT_MODE);
+  const assessmentTimeoutRaw = process.env.ASSESSMENT_TIMEOUT_SECONDS;
+  let assessmentTimeoutSeconds: number | undefined;
+  if (assessmentTimeoutRaw !== undefined && assessmentTimeoutRaw !== '') {
+    assessmentTimeoutSeconds = parseInt(assessmentTimeoutRaw, 10);
+    if (
+      Number.isNaN(assessmentTimeoutSeconds) ||
+      assessmentTimeoutSeconds < ASSESSMENT_TIMEOUT_MIN_SECONDS ||
+      assessmentTimeoutSeconds > ASSESSMENT_TIMEOUT_MAX_SECONDS
+    ) {
+      throw new Error(
+        `ASSESSMENT_TIMEOUT_SECONDS must be an integer between ${ASSESSMENT_TIMEOUT_MIN_SECONDS} and ${ASSESSMENT_TIMEOUT_MAX_SECONDS}`
+      );
+    }
+  }
 
   // Validate required environment variables
   if (!serverUrl) {
     throw new Error('SERVER_URL environment variable is required');
+  }
+
+  if (
+    Number.isNaN(assessmentIntervalSeconds) ||
+    assessmentIntervalSeconds < ASSESSMENT_INTERVAL_MIN_SECONDS
+  ) {
+    throw new Error(
+      `ASSESSMENT_INTERVAL_SECONDS must be an integer >= ${ASSESSMENT_INTERVAL_MIN_SECONDS}`
+    );
+  }
+
+  if (assessmentEnabled && assessmentMode === 'single-check') {
+    throw new Error(
+      'ASSESSMENT_MODE cannot be "single-check" for scheduled assessments (no check id context)'
+    );
   }
 
   const config: Config = {
@@ -60,6 +128,12 @@ export async function loadConfig(): Promise<Config> {
     workloadImageScanIntervalSeconds,
     eventRetentionInfoWarningDays,
     eventRetentionErrorCriticalDays,
+    assessmentEnabled,
+    assessmentIntervalSeconds,
+    assessmentMode,
+    ...(assessmentTimeoutSeconds !== undefined
+      ? { assessmentTimeoutSeconds }
+      : {}),
   };
 
   // Log configured intervals (and any overrides)
@@ -72,6 +146,17 @@ export async function loadConfig(): Promise<Config> {
     resourceConfigurationPatternsOverridden: process.env.RESOURCE_CONFIGURATION_PATTERNS_INTERVAL_SECONDS !== undefined,
     workloadImageScanIntervalSeconds: config.workloadImageScanIntervalSeconds,
     workloadImageScanOverridden: process.env.WORKLOAD_IMAGE_SCAN_INTERVAL_SECONDS !== undefined,
+  });
+
+  logger.info('Assessment schedule configured', {
+    assessmentEnabled: config.assessmentEnabled,
+    assessmentIntervalSeconds: config.assessmentIntervalSeconds,
+    assessmentMode: config.assessmentMode,
+    assessmentTimeoutSeconds: config.assessmentTimeoutSeconds ?? null,
+    assessmentEnabledOverridden: process.env.ASSESSMENT_ENABLED !== undefined,
+    assessmentIntervalOverridden: process.env.ASSESSMENT_INTERVAL_SECONDS !== undefined,
+    assessmentModeOverridden: process.env.ASSESSMENT_MODE !== undefined,
+    assessmentTimeoutOverridden: process.env.ASSESSMENT_TIMEOUT_SECONDS !== undefined,
   });
 
   return config;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -78,6 +78,12 @@ export interface Config {
   assessmentMode: 'full' | 'pillar' | 'single-check';
 
   /**
+   * Well-Architected pillar id when {@link assessmentMode} is `pillar` and scheduling is enabled.
+   * Set from `ASSESSMENT_PILLAR` (e.g. `security`).
+   */
+  assessmentPillar?: string;
+
+  /**
    * Optional wall-clock cap for a scheduled assessment run (seconds).
    * When unset, runners use their own defaults.
    */

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -58,5 +58,29 @@ export interface Config {
    * Default: 30 days
    */
   eventRetentionErrorCriticalDays: number;
+
+  /**
+   * When true, the operator may run periodic Well-Architected assessments on a schedule.
+   * Default: false (scheduler wiring is optional until enabled in deployment).
+   */
+  assessmentEnabled: boolean;
+
+  /**
+   * Seconds between scheduled assessment runs when {@link assessmentEnabled} is true.
+   * Default: 86400 (24 hours). Minimum: 3600 (1 hour).
+   */
+  assessmentIntervalSeconds: number;
+
+  /**
+   * Default run mode for scheduled assessments (CLI may still override per run).
+   * One of: full, pillar, single-check
+   */
+  assessmentMode: 'full' | 'pillar' | 'single-check';
+
+  /**
+   * Optional wall-clock cap for a scheduled assessment run (seconds).
+   * When unset, runners use their own defaults.
+   */
+  assessmentTimeoutSeconds?: number;
 }
 

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -29,6 +29,10 @@ import { SchemaManager } from './database/schema.js';
 import { KubernetesEventWatcher } from './events/kubernetes-event-watcher.js';
 import { EventQueueWorker } from './events/queue-worker.js';
 import { registerEventWatcher } from './events/health.js';
+import {
+  runScheduledAssessmentTick,
+  getScheduledAssessmentLastRunSnapshot,
+} from './assessment/scheduled-tick.js';
 
 // Module-level references for shutdown handler
 let statusWriterInstance: StatusWriter | null = null;
@@ -354,6 +358,45 @@ export async function startOperator() {
         }
       }
     );
+
+    if (config.assessmentEnabled) {
+      collectionScheduler.register(
+        'well-architected-assessment',
+        config.assessmentIntervalSeconds,
+        3600,
+        3600,
+        async () => {
+          const startTime = Date.now();
+          try {
+            await runScheduledAssessmentTick({
+              kubernetes: kubernetesClient,
+              config,
+              logger,
+              getTrivyStatus: () => trivyStatusTracker.getStatus(),
+            });
+            const durationSeconds = (Date.now() - startTime) / 1000;
+            const snap = getScheduledAssessmentLastRunSnapshot();
+            const tickOk = snap?.outcome !== 'failed';
+            recordCollection(
+              'well-architected-assessment',
+              tickOk ? 'success' : 'failed',
+              durationSeconds
+            );
+            if (tickOk) {
+              collectionStatsTracker.recordSuccess('well-architected-assessment');
+            } else {
+              collectionStatsTracker.recordFailure('well-architected-assessment');
+            }
+          } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            logger.error('Scheduled assessment tick failed unexpectedly', { error: errorMessage });
+            const durationSeconds = (Date.now() - startTime) / 1000;
+            recordCollection('well-architected-assessment', 'failed', durationSeconds);
+            collectionStatsTracker.recordFailure('well-architected-assessment');
+          }
+        }
+      );
+    }
     
       // Start scheduler
       collectionScheduler.start();

--- a/src/registration/manager.test.ts
+++ b/src/registration/manager.test.ts
@@ -24,6 +24,9 @@ function createMockConfig(): Config {
     workloadImageScanIntervalSeconds: 86400,
     eventRetentionInfoWarningDays: 7,
     eventRetentionErrorCriticalDays: 30,
+    assessmentEnabled: false,
+    assessmentIntervalSeconds: 86400,
+    assessmentMode: 'full',
   };
 }
 

--- a/src/shutdown/handler.ts
+++ b/src/shutdown/handler.ts
@@ -11,6 +11,8 @@ import { logger } from '../logging/logger.js';
 import { collectionStatsTracker } from '../collection/stats-tracker.js';
 import { argocdStatusTracker } from '../argocd/state.js';
 import { trivyStatusTracker } from '../trivy/state.js';
+import { buildAssessmentStatusSummary } from '../status/assessment-summary.js';
+import { getScheduledAssessmentLastRunSnapshot } from '../assessment/scheduled-tick.js';
 
 /**
  * Operator version (semver)
@@ -115,6 +117,7 @@ export async function gracefulShutdown(
     const collectionStats = collectionStatsTracker.getStats();
     const argocdStatus = argocdStatusTracker.getStatus();
     const trivyStatus = trivyStatusTracker.getStatus();
+    const assessmentSummary = buildAssessmentStatusSummary(getScheduledAssessmentLastRunSnapshot());
     const finalStatus: OperatorStatus = {
       mode: "operated",
       tier: "free",
@@ -131,7 +134,11 @@ export async function gracefulShutdown(
         lastSuccessTime: collectionStats.lastSuccessTime
       },
       argocd: argocdStatus,
-      trivy: trivyStatus
+      trivy: trivyStatus,
+      assessment: {
+        ...assessmentSummary,
+        lastScheduledTotals: { ...assessmentSummary.lastScheduledTotals },
+      },
     };
 
     // Include clusterId if registered

--- a/src/status/assessment-summary.ts
+++ b/src/status/assessment-summary.ts
@@ -1,0 +1,70 @@
+import type { ScheduledAssessmentLastRunSnapshot } from '../assessment/scheduled-tick.js';
+import type { AssessmentStatusSummary } from './types.js';
+
+const MAX_ASSESSMENT_ERROR_SUMMARY = 200;
+
+/**
+ * Default assessment summary before any scheduled tick has completed in-process.
+ */
+export const DEFAULT_ASSESSMENT_STATUS_SUMMARY: AssessmentStatusSummary = {
+  lastScheduledCompletedAt: null,
+  lastScheduledOutcome: 'none',
+  lastScheduledRunState: null,
+  lastScheduledRunId: null,
+  lastScheduledTotals: {
+    totalChecks: 0,
+    completedChecks: 0,
+    passedChecks: 0,
+    failedChecks: 0,
+    warningChecks: 0,
+  },
+  lastScheduledError: null,
+};
+
+const ZERO_TOTALS = DEFAULT_ASSESSMENT_STATUS_SUMMARY.lastScheduledTotals;
+
+/**
+ * Maps the in-memory scheduled assessment snapshot into a bounded status payload.
+ */
+export function buildAssessmentStatusSummary(
+  snap: ScheduledAssessmentLastRunSnapshot | null
+): AssessmentStatusSummary {
+  if (!snap) {
+    return {
+      ...DEFAULT_ASSESSMENT_STATUS_SUMMARY,
+      lastScheduledTotals: { ...ZERO_TOTALS },
+    };
+  }
+
+  if (snap.outcome === 'failed') {
+    const raw = snap.errorMessage ?? 'Scheduled assessment tick failed';
+    const lastScheduledError =
+      raw.length > MAX_ASSESSMENT_ERROR_SUMMARY
+        ? `${raw.slice(0, MAX_ASSESSMENT_ERROR_SUMMARY - 3)}...`
+        : raw;
+
+    return {
+      lastScheduledCompletedAt: snap.completedAt,
+      lastScheduledOutcome: 'failed',
+      lastScheduledRunState: null,
+      lastScheduledRunId: null,
+      lastScheduledTotals: { ...ZERO_TOTALS },
+      lastScheduledError,
+    };
+  }
+
+  return {
+    lastScheduledCompletedAt: snap.completedAt,
+    lastScheduledOutcome: 'success',
+    lastScheduledRunState: snap.state ?? null,
+    lastScheduledRunId: snap.runId ?? null,
+    lastScheduledTotals: {
+      totalChecks: snap.totalChecks ?? 0,
+      completedChecks: snap.completedChecks ?? 0,
+      passedChecks: snap.passedChecks ?? 0,
+      failedChecks: snap.failedChecks ?? 0,
+      warningChecks: snap.warningChecks ?? 0,
+    },
+    lastScheduledError: null,
+  };
+}

--- a/src/status/calculator.test.ts
+++ b/src/status/calculator.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import type { RegistrationState, CollectionStats, ArgoCDStatus, TrivyStatus } from './types.js';
+import type {
+  RegistrationState,
+  CollectionStats,
+  ArgoCDStatus,
+  TrivyStatus,
+  AssessmentStatusSummary,
+} from './types.js';
+import { DEFAULT_ASSESSMENT_STATUS_SUMMARY, buildAssessmentStatusSummary } from './assessment-summary.js';
 
 describe('calculateStatus', () => {
   let originalPodNamespace: string | undefined;
@@ -47,6 +54,10 @@ describe('calculateStatus', () => {
       expect(status.collectionStats).toBeDefined();
       expect(status.argocd).toBeDefined();
       expect(status.trivy).toBeDefined();
+      expect(status.assessment).toEqual({
+        ...DEFAULT_ASSESSMENT_STATUS_SUMMARY,
+        lastScheduledTotals: { ...DEFAULT_ASSESSMENT_STATUS_SUMMARY.lastScheduledTotals },
+      });
     });
 
     it('should return free tier when registered', async () => {
@@ -221,6 +232,108 @@ describe('calculateStatus', () => {
 
       expect(status.argocd).toEqual(argocdStatus);
       expect(status.namespace).toBe('kube9-system');
+    });
+  });
+
+  describe('assessment summary', () => {
+    it('should use stable defaults when no assessment run has occurred', async () => {
+      delete process.env.POD_NAMESPACE;
+
+      vi.resetModules();
+      const { calculateStatus } = await import('./calculator.js');
+      const status = calculateStatus();
+
+      expect(status.assessment.lastScheduledOutcome).toBe('none');
+      expect(status.assessment.lastScheduledCompletedAt).toBe(null);
+      expect(status.assessment.lastScheduledRunState).toBe(null);
+      expect(status.assessment.lastScheduledRunId).toBe(null);
+      expect(status.assessment.lastScheduledError).toBe(null);
+      expect(status.assessment.lastScheduledTotals).toEqual({
+        totalChecks: 0,
+        completedChecks: 0,
+        passedChecks: 0,
+        failedChecks: 0,
+        warningChecks: 0,
+      });
+    });
+
+    it('should include provided assessment summary in status', async () => {
+      delete process.env.POD_NAMESPACE;
+
+      vi.resetModules();
+      const { calculateStatus } = await import('./calculator.js');
+      const summary: AssessmentStatusSummary = {
+        lastScheduledCompletedAt: '2025-06-01T12:00:00Z',
+        lastScheduledOutcome: 'success',
+        lastScheduledRunState: 'completed',
+        lastScheduledRunId: 'run-1',
+        lastScheduledTotals: {
+          totalChecks: 10,
+          completedChecks: 10,
+          passedChecks: 8,
+          failedChecks: 1,
+          warningChecks: 1,
+        },
+        lastScheduledError: null,
+      };
+
+      const status = calculateStatus(
+        { isRegistered: false, consecutiveFailures: 0 },
+        null,
+        true,
+        {
+          totalSuccessCount: 0,
+          totalFailureCount: 0,
+          collectionsStoredCount: 0,
+          lastSuccessTime: null,
+        },
+        {
+          detected: false,
+          namespace: null,
+          version: null,
+          lastChecked: '2025-01-01T00:00:00Z',
+        },
+        {
+          detected: false,
+          serverUrl: null,
+          version: null,
+          lastChecked: '2025-01-01T00:00:00Z',
+        },
+        summary
+      );
+
+      expect(status.assessment).toEqual({
+        ...summary,
+        lastScheduledTotals: { ...summary.lastScheduledTotals },
+      });
+    });
+
+    it('should map scheduled snapshot via buildAssessmentStatusSummary', () => {
+      const fromSuccess = buildAssessmentStatusSummary({
+        startedAt: '2025-06-01T11:00:00Z',
+        completedAt: '2025-06-01T12:00:00Z',
+        outcome: 'success',
+        runId: 'abc',
+        state: 'completed',
+        totalChecks: 5,
+        completedChecks: 5,
+        passedChecks: 4,
+        failedChecks: 0,
+        warningChecks: 1,
+      });
+      expect(fromSuccess.lastScheduledOutcome).toBe('success');
+      expect(fromSuccess.lastScheduledRunId).toBe('abc');
+      expect(fromSuccess.lastScheduledTotals.passedChecks).toBe(4);
+
+      const fromFail = buildAssessmentStatusSummary({
+        startedAt: '2025-06-01T11:00:00Z',
+        completedAt: '2025-06-01T12:00:01Z',
+        outcome: 'failed',
+        errorMessage: 'boom',
+      });
+      expect(fromFail.lastScheduledOutcome).toBe('failed');
+      expect(fromFail.lastScheduledError).toBe('boom');
+      expect(fromFail.lastScheduledTotals.totalChecks).toBe(0);
     });
   });
 

--- a/src/status/calculator.ts
+++ b/src/status/calculator.ts
@@ -4,7 +4,9 @@ import type {
   CollectionStats,
   ArgoCDStatus,
   TrivyStatus,
+  AssessmentStatusSummary,
 } from './types.js';
+import { DEFAULT_ASSESSMENT_STATUS_SUMMARY } from './assessment-summary.js';
 
 /**
  * Operator version (semver)
@@ -60,6 +62,7 @@ const DEFAULT_TRIVY_STATUS: TrivyStatus = {
  * @param collectionStats - Optional collection statistics (defaults to zero stats)
  * @param argocdStatus - Optional ArgoCD detection status (defaults to not detected)
  * @param trivyStatus - Optional Trivy detection status (defaults to unavailable)
+ * @param assessmentSummary - Bounded last scheduled assessment tick summary (defaults to no-run state)
  * @returns OperatorStatus object with current operator state
  */
 export function calculateStatus(
@@ -73,7 +76,8 @@ export function calculateStatus(
     lastSuccessTime: null
   },
   argocdStatus: ArgoCDStatus = DEFAULT_ARGOCD_STATUS,
-  trivyStatus: TrivyStatus = DEFAULT_TRIVY_STATUS
+  trivyStatus: TrivyStatus = DEFAULT_TRIVY_STATUS,
+  assessmentSummary: AssessmentStatusSummary = DEFAULT_ASSESSMENT_STATUS_SUMMARY
 ): OperatorStatus {
   const { isRegistered, clusterId, consecutiveFailures = 0 } = registrationState;
   
@@ -129,7 +133,11 @@ export function calculateStatus(
       lastSuccessTime: collectionStats.lastSuccessTime
     },
     argocd: argocdStatus,
-    trivy: trivyStatus
+    trivy: trivyStatus,
+    assessment: {
+      ...assessmentSummary,
+      lastScheduledTotals: { ...assessmentSummary.lastScheduledTotals },
+    },
   };
   
   // Include clusterId when registration reports an id

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -80,6 +80,48 @@ export interface TrivyStatus {
 }
 
 /**
+ * Bounded summary of the last scheduled Well-Architected assessment tick.
+ * Intended for the status ConfigMap: counts and metadata only (no per-check arrays).
+ */
+export interface AssessmentStatusSummary {
+  /**
+   * ISO 8601 completion time of the last scheduled tick, or null before any tick completes.
+   */
+  lastScheduledCompletedAt: string | null;
+
+  /**
+   * `none` until the first scheduled tick finishes in this process; then `success` or `failed`.
+   */
+  lastScheduledOutcome: 'none' | 'success' | 'failed';
+
+  /**
+   * Assessment lifecycle state from the last successful run record; null if none or last tick failed.
+   */
+  lastScheduledRunState: string | null;
+
+  /**
+   * Storage run id for the last successful tick; null when there has been no successful completion.
+   */
+  lastScheduledRunId: string | null;
+
+  /**
+   * Aggregate check counts from the last successful run; all zero when no successful completion yet.
+   */
+  lastScheduledTotals: {
+    totalChecks: number;
+    completedChecks: number;
+    passedChecks: number;
+    failedChecks: number;
+    warningChecks: number;
+  };
+
+  /**
+   * Short error summary when `lastScheduledOutcome` is `failed`; otherwise null.
+   */
+  lastScheduledError: string | null;
+}
+
+/**
  * Operator Status Model
  * Represents the current state and health of the kube9 operator
  */
@@ -160,6 +202,11 @@ export interface OperatorStatus {
    * Optional Trivy server awareness (does not install or manage Trivy)
    */
   trivy: TrivyStatus;
+
+  /**
+   * Last scheduled Well-Architected assessment tick summary (bounded; no check result list).
+   */
+  assessment: AssessmentStatusSummary;
 }
 
 /**

--- a/src/status/writer.ts
+++ b/src/status/writer.ts
@@ -1,7 +1,9 @@
 import * as k8s from '@kubernetes/client-node';
 import { kubernetesClient, KubernetesClient } from '../kubernetes/client.js';
 import { calculateStatus } from './calculator.js';
+import { buildAssessmentStatusSummary } from './assessment-summary.js';
 import type { OperatorStatus, RegistrationState } from './types.js';
+import { getScheduledAssessmentLastRunSnapshot } from '../assessment/scheduled-tick.js';
 import type { RegistrationManager } from '../registration/manager.js';
 import { logger } from '../logging/logger.js';
 import { collectionStatsTracker } from '../collection/stats-tracker.js';
@@ -197,6 +199,7 @@ export class StatusWriter {
       // Get current ArgoCD status
       const argocdStatus = argocdStatusTracker.getStatus();
       const trivyStatus = trivyStatusTracker.getStatus();
+      const assessmentSummary = buildAssessmentStatusSummary(getScheduledAssessmentLastRunSnapshot());
       
       const status = calculateStatus(
         registrationState,
@@ -204,7 +207,8 @@ export class StatusWriter {
         canWriteConfigMap,
         collectionStats,
         argocdStatus,
-        trivyStatus
+        trivyStatus,
+        assessmentSummary
       );
 
       // Convert status to JSON string


### PR DESCRIPTION
## Summary

Implements parent https://github.com/alto9/kube9-operator/issues/22 periodic assessment work across **#122** (configuration surface), **#123** (scheduled tick execution), **#124** (operator main-loop wiring), and **#125** (assessment summary on the status ConfigMap).

## #122 — Schedule configuration

- `charts/kube9-operator/values.yaml`: `assessment.enabled`, `intervalSeconds`, `mode`, optional `timeoutSeconds`
- `charts/kube9-operator/templates/deployment.yaml`: `ASSESSMENT_*` environment variables
- `src/config/types.ts`, `src/config/loader.ts`: defaults, bounds, mode validation (`single-check` rejected when scheduling is enabled)
- `src/config/loader.test.ts`: loader tests for the assessment env surface

## #123 — Periodic scheduler execution

- `src/assessment/scheduled-tick.ts`: idempotent `ensureAssessmentRegistryBootstrapped`, `runScheduledAssessmentTick` using `AssessmentRunner` with `AssessmentRepository` and `ImageScanRepository` (same persistence path as `assess run`), in-memory last-run snapshot via `getScheduledAssessmentLastRunSnapshot`, failures logged without propagating to the scheduler callback
- `ASSESSMENT_PILLAR` required when `ASSESSMENT_ENABLED=true` and `ASSESSMENT_MODE=pillar`
- `src/assessment/scheduled-tick.test.ts`: unit coverage for bootstrap idempotency and tick error/success snapshots

## #124 — Operator main-loop wiring

- `src/operator.ts`: registers `well-architected-assessment` on `CollectionScheduler` only when `config.assessmentEnabled` is true; uses the same interval, minimum interval, and random offset window (3600s) as other long-interval scheduler tasks; records collection metrics from `getScheduledAssessmentLastRunSnapshot` so tick failures do not crash the scheduler callback
- Reuses the existing `CollectionScheduler` shutdown path via `gracefulShutdown` (no separate timer service)

## #125 — Status ConfigMap assessment summary

- `src/status/types.ts`: `AssessmentStatusSummary` and `assessment` on `OperatorStatus` (bounded counts and metadata only)
- `src/status/assessment-summary.ts`: `buildAssessmentStatusSummary()` maps `getScheduledAssessmentLastRunSnapshot()` into status fields
- `src/status/calculator.ts`: new optional argument and published `assessment` object
- `src/status/writer.ts` and `src/shutdown/handler.ts`: wire snapshot into periodic and final status JSON
- `src/status/calculator.test.ts`: defaults when no run, custom summary, and snapshot mapping coverage

## How tested

- `npm run lint`
- `npm run test`
- `npm run test:integration`

Closes #122
Closes #123
Closes #124
Closes #125
