### PR TITLE
fix(collection): cluster metadata metrics alignment (#50)

### DIFF
--- a/src/collection/collectors/cluster-metadata.test.ts
+++ b/src/collection/collectors/cluster-metadata.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as k8s from '@kubernetes/client-node';
+
+vi.mock('../../cluster/identifier.js', () => ({
+  generateClusterIdForCollection: vi.fn(() => 'cls_' + 'a'.repeat(32)),
+}));
+
+import { ClusterMetadataCollector } from './cluster-metadata.js';
+import type { KubernetesClient } from '../../kubernetes/client.js';
+import type { ClusterMetadata } from '../types.js';
+import type { LocalStorage } from '../storage.js';
+
+function mockKubernetesClient(
+  versionResponse: { gitVersion?: string },
+  nodes: k8s.V1Node[]
+): KubernetesClient {
+  return {
+    versionApi: {
+      getCode: vi.fn().mockResolvedValue(versionResponse),
+    },
+    coreApi: {
+      listNode: vi.fn().mockResolvedValue({ items: nodes }),
+    },
+  } as unknown as KubernetesClient;
+}
+
+describe('ClusterMetadataCollector', () => {
+  it('collect() rejects when the node list is empty', async () => {
+    const collector = new ClusterMetadataCollector(
+      mockKubernetesClient({ gitVersion: 'v1.28.0' }, []),
+      {} as LocalStorage
+    );
+
+    await expect(collector.collect()).rejects.toThrow(/node list is empty/i);
+  });
+
+  it('collect() returns metadata when at least one node exists', async () => {
+    const node: k8s.V1Node = {
+      metadata: {
+        labels: {
+          'topology.kubernetes.io/region': 'us-east-1',
+          'topology.kubernetes.io/zone': 'us-east-1a',
+        },
+      },
+    };
+
+    const collector = new ClusterMetadataCollector(
+      mockKubernetesClient({ gitVersion: 'v1.28.2' }, [node]),
+      {} as LocalStorage
+    );
+
+    const meta = await collector.collect();
+    expect(meta.nodeCount).toBe(1);
+    expect(meta.kubernetesVersion).toBe('1.28.2');
+    expect(meta.region).toBe('us-east-1');
+    expect(meta.zone).toBe('us-east-1a');
+    expect(meta.collectionId).toMatch(/^coll_[a-f0-9]{32}$/);
+    expect(meta.clusterId).toMatch(/^cls_[a-f0-9]{32}$/);
+  });
+
+  it('processCollection() propagates validation errors (metrics alignment)', async () => {
+    const store = vi.fn().mockResolvedValue(undefined);
+    const localStorage = { store } as unknown as LocalStorage;
+
+    const collector = new ClusterMetadataCollector(
+      mockKubernetesClient({ gitVersion: 'v1.28.0' }, [{ metadata: {} }]),
+      localStorage
+    );
+
+    const invalid: ClusterMetadata = {
+      timestamp: new Date().toISOString(),
+      collectionId: 'coll_' + 'b'.repeat(32),
+      clusterId: 'cls_' + 'c'.repeat(32),
+      kubernetesVersion: '1.28.0',
+      nodeCount: 0,
+    };
+
+    await expect(collector.processCollection(invalid)).rejects.toThrow(/nodeCount/i);
+    expect(store).not.toHaveBeenCalled();
+  });
+
+  it('processCollection() stores a validated payload on success', async () => {
+    const store = vi.fn().mockResolvedValue(undefined);
+    const localStorage = { store } as unknown as LocalStorage;
+
+    const collector = new ClusterMetadataCollector(
+      mockKubernetesClient({ gitVersion: 'v1.29.0' }, [{ metadata: {} }]),
+      localStorage
+    );
+
+    const meta = await collector.collect();
+    await collector.processCollection(meta);
+
+    expect(store).toHaveBeenCalledTimes(1);
+    const payload = store.mock.calls[0][0] as { type: string };
+    expect(payload.type).toBe('cluster-metadata');
+  });
+});

--- a/src/collection/collectors/cluster-metadata.ts
+++ b/src/collection/collectors/cluster-metadata.ts
@@ -49,12 +49,18 @@ export class ClusterMetadataCollector {
       // Strip 'v' prefix if present
       const kubernetesVersion = gitVersion.startsWith('v') ? gitVersion.substring(1) : gitVersion;
 
-      // Generate cluster identifier
-      const clusterId = generateClusterIdForCollection();
-
-      // Get node list for counting and metadata extraction
+      // Get node list for counting and metadata extraction (fail fast before cluster ID when unusable)
       const nodeList = await this.kubernetesClient.coreApi.listNode();
       const nodeCount = nodeList.items?.length || 0;
+
+      if (nodeCount === 0) {
+        const message =
+          'Cluster metadata collection failed: node list is empty (expected at least one node for a valid cluster-metadata payload; validation requires nodeCount 1–10000). Check RBAC for nodes/list and cluster state.';
+        logger.error(message);
+        throw new Error(message);
+      }
+
+      const clusterId = generateClusterIdForCollection();
 
       // Detect provider from node labels
       const provider = this.detectProvider(nodeList);
@@ -133,7 +139,7 @@ export class ClusterMetadataCollector {
         error: errorMessage,
         collectionId: metadata.collectionId,
       });
-      // Don't throw - graceful degradation
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Description

Completes M8 alignment for cluster metadata collection: when `listNode` returns no nodes, `collect()` now fails with a clear error so the scheduler records **failed** Prometheus metrics and `collectionStats` instead of succeeding while persistence cannot satisfy `validateClusterMetadata` (nodeCount 1–10000). `processCollection` now **rethrows** after logging so any validation or storage error no longer appears paired with a success metric path.

## Motivation and Context

Fixes #50

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated (`src/collection/collectors/cluster-metadata.test.ts`)
- [ ] Integration tests added/updated

Ran `npm run build`, `npm run lint`, `npm test`; `helm lint charts/kube9-operator` and `helm template` smoke check.

## Checklist

- [x] My code follows the code style of this project
- [ ] I have updated the documentation accordingly (behavior matches existing contract; no env/chart changes)
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)
