### PR TITLE
feat(collections): SQLite persistence and query CLI (#53)

### DIFF
--- a/src/assessment/runner.integration.test.ts
+++ b/src/assessment/runner.integration.test.ts
@@ -440,9 +440,11 @@ describe('AssessmentRunner (integration)', () => {
 
     const history = storage.queryHistory({ filters: { run_id: 'run-sustainability-pillar' } });
     expect(history).toHaveLength(2);
-    expect(history.map((h) => h.check_id)).toEqual([
-      'sustainability.resource-efficiency-signals',
-      'sustainability.workload-consolidation-signals',
-    ]);
+    expect(history.map((h) => h.check_id).sort()).toEqual(
+      [
+        'sustainability.resource-efficiency-signals',
+        'sustainability.workload-consolidation-signals',
+      ].sort()
+    );
   });
 });

--- a/src/cli/commands/collections.ts
+++ b/src/cli/commands/collections.ts
@@ -1,0 +1,123 @@
+/**
+ * CLI: query persisted collection payloads (M8).
+ */
+
+import { z } from 'zod';
+import { DatabaseManager } from '../../database/manager.js';
+import { SchemaManager } from '../../database/schema.js';
+import {
+  CollectionRepository,
+  type CollectionFilters,
+  type CollectionRowType,
+} from '../../database/collection-repository.js';
+import { formatOutput } from '../formatters.js';
+
+function writeError(message: string, details?: string) {
+  const err = details ? { error: message, details } : { error: message };
+  console.error(JSON.stringify(err));
+  process.exit(1);
+}
+
+function ensureDb() {
+  DatabaseManager.getInstance();
+  const schema = new SchemaManager();
+  schema.initialize();
+}
+
+const collectionTypeEnum = z.enum([
+  'cluster-metadata',
+  'resource-inventory',
+  'resource-configuration-patterns',
+]);
+
+const ListOptionsSchema = z.object({
+  type: collectionTypeEnum.optional(),
+  clusterId: z.string().optional(),
+  since: z.string().datetime().optional(),
+  until: z.string().datetime().optional(),
+  limit: z
+    .string()
+    .default('50')
+    .transform(Number)
+    .pipe(z.number().int().positive().max(1000)),
+  offset: z
+    .string()
+    .default('0')
+    .transform(Number)
+    .pipe(z.number().int().nonnegative()),
+  format: z.enum(['json', 'yaml', 'table', 'compact']).default('json'),
+});
+
+const GetOptionsSchema = z.object({
+  format: z.enum(['json', 'yaml', 'table', 'compact']).default('json'),
+});
+
+export async function listCollections(options: Record<string, unknown>) {
+  try {
+    const validated = ListOptionsSchema.parse(options);
+    ensureDb();
+
+    const filters: CollectionFilters = {};
+    if (validated.type) {
+      filters.type = validated.type as CollectionRowType;
+    }
+    if (validated.clusterId) {
+      filters.cluster_id = validated.clusterId;
+    }
+    if (validated.since) {
+      filters.collected_at_gte = validated.since;
+    }
+    if (validated.until) {
+      filters.collected_at_lt = validated.until;
+    }
+
+    const repo = new CollectionRepository();
+    const collections = repo.queryCollectionSummaries({
+      filters,
+      limit: validated.limit,
+      offset: validated.offset,
+    });
+    const total = repo.countCollections(filters);
+
+    const result = {
+      collections,
+      pagination: {
+        total,
+        limit: validated.limit,
+        offset: validated.offset,
+        returned: collections.length,
+      },
+    };
+
+    console.log(formatOutput(result, validated.format));
+    process.exit(0);
+  } catch (error: unknown) {
+    const err = error as Error;
+    writeError('Failed to list collections', err.message);
+  }
+}
+
+export async function getCollection(collectionId: string, options: Record<string, unknown>) {
+  try {
+    const validated = GetOptionsSchema.parse(options);
+    ensureDb();
+
+    const repo = new CollectionRepository();
+    const payload = repo.getCollectionById(collectionId);
+    if (!payload) {
+      console.error(
+        JSON.stringify({
+          error: 'Collection not found',
+          collection_id: collectionId,
+        })
+      );
+      process.exit(1);
+    }
+
+    console.log(formatOutput(payload, validated.format));
+    process.exit(0);
+  } catch (error: unknown) {
+    const err = error as Error;
+    writeError('Failed to get collection', err.message);
+  }
+}

--- a/src/cli/formatters.ts
+++ b/src/cli/formatters.ts
@@ -37,6 +37,18 @@ function formatTable(data: any, format: string = 'table'): string {
     return renderTable(headers, rows, isCompact);
   }
 
+  // Handle collections list (summaries)
+  if (data.collections && Array.isArray(data.collections)) {
+    const headers = ['COLLECTION_ID', 'CLUSTER_ID', 'TYPE', 'COLLECTED_AT'];
+    const rows = data.collections.map((c: any) => [
+      truncate(c.collection_id, isCompact ? 20 : 36),
+      truncate(c.cluster_id, isCompact ? 18 : 36),
+      truncate(c.type, isCompact ? 24 : 36),
+      formatDate(c.collected_at),
+    ]);
+    return renderTable(headers, rows, isCompact);
+  }
+
   // Handle assessments list
   if (data.assessments && Array.isArray(data.assessments)) {
     const headers = ['RUN_ID', 'MODE', 'STATE', 'TOTAL', 'PASSED', 'FAILED', 'REQUESTED'];

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -15,14 +15,11 @@ describe('createQueryCommands', () => {
     expect(queryCmd.description()).toBe('Query operator data');
   });
 
-  it('structure is extensible', () => {
+  it('includes collections query commands', () => {
     const queryCmd = createQueryCommands();
-    
-    // Verify it's a Command instance with commands array
-    expect('commands' in queryCmd).toBe(true);
-    
-    // Initially should have no subcommands (they will be added in later stories)
-    const subcommands = queryCmd.commands;
-    expect(Array.isArray(subcommands)).toBe(true);
+    const names = queryCmd.commands.map((c) => c.name());
+    expect(names).toContain('collections');
+    expect(names).toContain('events');
+    expect(names).toContain('vulnerabilities');
   });
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,7 @@ import {
   assessHistory,
 } from './commands/assess.js';
 import { listVulnerabilities, summarizeVulnerabilities } from './commands/vulnerabilities.js';
+import { listCollections, getCollection } from './commands/collections.js';
 
 /**
  * Create the assess command structure
@@ -138,6 +139,31 @@ export function createQueryCommands(): Command {
     .description('Summary counts by severity from stored findings')
     .option('--format <format>', 'Output format (json|yaml|table|compact)', 'json')
     .action(summarizeVulnerabilities);
+
+  const collections = query
+    .command('collections')
+    .description('Query persisted M8 collection payloads (SQLite)');
+
+  collections
+    .command('list')
+    .description('List stored collections')
+    .option(
+      '--type <type>',
+      'Filter by type: cluster-metadata, resource-inventory, resource-configuration-patterns'
+    )
+    .option('--cluster-id <id>', 'Filter by cluster id')
+    .option('--since <date>', 'Collected on/after (ISO 8601)')
+    .option('--until <date>', 'Collected before (ISO 8601)')
+    .option('--limit <number>', 'Limit number of results', '50')
+    .option('--offset <number>', 'Skip number of results', '0')
+    .option('--format <format>', 'Output format (json|yaml|table|compact)', 'json')
+    .action(listCollections);
+
+  collections
+    .command('get <collectionId>')
+    .description('Get full collection payload by id')
+    .option('--format <format>', 'Output format (json|yaml|table|compact)', 'json')
+    .action(getCollection);
 
   return query;
 }

--- a/src/collection/payload-schema.ts
+++ b/src/collection/payload-schema.ts
@@ -1,0 +1,84 @@
+/**
+ * Zod validation for CollectionPayload at persistence boundaries.
+ */
+
+import { z } from 'zod';
+
+const sanitizationSchema = z.object({
+  rulesApplied: z.array(z.string()),
+  timestamp: z.string(),
+});
+
+const clusterMetadataDataSchema = z.object({
+  timestamp: z.string(),
+  collectionId: z.string(),
+  clusterId: z.string(),
+  kubernetesVersion: z.string(),
+  nodeCount: z.number(),
+  provider: z.enum(['aws', 'gcp', 'azure', 'on-premise', 'other', 'unknown']).optional(),
+  region: z.string().optional(),
+  zone: z.string().optional(),
+});
+
+const resourceInventoryDataSchema = z.object({
+  timestamp: z.string(),
+  collectionId: z.string(),
+  clusterId: z.string(),
+  namespaces: z.object({
+    count: z.number(),
+    list: z.array(z.string()),
+  }),
+  resources: z.object({
+    pods: z.object({
+      total: z.number(),
+      byNamespace: z.record(z.string(), z.number()),
+    }),
+    deployments: z.object({ total: z.number() }),
+    statefulSets: z.object({ total: z.number() }),
+    replicaSets: z.object({ total: z.number() }),
+    services: z.object({
+      total: z.number(),
+      byType: z
+        .object({
+          ClusterIP: z.number().optional(),
+          NodePort: z.number().optional(),
+          LoadBalancer: z.number().optional(),
+          ExternalName: z.number().optional(),
+        })
+        .partial()
+        .optional(),
+    }),
+  }),
+});
+
+/** Nested pattern shapes vary; core identifiers and timestamp are required. */
+const resourceConfigurationDataSchema = z
+  .object({
+    timestamp: z.string(),
+    collectionId: z.string(),
+    clusterId: z.string(),
+  })
+  .passthrough();
+
+export const CollectionPayloadSchema = z.discriminatedUnion('type', [
+  z.object({
+    version: z.string(),
+    type: z.literal('cluster-metadata'),
+    data: clusterMetadataDataSchema,
+    sanitization: sanitizationSchema,
+  }),
+  z.object({
+    version: z.string(),
+    type: z.literal('resource-inventory'),
+    data: resourceInventoryDataSchema,
+    sanitization: sanitizationSchema,
+  }),
+  z.object({
+    version: z.string(),
+    type: z.literal('resource-configuration-patterns'),
+    data: resourceConfigurationDataSchema,
+    sanitization: sanitizationSchema,
+  }),
+]);
+
+export type ParsedCollectionPayload = z.infer<typeof CollectionPayloadSchema>;

--- a/src/database/collection-repository.test.ts
+++ b/src/database/collection-repository.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { SchemaManager } from './schema.js';
+import { DatabaseManager } from './manager.js';
+import { CollectionRepository } from './collection-repository.js';
+import type { CollectionPayload } from '../collection/types.js';
+import { existsSync, rmSync, mkdirSync, unlinkSync } from 'fs';
+import path from 'path';
+
+const testDbDir = path.join(process.cwd(), 'test-collection-repo-temp');
+
+function sampleClusterPayload(id: string): CollectionPayload {
+  const ts = new Date().toISOString();
+  return {
+    version: 'v1.0.0',
+    type: 'cluster-metadata',
+    data: {
+      timestamp: ts,
+      collectionId: id,
+      clusterId: 'cls_testabc',
+      kubernetesVersion: '1.28.0',
+      nodeCount: 2,
+    },
+    sanitization: {
+      rulesApplied: ['hash-identifiers'],
+      timestamp: ts,
+    },
+  };
+}
+
+describe('CollectionRepository', () => {
+  beforeAll(() => {
+    if (existsSync(testDbDir)) {
+      rmSync(testDbDir, { recursive: true, force: true });
+    }
+    mkdirSync(testDbDir, { recursive: true });
+    process.env.DB_PATH = testDbDir;
+  });
+
+  afterAll(() => {
+    DatabaseManager.reset();
+    if (existsSync(testDbDir)) {
+      rmSync(testDbDir, { recursive: true, force: true });
+    }
+    delete process.env.DB_PATH;
+  });
+
+  beforeEach(() => {
+    DatabaseManager.reset();
+    const dbFile = path.join(testDbDir, 'kube9.db');
+    if (existsSync(dbFile)) {
+      unlinkSync(dbFile);
+    }
+    const schema = new SchemaManager();
+    schema.initialize();
+  });
+
+  afterEach(() => {
+    DatabaseManager.reset();
+  });
+
+  it('inserts and retrieves a valid collection', () => {
+    const repo = new CollectionRepository();
+    const payload = sampleClusterPayload('coll_ins1');
+    expect(repo.insertCollection(payload)).toBe(true);
+
+    const got = repo.getCollectionById('coll_ins1');
+    expect(got).toBeTruthy();
+    expect(got?.type).toBe('cluster-metadata');
+    expect(got?.data).toEqual(payload.data);
+  });
+
+  it('rejects invalid payload', () => {
+    const repo = new CollectionRepository();
+    const bad = { version: 'v1', type: 'cluster-metadata', data: {}, sanitization: { rulesApplied: [], timestamp: 'x' } };
+    expect(repo.insertCollection(bad)).toBe(false);
+  });
+
+  it('rejects wrong enum type in database sense via zod alignment', () => {
+    const repo = new CollectionRepository();
+    const payload = sampleClusterPayload('coll_x');
+    const mangled = {
+      ...payload,
+      type: 'resource-inventory' as const,
+    };
+    expect(repo.insertCollection(mangled)).toBe(false);
+  });
+
+  it('lists and counts with filters', () => {
+    const repo = new CollectionRepository();
+    const p1 = sampleClusterPayload('coll_a');
+    const p2: CollectionPayload = {
+      ...sampleClusterPayload('coll_b'),
+      data: {
+        ...sampleClusterPayload('coll_b').data,
+        clusterId: 'cls_other',
+        timestamp: new Date(Date.now() + 1000).toISOString(),
+      },
+    };
+    repo.insertCollection(p1);
+    repo.insertCollection(p2);
+
+    const all = repo.queryCollectionSummaries({ limit: 10, offset: 0 });
+    expect(all.length).toBe(2);
+    expect(repo.countCollections({})).toBe(2);
+
+    const forCluster = repo.queryCollectionSummaries({
+      filters: { cluster_id: 'cls_other' },
+      limit: 10,
+      offset: 0,
+    });
+    expect(forCluster.length).toBe(1);
+    expect(forCluster[0].collection_id).toBe('coll_b');
+  });
+
+  it('returns false on duplicate collection id', () => {
+    const repo = new CollectionRepository();
+    const payload = sampleClusterPayload('coll_dup');
+    expect(repo.insertCollection(payload)).toBe(true);
+    expect(repo.insertCollection(payload)).toBe(false);
+  });
+});

--- a/src/database/collection-repository.ts
+++ b/src/database/collection-repository.ts
@@ -1,0 +1,175 @@
+/**
+ * SQLite persistence for M8 collection payloads (CollectionPayload).
+ */
+
+import Database from 'better-sqlite3';
+import { DatabaseManager } from './manager.js';
+import { logger } from '../logging/logger.js';
+import type { CollectionPayload } from '../collection/types.js';
+import { CollectionPayloadSchema } from '../collection/payload-schema.js';
+import { ZodError } from 'zod';
+
+export type CollectionRowType =
+  | 'cluster-metadata'
+  | 'resource-inventory'
+  | 'resource-configuration-patterns';
+
+export interface CollectionFilters {
+  type?: CollectionRowType;
+  cluster_id?: string;
+  collected_at_gte?: string;
+  collected_at_lt?: string;
+}
+
+export interface CollectionQueryOptions {
+  filters?: CollectionFilters;
+  limit?: number;
+  offset?: number;
+}
+
+export interface CollectionListRow {
+  collection_id: string;
+  cluster_id: string;
+  type: CollectionRowType;
+  collected_at: string;
+}
+
+export class CollectionRepository {
+  private db: Database.Database;
+
+  constructor() {
+    const manager = DatabaseManager.getInstance();
+    this.db = manager.getDatabase();
+  }
+
+  /**
+   * Parse and insert a collection payload. Rejects type/data mismatch and malformed payloads.
+   */
+  public insertCollection(input: unknown): boolean {
+    try {
+      const payload = CollectionPayloadSchema.parse(input) as CollectionPayload;
+      const collectionId = this.dataCollectionId(payload);
+      const clusterId = this.dataClusterId(payload);
+      const collectedAt = this.dataTimestamp(payload);
+
+      const stmt = this.db.prepare(`
+        INSERT INTO collections (
+          collection_id, cluster_id, type, collected_at, payload_json
+        ) VALUES (?, ?, ?, ?, ?)
+      `);
+
+      stmt.run(
+        collectionId,
+        clusterId,
+        payload.type,
+        collectedAt,
+        JSON.stringify(payload)
+      );
+      return true;
+    } catch (error: any) {
+      if (error?.code === 'SQLITE_CONSTRAINT_PRIMARYKEY' || error?.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+        logger.warn(`Duplicate collection_id insert`);
+        return false;
+      }
+      if (error instanceof ZodError) {
+        logger.warn('Collection payload validation failed', { issues: error.issues });
+        return false;
+      }
+      logger.error('Failed to insert collection', { error: error?.message });
+      return false;
+    }
+  }
+
+  public getCollectionById(collectionId: string): CollectionPayload | null {
+    const row = this.db
+      .prepare(
+        `SELECT payload_json FROM collections WHERE collection_id = ?`
+      )
+      .get(collectionId) as { payload_json: string } | undefined;
+    if (!row) return null;
+    try {
+      const parsed = JSON.parse(row.payload_json) as unknown;
+      return CollectionPayloadSchema.parse(parsed) as CollectionPayload;
+    } catch {
+      logger.warn('Stored collection payload failed validation', { collectionId });
+      return null;
+    }
+  }
+
+  public queryCollectionSummaries(options: CollectionQueryOptions = {}): CollectionListRow[] {
+    const { filters = {}, limit = 50, offset = 0 } = options;
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    if (filters.type) {
+      conditions.push('type = ?');
+      params.push(filters.type);
+    }
+    if (filters.cluster_id) {
+      conditions.push('cluster_id = ?');
+      params.push(filters.cluster_id);
+    }
+    if (filters.collected_at_gte) {
+      conditions.push('collected_at >= ?');
+      params.push(filters.collected_at_gte);
+    }
+    if (filters.collected_at_lt) {
+      conditions.push('collected_at < ?');
+      params.push(filters.collected_at_lt);
+    }
+
+    let query = `
+      SELECT collection_id, cluster_id, type, collected_at
+      FROM collections
+    `;
+    if (conditions.length > 0) {
+      query += ' WHERE ' + conditions.join(' AND ');
+    }
+    query += ' ORDER BY collected_at DESC LIMIT ? OFFSET ?';
+    params.push(limit, offset);
+
+    const rows = this.db.prepare(query).all(...params) as CollectionListRow[];
+    return rows;
+  }
+
+  public countCollections(filters: CollectionFilters = {}): number {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    if (filters.type) {
+      conditions.push('type = ?');
+      params.push(filters.type);
+    }
+    if (filters.cluster_id) {
+      conditions.push('cluster_id = ?');
+      params.push(filters.cluster_id);
+    }
+    if (filters.collected_at_gte) {
+      conditions.push('collected_at >= ?');
+      params.push(filters.collected_at_gte);
+    }
+    if (filters.collected_at_lt) {
+      conditions.push('collected_at < ?');
+      params.push(filters.collected_at_lt);
+    }
+
+    let query = 'SELECT COUNT(*) as count FROM collections';
+    if (conditions.length > 0) {
+      query += ' WHERE ' + conditions.join(' AND ');
+    }
+    const row = this.db.prepare(query).get(...params) as { count: number };
+    return row.count;
+  }
+
+  private dataCollectionId(payload: CollectionPayload): string {
+    return (payload.data as { collectionId: string }).collectionId;
+  }
+
+  private dataClusterId(payload: CollectionPayload): string {
+    return (payload.data as { clusterId: string }).clusterId;
+  }
+
+  private dataTimestamp(payload: CollectionPayload): string {
+    return (payload.data as { timestamp: string }).timestamp;
+  }
+}

--- a/src/database/schema.test.ts
+++ b/src/database/schema.test.ts
@@ -116,7 +116,7 @@ describe('SchemaManager', () => {
     
     expect(versions.length).toBeGreaterThanOrEqual(1);
     expect(versions[0]?.version).toBe(1);
-    expect(schema.getVersion()).toBeGreaterThanOrEqual(3);
+    expect(schema.getVersion()).toBeGreaterThanOrEqual(4);
   });
 
   it('schema version has correct fields', () => {
@@ -256,7 +256,7 @@ describe('SchemaManager', () => {
     const versionAfter = schema.getVersion();
     
     expect(versionBefore).toBe(versionAfter);
-    expect(versionAfter).toBeGreaterThanOrEqual(3);
+    expect(versionAfter).toBeGreaterThanOrEqual(4);
   });
 
   it('creates image_scans and image_vulnerabilities when migrating to v3', () => {
@@ -285,13 +285,39 @@ describe('SchemaManager', () => {
     expect(scanFk?.to).toBe('scan_id');
   });
 
+  it('creates collections table when migrating to v4', () => {
+    const schema = new SchemaManager();
+    schema.initialize();
+
+    const manager = DatabaseManager.getInstance();
+    const db = manager.getDatabase();
+
+    const result = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='collections'`)
+      .get() as { name: string } | undefined;
+
+    expect(result?.name).toBe('collections');
+
+    const columns = db.prepare(`PRAGMA table_info(collections)`).all() as Array<{ name: string }>;
+    const columnNames = columns.map((col) => col.name);
+    expect(columnNames).toEqual(
+      expect.arrayContaining([
+        'collection_id',
+        'cluster_id',
+        'type',
+        'collected_at',
+        'payload_json',
+      ])
+    );
+  });
+
   it('migration runs cleanly on fresh database', () => {
     DatabaseManager.reset();
     const schema = new SchemaManager();
     schema.initialize();
     
-    expect(schema.getVersion()).toBeGreaterThanOrEqual(3);
-    
+    expect(schema.getVersion()).toBeGreaterThanOrEqual(4);
+
     const manager = DatabaseManager.getInstance();
     const db = manager.getDatabase();
     

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -7,7 +7,7 @@ import Database from 'better-sqlite3';
 import { logger } from '../logging/logger.js';
 
 /** Latest schema version - bump when adding migrations */
-const LATEST_SCHEMA_VERSION = 3;
+const LATEST_SCHEMA_VERSION = 4;
 
 /**
  * SchemaManager handles database schema initialization and migrations
@@ -53,6 +53,10 @@ export class SchemaManager {
       {
         version: 3,
         apply: () => this.migrateToV3(),
+      },
+      {
+        version: 4,
+        apply: () => this.migrateToV4(),
       },
     ];
 
@@ -156,6 +160,29 @@ export class SchemaManager {
       CREATE INDEX IF NOT EXISTS idx_image_vulnerabilities_scan_id ON image_vulnerabilities(scan_id);
       CREATE INDEX IF NOT EXISTS idx_image_vulnerabilities_severity ON image_vulnerabilities(severity);
       CREATE INDEX IF NOT EXISTS idx_image_vulnerabilities_vulnerability_id ON image_vulnerabilities(vulnerability_id);
+    `);
+  }
+
+  /**
+   * Migration v4: M8 collection payloads (SQLite persistence + CLI query path).
+   */
+  private migrateToV4(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS collections (
+        collection_id TEXT PRIMARY KEY,
+        cluster_id TEXT NOT NULL,
+        type TEXT NOT NULL CHECK (type IN (
+          'cluster-metadata',
+          'resource-inventory',
+          'resource-configuration-patterns'
+        )),
+        collected_at TEXT NOT NULL,
+        payload_json TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_collections_cluster_id ON collections(cluster_id);
+      CREATE INDEX IF NOT EXISTS idx_collections_type ON collections(type);
+      CREATE INDEX IF NOT EXISTS idx_collections_collected_at ON collections(collected_at DESC);
     `);
   }
 


### PR DESCRIPTION
## Description

Adds SQLite-backed storage for M8 collection payloads (`collections` table, schema v4), a `CollectionRepository` with Zod-validated inserts, and read-only CLI commands `kube9-operator query collections list|get` with filters and `json|yaml|table|compact` output—matching patterns used by events and vulnerabilities queries.

## Motivation and Context

Fixes #53

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated
- [x] Integration tests added/updated

`npm run lint`, `npm run build`, `npm run test`, `npm run test:integration`

## Checklist

- [x] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [ ] I have updated the CHANGELOG.md (if applicable)

Closes #53
