### PR TITLE
feat(collection): resource inventory interval enforcement and tests (#52)

### DIFF
--- a/src/collection/collectors/resource-inventory.test.ts
+++ b/src/collection/collectors/resource-inventory.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as k8s from '@kubernetes/client-node';
+import { createHash } from 'crypto';
+
+vi.mock('../../cluster/identifier.js', () => ({
+  generateClusterIdForCollection: vi.fn(() => 'cls_' + 'a'.repeat(32)),
+}));
+
+import { ResourceInventoryCollector } from './resource-inventory.js';
+import type { KubernetesClient } from '../../kubernetes/client.js';
+import type { LocalStorage } from '../storage.js';
+
+function nsId(name: string): string {
+  return `namespace-${createHash('sha256').update(name).digest('hex').substring(0, 12)}`;
+}
+
+function mockKubernetesClient(): KubernetesClient {
+  const listNamespace = vi.fn().mockResolvedValue({
+    items: [
+      { metadata: { name: 'team-a' } },
+      { metadata: { name: 'team-b' } },
+    ] satisfies k8s.V1Namespace[],
+  });
+
+  const listPodForAllNamespaces = vi.fn().mockResolvedValue({
+    items: [
+      { metadata: { namespace: 'team-a' } },
+      { metadata: { namespace: 'team-a' } },
+      { metadata: { namespace: 'team-b' } },
+    ] satisfies k8s.V1Pod[],
+  });
+
+  const listDeploymentForAllNamespaces = vi.fn().mockResolvedValue({
+    items: [{ metadata: {} }, { metadata: {} }, { metadata: {} }] satisfies k8s.V1Deployment[],
+  });
+
+  const listStatefulSetForAllNamespaces = vi.fn().mockResolvedValue({
+    items: [{ metadata: {} }] satisfies k8s.V1StatefulSet[],
+  });
+
+  const listReplicaSetForAllNamespaces = vi.fn().mockResolvedValue({
+    items: [{ metadata: {} }, { metadata: {} }] satisfies k8s.V1ReplicaSet[],
+  });
+
+  const listServiceForAllNamespaces = vi.fn().mockResolvedValue({
+    items: [
+      { metadata: {}, spec: { type: 'ClusterIP' } },
+      { metadata: {}, spec: { type: 'ClusterIP' } },
+      { metadata: {}, spec: { type: 'NodePort' } },
+      { metadata: {}, spec: { type: 'LoadBalancer' } },
+      { metadata: {}, spec: { type: 'ExternalName' } },
+    ] satisfies k8s.V1Service[],
+  });
+
+  return {
+    coreApi: {
+      listNamespace,
+      listPodForAllNamespaces,
+      listServiceForAllNamespaces,
+    },
+    appsApi: {
+      listDeploymentForAllNamespaces,
+      listStatefulSetForAllNamespaces,
+      listReplicaSetForAllNamespaces,
+    },
+  } as unknown as KubernetesClient;
+}
+
+describe('ResourceInventoryCollector', () => {
+  it('collect() hashes namespace names and aggregates counts', async () => {
+    const k8sClient = mockKubernetesClient();
+    const collector = new ResourceInventoryCollector(k8sClient, {} as LocalStorage);
+
+    const inv = await collector.collect();
+
+    expect(inv.namespaces.count).toBe(2);
+    expect(inv.namespaces.list).toHaveLength(2);
+    expect(inv.namespaces.list).toContain(nsId('team-a'));
+    expect(inv.namespaces.list).toContain(nsId('team-b'));
+    for (const id of inv.namespaces.list) {
+      expect(id).toMatch(/^namespace-[a-f0-9]{12}$/);
+    }
+    expect(inv.namespaces.list.some((id) => id.includes('team'))).toBe(false);
+
+    expect(inv.resources.pods.total).toBe(3);
+    expect(inv.resources.pods.byNamespace[nsId('team-a')]).toBe(2);
+    expect(inv.resources.pods.byNamespace[nsId('team-b')]).toBe(1);
+
+    expect(inv.resources.deployments.total).toBe(3);
+    expect(inv.resources.statefulSets.total).toBe(1);
+    expect(inv.resources.replicaSets.total).toBe(2);
+
+    expect(inv.resources.services.total).toBe(5);
+    expect(inv.resources.services.byType.ClusterIP).toBe(2);
+    expect(inv.resources.services.byType.NodePort).toBe(1);
+    expect(inv.resources.services.byType.LoadBalancer).toBe(1);
+    expect(inv.resources.services.byType.ExternalName).toBe(1);
+
+    expect(inv.collectionId).toMatch(/^coll_[a-f0-9]{32}$/);
+    expect(inv.clusterId).toMatch(/^cls_[a-f0-9]{32}$/);
+  });
+
+  it('collect() defaults service type to ClusterIP when spec.type is missing', async () => {
+    const k8sClient = mockKubernetesClient();
+    const core = k8sClient.coreApi as unknown as {
+      listServiceForAllNamespaces: ReturnType<typeof vi.fn>;
+    };
+    core.listServiceForAllNamespaces.mockResolvedValue({
+      items: [{ metadata: {}, spec: {} }],
+    });
+
+    const collector = new ResourceInventoryCollector(k8sClient, {} as LocalStorage);
+    const inv = await collector.collect();
+
+    expect(inv.resources.services.total).toBe(1);
+    expect(inv.resources.services.byType.ClusterIP).toBe(1);
+  });
+
+  it('processCollection() stores a validated resource-inventory payload', async () => {
+    const k8sClient = mockKubernetesClient();
+    const store = vi.fn().mockResolvedValue(undefined);
+    const localStorage = { store } as unknown as LocalStorage;
+
+    const collector = new ResourceInventoryCollector(k8sClient, localStorage);
+    const inv = await collector.collect();
+    await collector.processCollection(inv);
+
+    expect(store).toHaveBeenCalledTimes(1);
+    const payload = store.mock.calls[0][0] as {
+      type: string;
+      sanitization: { rulesApplied: string[] };
+    };
+    expect(payload.type).toBe('resource-inventory');
+    expect(payload.sanitization.rulesApplied).toEqual([
+      'no-resource-names',
+      'hashed-namespace-ids',
+    ]);
+  });
+
+  it('processCollection() does not store when validation fails', async () => {
+    const store = vi.fn().mockResolvedValue(undefined);
+    const localStorage = { store } as unknown as LocalStorage;
+    const collector = new ResourceInventoryCollector(
+      mockKubernetesClient(),
+      localStorage
+    );
+
+    await collector.processCollection({
+      timestamp: new Date().toISOString(),
+      collectionId: 'bad-id',
+      clusterId: 'cls_' + 'a'.repeat(32),
+      namespaces: { count: 0, list: [] },
+      resources: {
+        pods: { total: 0, byNamespace: {} },
+        deployments: { total: 0 },
+        statefulSets: { total: 0 },
+        replicaSets: { total: 0 },
+        services: { total: 0, byType: {} },
+      },
+    });
+
+    expect(store).not.toHaveBeenCalled();
+  });
+});

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -3,6 +3,7 @@ import { loadConfig } from './loader.js';
 
 const trackedKeys = [
   'SERVER_URL',
+  'RESOURCE_INVENTORY_INTERVAL_SECONDS',
   'ASSESSMENT_ENABLED',
   'ASSESSMENT_INTERVAL_SECONDS',
   'ASSESSMENT_MODE',
@@ -33,6 +34,7 @@ describe('loadConfig — assessment schedule', () => {
   beforeEach(() => {
     stashEnv();
     process.env.SERVER_URL = 'https://config-test.example';
+    delete process.env.RESOURCE_INVENTORY_INTERVAL_SECONDS;
     delete process.env.ASSESSMENT_ENABLED;
     delete process.env.ASSESSMENT_INTERVAL_SECONDS;
     delete process.env.ASSESSMENT_MODE;
@@ -128,5 +130,42 @@ describe('loadConfig — assessment schedule', () => {
   it('rejects invalid ASSESSMENT_ENABLED', async () => {
     process.env.ASSESSMENT_ENABLED = 'sure';
     await expect(loadConfig()).rejects.toThrow(/ASSESSMENT_ENABLED/);
+  });
+});
+
+describe('loadConfig — resource inventory interval', () => {
+  beforeEach(() => {
+    stashEnv();
+    delete process.env.RESOURCE_INVENTORY_INTERVAL_SECONDS;
+    delete process.env.ASSESSMENT_ENABLED;
+    delete process.env.ASSESSMENT_INTERVAL_SECONDS;
+    delete process.env.ASSESSMENT_MODE;
+    delete process.env.ASSESSMENT_PILLAR;
+    delete process.env.ASSESSMENT_TIMEOUT_SECONDS;
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('defaults to 21600 seconds (6 hours)', async () => {
+    const config = await loadConfig();
+    expect(config.resourceInventoryIntervalSeconds).toBe(21600);
+  });
+
+  it('accepts the minimum interval (1800 seconds)', async () => {
+    process.env.RESOURCE_INVENTORY_INTERVAL_SECONDS = '1800';
+    const config = await loadConfig();
+    expect(config.resourceInventoryIntervalSeconds).toBe(1800);
+  });
+
+  it('rejects values below the minimum', async () => {
+    process.env.RESOURCE_INVENTORY_INTERVAL_SECONDS = '1799';
+    await expect(loadConfig()).rejects.toThrow(/RESOURCE_INVENTORY_INTERVAL_SECONDS/);
+  });
+
+  it('rejects non-numeric values', async () => {
+    process.env.RESOURCE_INVENTORY_INTERVAL_SECONDS = 'not-a-number';
+    await expect(loadConfig()).rejects.toThrow(/RESOURCE_INVENTORY_INTERVAL_SECONDS/);
   });
 });

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -8,6 +8,8 @@ type AssessmentMode = (typeof ASSESSMENT_MODES)[number];
 const ASSESSMENT_INTERVAL_MIN_SECONDS = 3600;
 const ASSESSMENT_TIMEOUT_MIN_SECONDS = 60;
 const ASSESSMENT_TIMEOUT_MAX_SECONDS = 7 * 24 * 3600;
+/** Matches operator scheduler minimum for `resource-inventory` (30 minutes). */
+const RESOURCE_INVENTORY_INTERVAL_MIN_SECONDS = 1800;
 
 /**
  * Parses a positive base-10 integer from env or a default string.
@@ -75,7 +77,8 @@ export async function loadConfig(): Promise<Config> {
   const resourceInventoryIntervalSeconds = parsePositiveInt(
     'RESOURCE_INVENTORY_INTERVAL_SECONDS',
     process.env.RESOURCE_INVENTORY_INTERVAL_SECONDS,
-    '21600'
+    '21600',
+    RESOURCE_INVENTORY_INTERVAL_MIN_SECONDS
   );
   const resourceConfigurationPatternsIntervalSeconds = parsePositiveInt(
     'RESOURCE_CONFIGURATION_PATTERNS_INTERVAL_SECONDS',


### PR DESCRIPTION
## Description

Completes GitHub **#52** (Resource Inventory Collector) follow-ups on top of the existing `ResourceInventoryCollector` implementation on `main`:

- Enforces **`RESOURCE_INVENTORY_INTERVAL_SECONDS` ≥ 1800** (30 minutes) at config load using `parsePositiveInt`, aligned with the scheduler minimum and Helm `values.schema.json`.
- Adds **`resource-inventory.test.ts`**: mocked Kubernetes lists for namespace hashing, pod/deployment/statefulSet/replicaSet/service totals, service **byType** breakdown, default ClusterIP when `spec.type` is absent, `processCollection` payload/sanitization, and no store on validation failure.
- Extends **`loader.test.ts`** for resource inventory defaults and validation errors.

## Motivation and Context

Issue #52 requires a 6h default interval, a 30m minimum in code, privacy-preserving namespace hashing, aggregated counts (including services by type), local persistence via `CollectionPayload`, and **automated tests** in the same PR. The collector and operator wiring were already present on `main`; this PR closes the remaining config validation and test coverage gaps called out in the acceptance criteria.

Fixes #52

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated
- [x] All new and existing tests pass (`npm test`)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass (`npm test`)

## Additional Notes

**Note:** Values below **1800** for `RESOURCE_INVENTORY_INTERVAL_SECONDS` now **fail fast at startup** instead of being silently clamped by the scheduler alone.
