### PR TITLE
test(collection): verify M8 resource configuration patterns list APIs (#54)

### DIFF
--- a/src/collection/collectors/resource-configuration-patterns.test.ts
+++ b/src/collection/collectors/resource-configuration-patterns.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 import type { ResourceConfigurationPatternsData } from '../types.js';
 import {
@@ -940,6 +940,42 @@ it('processServiceType - handles multiple services', () => {
   expect(data.services.serviceTypes.LoadBalancer).toBe(1);
   expect(data.services.portsPerService).toEqual([1, 2, 1, 0]);
   expect(data.services.totalServices).toBe(4);
+});
+
+// M8 / #54 acceptance: collector must walk cluster-scoped List APIs for core workloads + services.
+it('ResourceConfigurationPatternsCollector - collect() invokes cluster-wide pod, workload, and service list APIs', async () => {
+  const listPods = vi.fn(async () => ({ body: { items: [] } }));
+  const listServices = vi.fn(async () => ({ body: { items: [] } }));
+  const listDeployments = vi.fn(async () => ({ body: { items: [] } }));
+  const listStatefulSets = vi.fn(async () => ({ body: { items: [] } }));
+  const listDaemonSets = vi.fn(async () => ({ body: { items: [] } }));
+
+  const mockKubernetesClient = {
+    coreApi: {
+      listPodForAllNamespaces: listPods,
+      listServiceForAllNamespaces: listServices,
+    },
+    appsApi: {
+      listDeploymentForAllNamespaces: listDeployments,
+      listStatefulSetForAllNamespaces: listStatefulSets,
+      listDaemonSetForAllNamespaces: listDaemonSets,
+    },
+  };
+
+  const mockLocalStorage = { store: async () => {} };
+
+  const collector = new ResourceConfigurationPatternsCollector(
+    mockKubernetesClient as any,
+    mockLocalStorage as any
+  );
+
+  await collector.collect();
+
+  expect(listPods).toHaveBeenCalledTimes(1);
+  expect(listDeployments).toHaveBeenCalledTimes(1);
+  expect(listStatefulSets).toHaveBeenCalledTimes(1);
+  expect(listDaemonSets).toHaveBeenCalledTimes(1);
+  expect(listServices).toHaveBeenCalledTimes(1);
 });
 
 // ResourceConfigurationPatternsCollector tests


### PR DESCRIPTION
## Description

Adds a focused unit test that asserts `ResourceConfigurationPatternsCollector.collect()` calls each cluster-wide list API once: `listPodForAllNamespaces`, `listDeploymentForAllNamespaces`, `listStatefulSetForAllNamespaces`, `listDaemonSetForAllNamespaces`, and `listServiceForAllNamespaces`. This locks the M8 acceptance criterion that the collector walks those APIs.

The production path was already implemented on `main`: validation (`validateResourceConfigurationPatterns`), payload type `resource-configuration-patterns`, local storage with sanitization metadata, operator registration with 3600s floor and 0–3600s random offset, and Helm documentation for `metrics.intervals.resourceConfigurationPatterns`.

## Motivation and Context

Closes the verification scope for [M8: Resource configuration patterns collector](https://github.com/alto9/kube9-operator/issues/54).

Fixes #54

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated
- [x] All new and existing tests pass (`npm test`)
- [x] Linter (`npm run lint`)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter (`npm run lint`)
