### PR TITLE
feat(ai-conformance): Kubernetes AI Conformance epic (#141)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ COPY scripts/prepare-husky.cjs scripts/prepare-husky.cjs
 # better-sqlite3 needs a native build — rebuild it after install.
 RUN npm ci --omit=dev --ignore-scripts && npm rebuild better-sqlite3
 
-# Copy built dist folder from build stage
+# Copy built dist folder from build stage (includes bundled checklist YAML)
 COPY --from=builder /app/dist ./dist
 
 # Link the binary globally (creates /usr/local/bin/kube9-operator).

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ COPY scripts/prepare-husky.cjs scripts/prepare-husky.cjs
 # Install all dependencies (including dev dependencies for TypeScript build)
 RUN npm ci
 
+# Copy build helper for bundled checklist assets
+COPY scripts/copy-checklist-bundle.cjs scripts/copy-checklist-bundle.cjs
+
 # Copy source code
 COPY src/ ./src/
 COPY tsconfig.json ./

--- a/README.md
+++ b/README.md
@@ -457,11 +457,54 @@ data:
           "warningChecks": 0
         },
         "lastScheduledError": null
+      },
+      "aiConformance": {
+        "checklistVersion": "unknown",
+        "kubernetesMinor": "unknown",
+        "sourceRevision": null,
+        "lastCompletedAt": null,
+        "lastOutcome": "none",
+        "runState": null,
+        "runId": null,
+        "totals": {
+          "totalRequirements": 0,
+          "mustRequirements": 0,
+          "shouldRequirements": 0,
+          "passed": 0,
+          "failed": 0,
+          "warning": 0,
+          "notApplicable": 0,
+          "notEvaluated": 0,
+          "needsEvidence": 0
+        },
+        "categories": {},
+        "requirements": [],
+        "error": null,
+        "schedulingEnabled": true,
+        "scheduleIntervalSeconds": 86400,
+        "checklistSource": "bundled"
       }
     }
 ```
 
 The VS Code extension reads this ConfigMap to discover where the operator runs, surface status, and enable optional experiences that depend on in-cluster signals (for example ArgoCD awareness).
+
+`aiConformance` is a **Kube9 readiness assessment** against bundled Kubernetes AI Conformance checklist data. It is **not** proof of official CNCF certification.
+
+### Kubernetes AI Conformance smoke check
+
+After deploy, inspect the published readiness summary:
+
+```bash
+kubectl get configmap kube9-operator-status -n kube9-system -o jsonpath='{.data.status}' | jq '.aiConformance'
+```
+
+Run an on-demand evaluation from the operator pod:
+
+```bash
+kubectl exec -n kube9-system deploy/kube9-operator -- kube9-operator ai-conformance run
+kubectl exec -n kube9-system deploy/kube9-operator -- kube9-operator ai-conformance latest
+```
 
 ### Operating modes (summary)
 

--- a/charts/kube9-operator/ai-conformance-helm.test.ts
+++ b/charts/kube9-operator/ai-conformance-helm.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+
+const chartDir = path.join(process.cwd(), 'charts/kube9-operator');
+
+describe('kube9-operator Helm chart aiConformance values', () => {
+  it('renders AI_CONFORMANCE_* environment variables from values', () => {
+    let rendered: string;
+    try {
+      rendered = execSync(
+        `helm template kube9-operator ${chartDir} --namespace kube9-system`,
+        { encoding: 'utf8' }
+      );
+    } catch {
+      // Skip when helm is unavailable in the environment
+      return;
+    }
+
+    expect(rendered).toContain('name: AI_CONFORMANCE_ENABLED');
+    expect(rendered).toContain('name: AI_CONFORMANCE_INTERVAL_SECONDS');
+    expect(rendered).toContain('name: AI_CONFORMANCE_CHECKLIST_SOURCE');
+    expect(rendered).toContain('value: "bundled"');
+  });
+
+  it('honors disabled aiConformance schedule overrides', () => {
+    let rendered: string;
+    try {
+      rendered = execSync(
+        `helm template kube9-operator ${chartDir} --namespace kube9-system --set aiConformance.enabled=false`,
+        { encoding: 'utf8' }
+      );
+    } catch {
+      return;
+    }
+
+    expect(rendered).toContain('name: AI_CONFORMANCE_ENABLED');
+    expect(rendered).toContain('value: "false"');
+  });
+});

--- a/charts/kube9-operator/ai-conformance-helm.test.ts
+++ b/charts/kube9-operator/ai-conformance-helm.test.ts
@@ -4,15 +4,21 @@ import path from 'node:path';
 
 const chartDir = path.join(process.cwd(), 'charts/kube9-operator');
 
+function renderChart(extraArgs = ''): string | undefined {
+  try {
+    return execSync(
+      `helm template kube9-operator ${chartDir} --namespace kube9-system ${extraArgs}`.trim(),
+      { encoding: 'utf8', timeout: 15_000 }
+    );
+  } catch {
+    return undefined;
+  }
+}
+
 describe('kube9-operator Helm chart aiConformance values', () => {
   it('renders AI_CONFORMANCE_* environment variables from values', () => {
-    let rendered: string;
-    try {
-      rendered = execSync(
-        `helm template kube9-operator ${chartDir} --namespace kube9-system`,
-        { encoding: 'utf8' }
-      );
-    } catch {
+    const rendered = renderChart();
+    if (!rendered) {
       // Skip when helm is unavailable in the environment
       return;
     }
@@ -24,17 +30,23 @@ describe('kube9-operator Helm chart aiConformance values', () => {
   });
 
   it('honors disabled aiConformance schedule overrides', () => {
-    let rendered: string;
-    try {
-      rendered = execSync(
-        `helm template kube9-operator ${chartDir} --namespace kube9-system --set aiConformance.enabled=false`,
-        { encoding: 'utf8' }
-      );
-    } catch {
+    const rendered = renderChart('--set aiConformance.enabled=false');
+    if (!rendered) {
       return;
     }
 
     expect(rendered).toContain('name: AI_CONFORMANCE_ENABLED');
     expect(rendered).toContain('value: "false"');
+  });
+
+  it('grants ClusterRole list/watch on networkpolicies for conformance evaluation', () => {
+    const rendered = renderChart();
+    if (!rendered) {
+      return;
+    }
+
+    expect(rendered).toContain('apiGroups: ["networking.k8s.io"]');
+    expect(rendered).toContain('resources: ["networkpolicies"]');
+    expect(rendered).toContain('verbs: ["get", "list", "watch"]');
   });
 });

--- a/charts/kube9-operator/templates/clusterrole.yaml
+++ b/charts/kube9-operator/templates/clusterrole.yaml
@@ -31,6 +31,10 @@ rules:
 - apiGroups: ["policy"]
   resources: ["poddisruptionbudgets"]
   verbs: ["get", "list", "watch"]
+# Read NetworkPolicies (ai-conformance security.network-policy-default-deny)
+- apiGroups: ["networking.k8s.io"]
+  resources: ["networkpolicies"]
+  verbs: ["get", "list", "watch"]
 # Read namespace governance resources (assessment checks)
 - apiGroups: [""]
   resources: ["resourcequotas", "limitranges"]

--- a/charts/kube9-operator/templates/deployment.yaml
+++ b/charts/kube9-operator/templates/deployment.yaml
@@ -130,6 +130,14 @@ spec:
         - name: ASSESSMENT_TIMEOUT_SECONDS
           value: {{ $assessment.timeoutSeconds | quote }}
         {{- end }}
+        # Periodic AI conformance schedule (see aiConformance.* in values.yaml)
+        {{- $aiConformance := .Values.aiConformance | default dict }}
+        - name: AI_CONFORMANCE_ENABLED
+          value: {{ $aiConformance.enabled | default true | quote }}
+        - name: AI_CONFORMANCE_INTERVAL_SECONDS
+          value: {{ $aiConformance.intervalSeconds | default 86400 | quote }}
+        - name: AI_CONFORMANCE_CHECKLIST_SOURCE
+          value: {{ $aiConformance.checklistSource | default "bundled" | quote }}
         # Event retention configuration
         - name: EVENT_RETENTION_INFO_WARNING_DAYS
           value: {{ .Values.events.retention.infoWarning | default 7 | quote }}

--- a/charts/kube9-operator/values.yaml
+++ b/charts/kube9-operator/values.yaml
@@ -111,6 +111,14 @@ assessment:
   # Optional per-run timeout in seconds (omit to use runner defaults)
   # timeoutSeconds: 3600
 
+# Periodic Kubernetes AI Conformance readiness evaluation (bundled checklist data)
+aiConformance:
+  enabled: true
+  # Interval between scheduled runs when enabled (seconds). Minimum: 3600
+  intervalSeconds: 86400
+  # Checklist source packaged with the operator image (only bundled is supported today)
+  checklistSource: bundled
+
 # Event storage configuration
 events:
   # PersistentVolume configuration for event database

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/copy-checklist-bundle.cjs",
     "lint": "tsc --noEmit",
     "dev": "LOG_LEVEL=${LOG_LEVEL:-info} DB_PATH=${DB_PATH:-$PWD/.kube9-data} tsx src/index.ts",
     "dev:watch": "LOG_LEVEL=${LOG_LEVEL:-info} DB_PATH=${DB_PATH:-$PWD/.kube9-data} nodemon --exec tsx src/index.ts",

--- a/scripts/copy-checklist-bundle.cjs
+++ b/scripts/copy-checklist-bundle.cjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const projectRoot = path.resolve(__dirname, '..');
+const sourceDir = path.join(projectRoot, 'src', 'ai-conformance', 'checklist');
+const targetDir = path.join(projectRoot, 'dist', 'ai-conformance', 'checklist');
+
+function copyRecursive(source, target) {
+  fs.mkdirSync(target, { recursive: true });
+
+  for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
+    const sourcePath = path.join(source, entry.name);
+    const targetPath = path.join(target, entry.name);
+
+    if (entry.isDirectory()) {
+      copyRecursive(sourcePath, targetPath);
+      continue;
+    }
+
+    if (entry.name.endsWith('.ts')) {
+      continue;
+    }
+
+    fs.copyFileSync(sourcePath, targetPath);
+  }
+}
+
+if (!fs.existsSync(sourceDir)) {
+  console.error(`Checklist source directory not found: ${sourceDir}`);
+  process.exit(1);
+}
+
+copyRecursive(sourceDir, targetDir);
+console.log(`Copied checklist bundle assets to ${targetDir}`);

--- a/src/ai-conformance/checklist/bundle-manifest.json
+++ b/src/ai-conformance/checklist/bundle-manifest.json
@@ -1,0 +1,5 @@
+{
+  "sourceRevision": "bundle-2026.1",
+  "packageIdentifier": "kube9-operator-ai-conformance-bundle",
+  "supportedMinors": ["1.30", "1.31", "1.32"]
+}

--- a/src/ai-conformance/checklist/bundled/KubernetesAIConformance-1.30.yaml
+++ b/src/ai-conformance/checklist/bundled/KubernetesAIConformance-1.30.yaml
@@ -1,0 +1,24 @@
+version: KubernetesAIConformance-1.30
+kubernetesMinor: "1.30"
+title: Kubernetes AI Conformance Checklist
+requirements:
+  - id: security.rbac-least-privilege
+    category: security
+    level: MUST
+    title: Enforce least-privilege RBAC
+    description: Cluster roles and bindings should avoid wildcard verbs and resources for routine workloads.
+  - id: security.network-policy-default-deny
+    category: security
+    level: MUST
+    title: Default deny network policies
+    description: Workload namespaces should adopt default-deny network policies unless explicitly exempted.
+  - id: reliability.pod-disruption-budgets
+    category: reliability
+    level: SHOULD
+    title: Pod disruption budgets for critical services
+    description: Stateful or critical services should declare PodDisruptionBudgets before maintenance windows.
+  - id: observability.audit-logging
+    category: operational-excellence
+    level: SHOULD
+    title: Audit logging enabled
+    description: Cluster audit logging should be enabled and retained according to organizational policy.

--- a/src/ai-conformance/checklist/bundled/KubernetesAIConformance-1.31.yaml
+++ b/src/ai-conformance/checklist/bundled/KubernetesAIConformance-1.31.yaml
@@ -1,0 +1,29 @@
+version: KubernetesAIConformance-1.31
+kubernetesMinor: "1.31"
+title: Kubernetes AI Conformance Checklist
+requirements:
+  - id: security.rbac-least-privilege
+    category: security
+    level: MUST
+    title: Enforce least-privilege RBAC
+    description: Cluster roles and bindings should avoid wildcard verbs and resources for routine workloads.
+  - id: security.network-policy-default-deny
+    category: security
+    level: MUST
+    title: Default deny network policies
+    description: Workload namespaces should adopt default-deny network policies unless explicitly exempted.
+  - id: security.secrets-encryption-at-rest
+    category: security
+    level: MUST
+    title: Secrets encryption at rest
+    description: etcd secrets encryption should be configured for clusters handling sensitive workload data.
+  - id: reliability.pod-disruption-budgets
+    category: reliability
+    level: SHOULD
+    title: Pod disruption budgets for critical services
+    description: Stateful or critical services should declare PodDisruptionBudgets before maintenance windows.
+  - id: observability.audit-logging
+    category: operational-excellence
+    level: SHOULD
+    title: Audit logging enabled
+    description: Cluster audit logging should be enabled and retained according to organizational policy.

--- a/src/ai-conformance/checklist/bundled/KubernetesAIConformance-1.32.yaml
+++ b/src/ai-conformance/checklist/bundled/KubernetesAIConformance-1.32.yaml
@@ -1,0 +1,34 @@
+version: KubernetesAIConformance-1.32
+kubernetesMinor: "1.32"
+title: Kubernetes AI Conformance Checklist
+requirements:
+  - id: security.rbac-least-privilege
+    category: security
+    level: MUST
+    title: Enforce least-privilege RBAC
+    description: Cluster roles and bindings should avoid wildcard verbs and resources for routine workloads.
+  - id: security.network-policy-default-deny
+    category: security
+    level: MUST
+    title: Default deny network policies
+    description: Workload namespaces should adopt default-deny network policies unless explicitly exempted.
+  - id: security.secrets-encryption-at-rest
+    category: security
+    level: MUST
+    title: Secrets encryption at rest
+    description: etcd secrets encryption should be configured for clusters handling sensitive workload data.
+  - id: security.admission-policy-enforcement
+    category: security
+    level: MUST
+    title: Admission policy enforcement
+    description: Validating admission policies should enforce baseline security constraints for AI workloads.
+  - id: reliability.pod-disruption-budgets
+    category: reliability
+    level: SHOULD
+    title: Pod disruption budgets for critical services
+    description: Stateful or critical services should declare PodDisruptionBudgets before maintenance windows.
+  - id: observability.audit-logging
+    category: operational-excellence
+    level: SHOULD
+    title: Audit logging enabled
+    description: Cluster audit logging should be enabled and retained according to organizational policy.

--- a/src/ai-conformance/checklist/contracts.ts
+++ b/src/ai-conformance/checklist/contracts.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+export const AiConformanceRequirementLevelSchema = z.enum(['MUST', 'SHOULD']);
+
+export const AiConformanceChecklistRequirementSchema = z.object({
+  id: z.string().min(1),
+  category: z.string().min(1),
+  level: AiConformanceRequirementLevelSchema,
+  title: z.string().min(1),
+  description: z.string().min(1),
+});
+
+export const AiConformanceChecklistDocumentSchema = z.object({
+  version: z.string().min(1),
+  kubernetesMinor: z.string().regex(/^\d+\.\d+$/),
+  title: z.string().min(1),
+  requirements: z.array(AiConformanceChecklistRequirementSchema).min(1),
+});
+
+export const AiConformanceBundleManifestSchema = z.object({
+  sourceRevision: z.string().min(1),
+  packageIdentifier: z.string().min(1),
+  supportedMinors: z.array(z.string().regex(/^\d+\.\d+$/)).min(1),
+});
+
+export type AiConformanceChecklistRequirement = z.infer<
+  typeof AiConformanceChecklistRequirementSchema
+>;
+export type AiConformanceChecklistDocument = z.infer<
+  typeof AiConformanceChecklistDocumentSchema
+>;
+export type AiConformanceBundleManifest = z.infer<
+  typeof AiConformanceBundleManifestSchema
+>;

--- a/src/ai-conformance/checklist/errors.ts
+++ b/src/ai-conformance/checklist/errors.ts
@@ -1,0 +1,42 @@
+/**
+ * Bounded errors for checklist loading and selection.
+ */
+
+export type ChecklistErrorCode =
+  | 'unsupported_minor'
+  | 'missing_checklist_file'
+  | 'malformed_yaml'
+  | 'invalid_checklist_document'
+  | 'manifest_error';
+
+export class ChecklistLoadError extends Error {
+  readonly code: ChecklistErrorCode;
+  readonly kubernetesMinor: string | null;
+
+  constructor(
+    code: ChecklistErrorCode,
+    message: string,
+    kubernetesMinor: string | null = null
+  ) {
+    super(message);
+    this.name = 'ChecklistLoadError';
+    this.code = code;
+    this.kubernetesMinor = kubernetesMinor;
+  }
+}
+
+const MAX_ISSUE_DETAIL_LENGTH = 120;
+
+/**
+ * Produce a bounded parser detail string suitable for conformance run failure text.
+ */
+export function boundChecklistErrorDetail(error: ChecklistLoadError): string {
+  const prefix = error.kubernetesMinor
+    ? `${error.code}:${error.kubernetesMinor}`
+    : error.code;
+  const detail = error.message.trim();
+  const combined = detail ? `${prefix} - ${detail}` : prefix;
+  return combined.length <= MAX_ISSUE_DETAIL_LENGTH
+    ? combined
+    : `${combined.slice(0, MAX_ISSUE_DETAIL_LENGTH - 3)}...`;
+}

--- a/src/ai-conformance/checklist/loader.test.ts
+++ b/src/ai-conformance/checklist/loader.test.ts
@@ -1,0 +1,66 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { describe, expect, it } from 'vitest';
+import { ChecklistLoadError } from './errors.js';
+import {
+  loadBundleManifest,
+  loadChecklistFile,
+  parseChecklistYaml,
+} from './loader.js';
+
+function createTempBundleRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'kube9-checklist-'));
+  const bundledDir = join(root, 'bundled');
+  mkdirSync(bundledDir, { recursive: true });
+  writeFileSync(
+    join(root, 'bundle-manifest.json'),
+    JSON.stringify({
+      sourceRevision: 'test-revision',
+      packageIdentifier: 'test-bundle',
+      supportedMinors: ['1.31'],
+    })
+  );
+  return root;
+}
+
+describe('checklist loader', () => {
+  it('loads and validates the packaged bundle manifest', () => {
+    const manifest = loadBundleManifest();
+    expect(manifest.sourceRevision).toBe('bundle-2026.1');
+    expect(manifest.supportedMinors).toContain('1.31');
+  });
+
+  it('loads a supported checklist file from the bundled directory', () => {
+    const document = loadChecklistFile('KubernetesAIConformance-1.31.yaml');
+    expect(document.version).toBe('KubernetesAIConformance-1.31');
+    expect(document.kubernetesMinor).toBe('1.31');
+    expect(document.requirements.length).toBeGreaterThan(0);
+  });
+
+  it('rejects malformed checklist YAML with bounded errors', () => {
+    expect(() => parseChecklistYaml('version: [', 'test.yaml')).toThrow(ChecklistLoadError);
+    expect(() => parseChecklistYaml('not-an-object', 'test.yaml')).toThrow(
+      /expected a document object/
+    );
+  });
+
+  it('rejects invalid checklist documents', () => {
+    const invalid = `
+version: KubernetesAIConformance-1.31
+kubernetesMinor: "1.31"
+title: Test
+requirements: []
+`;
+    expect(() => parseChecklistYaml(invalid, 'invalid.yaml')).toThrow(
+      ChecklistLoadError
+    );
+  });
+
+  it('reports missing checklist files', () => {
+    const bundleRoot = createTempBundleRoot();
+    expect(() =>
+      loadChecklistFile('KubernetesAIConformance-9.99.yaml', bundleRoot)
+    ).toThrow(ChecklistLoadError);
+  });
+});

--- a/src/ai-conformance/checklist/loader.ts
+++ b/src/ai-conformance/checklist/loader.ts
@@ -1,0 +1,120 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import yaml from 'js-yaml';
+import { ZodError } from 'zod';
+import {
+  AiConformanceBundleManifestSchema,
+  AiConformanceChecklistDocumentSchema,
+} from './contracts.js';
+import type { AiConformanceBundleManifest, AiConformanceChecklistDocument } from './contracts.js';
+import { ChecklistLoadError } from './errors.js';
+import { resolveBundledDir, resolveChecklistModuleRoot } from './paths.js';
+
+function formatZodIssues(error: ZodError): string {
+  const first = error.issues[0];
+  if (!first) {
+    return 'Checklist document failed validation.';
+  }
+  const path = first.path.length > 0 ? first.path.join('.') : 'root';
+  return `Checklist document failed validation at "${path}": ${first.message}`;
+}
+
+/**
+ * Load and validate the bundled checklist manifest.
+ */
+export function loadBundleManifest(bundleRoot?: string): AiConformanceBundleManifest {
+  const moduleRoot = resolveChecklistModuleRoot(bundleRoot);
+  const manifestPath = join(moduleRoot, 'bundle-manifest.json');
+
+  let raw: string;
+  try {
+    raw = readFileSync(manifestPath, 'utf8');
+  } catch {
+    throw new ChecklistLoadError(
+      'manifest_error',
+      'Bundled checklist manifest is missing or unreadable.'
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new ChecklistLoadError(
+      'manifest_error',
+      'Bundled checklist manifest is not valid JSON.'
+    );
+  }
+
+  try {
+    return AiConformanceBundleManifestSchema.parse(parsed);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      throw new ChecklistLoadError('manifest_error', formatZodIssues(error));
+    }
+    throw error;
+  }
+}
+
+/**
+ * Parse and validate checklist YAML content.
+ */
+export function parseChecklistYaml(
+  yamlContent: string,
+  sourceLabel: string
+): AiConformanceChecklistDocument {
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(yamlContent);
+  } catch (error) {
+    const detail =
+      error instanceof Error ? error.message : 'Checklist YAML could not be parsed.';
+    throw new ChecklistLoadError(
+      'malformed_yaml',
+      `Malformed checklist YAML in ${sourceLabel}: ${detail}`
+    );
+  }
+
+  if (parsed === null || typeof parsed !== 'object') {
+    throw new ChecklistLoadError(
+      'malformed_yaml',
+      `Malformed checklist YAML in ${sourceLabel}: expected a document object.`
+    );
+  }
+
+  try {
+    return AiConformanceChecklistDocumentSchema.parse(parsed);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      throw new ChecklistLoadError(
+        'invalid_checklist_document',
+        formatZodIssues(error)
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Load a checklist YAML file from the bundled directory.
+ */
+export function loadChecklistFile(
+  filename: string,
+  bundleRoot?: string
+): AiConformanceChecklistDocument {
+  const bundledDir = resolveBundledDir(resolveChecklistModuleRoot(bundleRoot));
+  const filePath = join(bundledDir, filename);
+
+  let yamlContent: string;
+  try {
+    yamlContent = readFileSync(filePath, 'utf8');
+  } catch {
+    throw new ChecklistLoadError(
+      'missing_checklist_file',
+      `Checklist file "${filename}" is missing from the operator bundle.`,
+      null
+    );
+  }
+
+  return parseChecklistYaml(yamlContent, filename);
+}

--- a/src/ai-conformance/checklist/paths.ts
+++ b/src/ai-conformance/checklist/paths.ts
@@ -1,0 +1,27 @@
+import { existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * Resolve the checklist module directory that contains bundle-manifest.json and bundled/.
+ */
+export function resolveDefaultChecklistModuleRoot(): string {
+  return dirname(fileURLToPath(import.meta.url));
+}
+
+/**
+ * Resolve checklist module root, preferring an explicit override when it exists.
+ */
+export function resolveChecklistModuleRoot(override?: string): string {
+  if (override && existsSync(override)) {
+    return override;
+  }
+  return resolveDefaultChecklistModuleRoot();
+}
+
+/**
+ * Resolve the packaged checklist YAML directory for a module root.
+ */
+export function resolveBundledDir(moduleRoot: string): string {
+  return join(moduleRoot, 'bundled');
+}

--- a/src/ai-conformance/checklist/selector.test.ts
+++ b/src/ai-conformance/checklist/selector.test.ts
@@ -1,0 +1,119 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { describe, expect, it } from 'vitest';
+import { boundChecklistErrorDetail, ChecklistLoadError } from './errors.js';
+import {
+  resolveKubernetesMinorForSelection,
+  selectChecklistForCluster,
+} from './selector.js';
+
+function writeValidChecklist(bundleRoot: string, minor: string): void {
+  const bundledDir = join(bundleRoot, 'bundled');
+  mkdirSync(bundledDir, { recursive: true });
+  writeFileSync(
+    join(bundleRoot, 'bundle-manifest.json'),
+    JSON.stringify({
+      sourceRevision: 'test-revision',
+      packageIdentifier: 'test-bundle',
+      supportedMinors: [minor],
+    })
+  );
+  writeFileSync(
+    join(bundledDir, `KubernetesAIConformance-${minor}.yaml`),
+    `version: KubernetesAIConformance-${minor}
+kubernetesMinor: "${minor}"
+title: Test Checklist
+requirements:
+  - id: security.example
+    category: security
+    level: MUST
+    title: Example requirement
+    description: Example description for tests.
+`
+  );
+}
+
+describe('checklist selector', () => {
+  it('selects a supported checklist by detected Kubernetes minor', () => {
+    const loaded = selectChecklistForCluster({ gitVersion: 'v1.31.4' });
+    expect(loaded.metadata.checklistVersion).toBe('KubernetesAIConformance-1.31');
+    expect(loaded.metadata.kubernetesMinor).toBe('1.31');
+    expect(loaded.metadata.sourceRevision).toBe('bundle-2026.1');
+    expect(loaded.metadata.requirementCount).toBe(loaded.document.requirements.length);
+  });
+
+  it('supports kubernetesMinor override for deterministic tests', () => {
+    const loaded = selectChecklistForCluster({
+      gitVersion: 'v9.99.0',
+      options: { kubernetesMinorOverride: '1.32' },
+    });
+    expect(loaded.metadata.kubernetesMinor).toBe('1.32');
+    expect(loaded.metadata.checklistVersion).toBe('KubernetesAIConformance-1.32');
+  });
+
+  it('rejects unsupported Kubernetes minors', () => {
+    expect(() =>
+      selectChecklistForCluster({
+        gitVersion: 'v1.29.0',
+      })
+    ).toThrow(ChecklistLoadError);
+
+    try {
+      selectChecklistForCluster({ gitVersion: 'v1.29.0' });
+    } catch (error) {
+      expect(error).toBeInstanceOf(ChecklistLoadError);
+      if (error instanceof ChecklistLoadError) {
+        expect(error.code).toBe('unsupported_minor');
+        expect(error.kubernetesMinor).toBe('1.29');
+        expect(boundChecklistErrorDetail(error)).toContain('unsupported_minor');
+      }
+    }
+  });
+
+  it('rejects malformed checklist YAML from a custom bundle root', () => {
+    const bundleRoot = mkdtempSync(join(tmpdir(), 'kube9-checklist-bad-'));
+    const bundledDir = join(bundleRoot, 'bundled');
+    mkdirSync(bundledDir, { recursive: true });
+    writeFileSync(
+      join(bundleRoot, 'bundle-manifest.json'),
+      JSON.stringify({
+        sourceRevision: 'bad-revision',
+        packageIdentifier: 'bad-bundle',
+        supportedMinors: ['1.31'],
+      })
+    );
+    writeFileSync(join(bundledDir, 'KubernetesAIConformance-1.31.yaml'), 'version: [');
+
+    expect(() =>
+      selectChecklistForCluster({
+        options: {
+          kubernetesMinorOverride: '1.31',
+          bundleRoot,
+        },
+      })
+    ).toThrow(ChecklistLoadError);
+  });
+
+  it('propagates source revision from bundle manifest', () => {
+    const bundleRoot = mkdtempSync(join(tmpdir(), 'kube9-checklist-rev-'));
+    writeValidChecklist(bundleRoot, '1.30');
+    const loaded = selectChecklistForCluster({
+      options: {
+        kubernetesMinorOverride: '1.30',
+        bundleRoot,
+      },
+    });
+    expect(loaded.metadata.sourceRevision).toBe('test-revision');
+    expect(loaded.metadata.packageIdentifier).toBe('test-bundle');
+  });
+
+  it('resolves Kubernetes minor from override before gitVersion', () => {
+    expect(
+      resolveKubernetesMinorForSelection({
+        gitVersion: 'v1.31.0',
+        options: { kubernetesMinorOverride: '1.32' },
+      })
+    ).toBe('1.32');
+  });
+});

--- a/src/ai-conformance/checklist/selector.ts
+++ b/src/ai-conformance/checklist/selector.ts
@@ -1,0 +1,87 @@
+import { checklistFilenameForMinor, normalizeKubernetesMinor } from '../kubernetes-version.js';
+import type { LoadedChecklist, ChecklistSelectionOptions } from './types.js';
+import { ChecklistLoadError } from './errors.js';
+import { loadBundleManifest, loadChecklistFile } from './loader.js';
+
+export interface ChecklistSelectionInput {
+  /**
+   * Cluster gitVersion when no override is provided.
+   */
+  gitVersion?: string | null;
+  options?: ChecklistSelectionOptions;
+}
+
+/**
+ * Resolve the Kubernetes minor used for checklist selection.
+ */
+export function resolveKubernetesMinorForSelection(
+  input: ChecklistSelectionInput
+): string {
+  const override = input.options?.kubernetesMinorOverride;
+  if (override !== undefined && override !== null && override !== '') {
+    return normalizeKubernetesMinor(override);
+  }
+
+  const gitVersion = input.gitVersion?.trim();
+  if (!gitVersion) {
+    throw new ChecklistLoadError(
+      'unsupported_minor',
+      'Kubernetes minor is unavailable for checklist selection.'
+    );
+  }
+
+  const withoutPrefix = gitVersion.startsWith('v') ? gitVersion.slice(1) : gitVersion;
+  const core = withoutPrefix.split('+')[0]?.split('-')[0] ?? '';
+  const parts = core.split('.');
+  if (parts.length < 2 || !/^\d+$/.test(parts[0] ?? '') || !/^\d+$/.test(parts[1] ?? '')) {
+    throw new ChecklistLoadError(
+      'unsupported_minor',
+      `Kubernetes version "${gitVersion}" does not include a supported minor.`,
+      null
+    );
+  }
+
+  return `${parts[0]}.${parts[1]}`;
+}
+
+/**
+ * Select and load the bundled checklist for a Kubernetes minor.
+ */
+export function selectChecklistForCluster(
+  input: ChecklistSelectionInput
+): LoadedChecklist {
+  const bundleRoot = input.options?.bundleRoot;
+  const manifest = loadBundleManifest(bundleRoot);
+  const kubernetesMinor = resolveKubernetesMinorForSelection(input);
+
+  if (!manifest.supportedMinors.includes(kubernetesMinor)) {
+    throw new ChecklistLoadError(
+      'unsupported_minor',
+      `Kubernetes minor ${kubernetesMinor} is not supported by the packaged checklist bundle.`,
+      kubernetesMinor
+    );
+  }
+
+  const filename = checklistFilenameForMinor(kubernetesMinor);
+  const document = loadChecklistFile(filename, bundleRoot);
+
+  if (document.kubernetesMinor !== kubernetesMinor) {
+    throw new ChecklistLoadError(
+      'invalid_checklist_document',
+      `Checklist file ${filename} declares kubernetesMinor ${document.kubernetesMinor}, expected ${kubernetesMinor}.`,
+      kubernetesMinor
+    );
+  }
+
+  return {
+    document,
+    metadata: {
+      checklistVersion: document.version,
+      kubernetesMinor,
+      sourceRevision: manifest.sourceRevision,
+      packageIdentifier: manifest.packageIdentifier,
+      requirementCount: document.requirements.length,
+    },
+    sourcePath: filename,
+  };
+}

--- a/src/ai-conformance/checklist/types.ts
+++ b/src/ai-conformance/checklist/types.ts
@@ -1,0 +1,32 @@
+import type { AiConformanceChecklistDocument } from './contracts.js';
+
+/**
+ * Metadata recorded with every checklist selection and conformance run.
+ */
+export interface SelectedChecklistMetadata {
+  checklistVersion: string;
+  kubernetesMinor: string;
+  sourceRevision: string;
+  packageIdentifier: string;
+  requirementCount: number;
+}
+
+/**
+ * Loaded checklist with selection metadata for downstream evaluator and persistence.
+ */
+export interface LoadedChecklist {
+  document: AiConformanceChecklistDocument;
+  metadata: SelectedChecklistMetadata;
+  sourcePath: string;
+}
+
+export interface ChecklistSelectionOptions {
+  /**
+   * Override detected Kubernetes minor for deterministic tests and CLI runs.
+   */
+  kubernetesMinorOverride?: string;
+  /**
+   * Optional checklist module root for tests (contains bundle-manifest.json and bundled/).
+   */
+  bundleRoot?: string;
+}

--- a/src/ai-conformance/contracts.ts
+++ b/src/ai-conformance/contracts.ts
@@ -1,0 +1,101 @@
+import { z } from 'zod';
+
+export const AiConformanceRunStateSchema = z.enum(['completed', 'failed', 'partial']);
+
+export const AiConformanceRequirementStatusSchema = z.enum([
+  'passed',
+  'failed',
+  'warning',
+  'not-applicable',
+  'not-evaluated',
+  'needs-evidence',
+]);
+
+export const AiConformanceRequirementLevelSchema = z.enum(['MUST', 'SHOULD']);
+
+export const AiConformanceTotalsSchema = z.object({
+  totalRequirements: z.number().int().nonnegative(),
+  mustRequirements: z.number().int().nonnegative(),
+  shouldRequirements: z.number().int().nonnegative(),
+  passed: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+  warning: z.number().int().nonnegative(),
+  notApplicable: z.number().int().nonnegative(),
+  notEvaluated: z.number().int().nonnegative(),
+  needsEvidence: z.number().int().nonnegative(),
+});
+
+export const AiConformanceCategorySummarySchema = z.object({
+  total: z.number().int().nonnegative(),
+  passed: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+  warning: z.number().int().nonnegative(),
+  notApplicable: z.number().int().nonnegative(),
+  notEvaluated: z.number().int().nonnegative(),
+  needsEvidence: z.number().int().nonnegative(),
+});
+
+export const AiConformanceRequirementSummarySchema = z.object({
+  id: z.string().min(1),
+  category: z.string().min(1),
+  level: AiConformanceRequirementLevelSchema,
+  title: z.string().min(1),
+  status: AiConformanceRequirementStatusSchema,
+  rationale: z.string().min(1),
+  evidenceRef: z.string().nullable().optional(),
+});
+
+export const AiConformanceLatestSummarySchema = z.object({
+  checklistVersion: z.string().min(1),
+  kubernetesMinor: z.string().min(1),
+  sourceRevision: z.string().nullable(),
+  lastCompletedAt: z.string().nullable(),
+  lastOutcome: z.enum(['none', 'success', 'failed']),
+  runState: AiConformanceRunStateSchema.nullable(),
+  runId: z.string().nullable(),
+  totals: AiConformanceTotalsSchema,
+  categories: z.record(z.string(), AiConformanceCategorySummarySchema),
+  requirements: z.array(AiConformanceRequirementSummarySchema),
+  error: z.string().nullable(),
+});
+
+export const EvaluatedRequirementResultSchema = z.object({
+  requirement_id: z.string().min(1),
+  category: z.string().min(1),
+  level: AiConformanceRequirementLevelSchema,
+  title: z.string().min(1),
+  status: AiConformanceRequirementStatusSchema,
+  rationale: z.string().min(1),
+  evidence_ref: z.string().nullable().optional(),
+  evaluated_at: z.string().min(1),
+});
+
+export type AiConformanceRunState = z.infer<typeof AiConformanceRunStateSchema>;
+export type AiConformanceRequirementStatus = z.infer<
+  typeof AiConformanceRequirementStatusSchema
+>;
+export type AiConformanceRequirementLevel = z.infer<typeof AiConformanceRequirementLevelSchema>;
+export type AiConformanceTotals = z.infer<typeof AiConformanceTotalsSchema>;
+export type AiConformanceCategorySummary = z.infer<typeof AiConformanceCategorySummarySchema>;
+export type AiConformanceRequirementSummary = z.infer<
+  typeof AiConformanceRequirementSummarySchema
+>;
+export type AiConformanceLatestSummary = z.infer<typeof AiConformanceLatestSummarySchema>;
+export type EvaluatedRequirementResult = z.infer<typeof EvaluatedRequirementResultSchema>;
+
+/** Unicode-safe length cap for status JSON fields. */
+export const CONFORMANCE_STATUS_FIELD_MAX = 420;
+
+/** Bounded failure reason for persisted runs. */
+export const CONFORMANCE_FAILURE_REASON_MAX = 120;
+
+export function boundConformanceText(
+  value: string,
+  maxLength: number = CONFORMANCE_STATUS_FIELD_MAX
+): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= maxLength) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, maxLength - 3)}...`;
+}

--- a/src/ai-conformance/evaluator.test.ts
+++ b/src/ai-conformance/evaluator.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { AiConformanceChecklistRequirement } from './checklist/contracts.js';
+import {
+  evaluateRequirement,
+  evaluateChecklistRequirements,
+} from './evaluator.js';
+import type { KubernetesClient } from '../kubernetes/client.js';
+
+function requirement(
+  id: string,
+  overrides: Partial<AiConformanceChecklistRequirement> = {}
+): AiConformanceChecklistRequirement {
+  return {
+    id,
+    category: overrides.category ?? 'security',
+    level: overrides.level ?? 'MUST',
+    title: overrides.title ?? 'Test requirement',
+    description: overrides.description ?? 'Test description',
+  };
+}
+
+function mockKubernetes(overrides: Partial<KubernetesClient> = {}): KubernetesClient {
+  return {
+    rbacApi: {
+      listClusterRole: vi.fn().mockResolvedValue({ items: [] }),
+      listRoleForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+      listClusterRoleBinding: vi.fn().mockResolvedValue({ items: [] }),
+      listRoleBindingForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+    },
+    appsApi: {
+      listDeploymentForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+      listStatefulSetForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+    },
+    policyApi: {
+      listPodDisruptionBudgetForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+    },
+    networkingApi: {
+      listNetworkPolicyForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+    },
+    ...overrides,
+  } as unknown as KubernetesClient;
+}
+
+describe('AiConformance evaluator', () => {
+  it('maps RBAC least-privilege to passed when no violations', async () => {
+    const result = await evaluateRequirement(
+      requirement('security.rbac-least-privilege'),
+      { kubernetes: mockKubernetes() }
+    );
+    expect(result.status).toBe('passed');
+  });
+
+  it('maps RBAC wildcard rules to failed', async () => {
+    const k8s = mockKubernetes({
+      rbacApi: {
+        listClusterRole: vi.fn().mockResolvedValue({
+          items: [
+            {
+              metadata: { name: 'wildcard-role' },
+              rules: [{ resources: ['*'], verbs: ['get'], apiGroups: [''] }],
+            },
+          ],
+        }),
+        listRoleForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+        listClusterRoleBinding: vi.fn().mockResolvedValue({ items: [] }),
+        listRoleBindingForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+      },
+    } as unknown as Partial<KubernetesClient>);
+
+    const result = await evaluateRequirement(
+      requirement('security.rbac-least-privilege'),
+      { kubernetes: k8s }
+    );
+    expect(result.status).toBe('failed');
+  });
+
+  it('maps secrets encryption to needs-evidence', async () => {
+    const result = await evaluateRequirement(
+      requirement('security.secrets-encryption-at-rest'),
+      { kubernetes: mockKubernetes() }
+    );
+    expect(result.status).toBe('needs-evidence');
+  });
+
+  it('maps audit logging to needs-evidence', async () => {
+    const result = await evaluateRequirement(
+      requirement('observability.audit-logging', {
+        category: 'operational-excellence',
+        level: 'SHOULD',
+      }),
+      { kubernetes: mockKubernetes() }
+    );
+    expect(result.status).toBe('needs-evidence');
+  });
+
+  it('maps network policy gaps to failed', async () => {
+    const k8s = mockKubernetes({
+      appsApi: {
+        listDeploymentForAllNamespaces: vi.fn().mockResolvedValue({
+          items: [{ metadata: { namespace: 'app', name: 'api' }, spec: { replicas: 1 } }],
+        }),
+        listStatefulSetForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+      },
+      networkingApi: {
+        listNetworkPolicyForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+      },
+    } as unknown as Partial<KubernetesClient>);
+
+    const result = await evaluateRequirement(
+      requirement('security.network-policy-default-deny'),
+      { kubernetes: k8s }
+    );
+    expect(result.status).toBe('failed');
+  });
+
+  it('maps PDB gaps to warning for HA workloads', async () => {
+    const k8s = mockKubernetes({
+      appsApi: {
+        listDeploymentForAllNamespaces: vi.fn().mockResolvedValue({
+          items: [
+            {
+              metadata: { namespace: 'app', name: 'api', labels: { app: 'api' } },
+              spec: {
+                replicas: 3,
+                template: { metadata: { labels: { app: 'api' } } },
+              },
+            },
+          ],
+        }),
+        listStatefulSetForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+      },
+      policyApi: {
+        listPodDisruptionBudgetForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+      },
+    } as unknown as Partial<KubernetesClient>);
+
+    const result = await evaluateRequirement(
+      requirement('reliability.pod-disruption-budgets', {
+        category: 'reliability',
+        level: 'SHOULD',
+      }),
+      { kubernetes: k8s }
+    );
+    expect(result.status).toBe('warning');
+  });
+
+  it('maps unregistered requirements to not-evaluated', async () => {
+    const result = await evaluateRequirement(
+      requirement('custom.unknown-requirement'),
+      { kubernetes: mockKubernetes() }
+    );
+    expect(result.status).toBe('not-evaluated');
+  });
+
+  it('maps API failures to not-evaluated without throwing', async () => {
+    const k8s = mockKubernetes({
+      rbacApi: {
+        listClusterRole: vi.fn().mockRejectedValue(new Error('API unavailable')),
+        listRoleForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+        listClusterRoleBinding: vi.fn().mockResolvedValue({ items: [] }),
+        listRoleBindingForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+      },
+    } as unknown as Partial<KubernetesClient>);
+
+    const result = await evaluateRequirement(
+      requirement('security.rbac-least-privilege'),
+      { kubernetes: k8s }
+    );
+    expect(result.status).toBe('not-evaluated');
+    expect(result.rationale).toContain('Could not list RBAC resources');
+  });
+
+  it('evaluates all checklist requirements in order', async () => {
+    const requirements = [
+      requirement('security.rbac-least-privilege'),
+      requirement('security.secrets-encryption-at-rest'),
+    ];
+    const results = await evaluateChecklistRequirements(requirements, {
+      kubernetes: mockKubernetes(),
+    });
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.status)).toEqual(['passed', 'needs-evidence']);
+  });
+});

--- a/src/ai-conformance/evaluator.ts
+++ b/src/ai-conformance/evaluator.ts
@@ -1,0 +1,419 @@
+/**
+ * Kubernetes AI Conformance requirement evaluator.
+ *
+ * Maps checklist requirement IDs to observable Kubernetes API signals.
+ * Requirements without objective signals are marked not-evaluated or needs-evidence.
+ */
+
+import * as k8s from '@kubernetes/client-node';
+import type { KubernetesClient } from '../kubernetes/client.js';
+import type { Logger } from 'winston';
+import type { AiConformanceChecklistRequirement } from './checklist/contracts.js';
+import {
+  boundConformanceText,
+  EvaluatedRequirementResultSchema,
+  type AiConformanceRequirementStatus,
+  type EvaluatedRequirementResult,
+} from './contracts.js';
+
+export interface AiConformanceEvaluatorContext {
+  kubernetes: KubernetesClient;
+  logger?: Logger;
+}
+
+export type RequirementEvaluator = (
+  requirement: AiConformanceChecklistRequirement,
+  ctx: AiConformanceEvaluatorContext
+) => Promise<EvaluatedRequirementResult>;
+
+const SYSTEM_NAMESPACES = new Set([
+  'kube-system',
+  'kube-public',
+  'kube-node-lease',
+  'kube9-system',
+]);
+
+function hasWildcard(arr: string[] | undefined): boolean {
+  if (!arr || !Array.isArray(arr)) {
+    return false;
+  }
+  return arr.some((v) => v === '*');
+}
+
+function result(
+  requirement: AiConformanceChecklistRequirement,
+  status: AiConformanceRequirementStatus,
+  rationale: string,
+  evidenceRef?: string | null,
+  evaluatedAt?: string
+): EvaluatedRequirementResult {
+  return EvaluatedRequirementResultSchema.parse({
+    requirement_id: requirement.id,
+    category: requirement.category,
+    level: requirement.level,
+    title: requirement.title,
+    status,
+    rationale: boundConformanceText(rationale),
+    evidence_ref: evidenceRef ?? null,
+    evaluated_at: evaluatedAt ?? new Date().toISOString(),
+  });
+}
+
+async function evaluateRbacLeastPrivilege(
+  requirement: AiConformanceChecklistRequirement,
+  ctx: AiConformanceEvaluatorContext
+): Promise<EvaluatedRequirementResult> {
+  try {
+    const [clusterRoleList, roleList, crbList, rbList] = await Promise.all([
+      ctx.kubernetes.rbacApi.listClusterRole(),
+      ctx.kubernetes.rbacApi.listRoleForAllNamespaces(),
+      ctx.kubernetes.rbacApi.listClusterRoleBinding(),
+      ctx.kubernetes.rbacApi.listRoleBindingForAllNamespaces(),
+    ]);
+
+    const wildcardViolations: string[] = [];
+    for (const cr of clusterRoleList?.items ?? []) {
+      const name = cr.metadata?.name ?? 'unknown';
+      for (const rule of cr.rules ?? []) {
+        if (
+          hasWildcard(rule.resources) ||
+          hasWildcard(rule.verbs) ||
+          hasWildcard(rule.apiGroups)
+        ) {
+          wildcardViolations.push(`ClusterRole/${name}`);
+          break;
+        }
+      }
+    }
+    for (const r of roleList?.items ?? []) {
+      const name = r.metadata?.name ?? 'unknown';
+      const namespace = r.metadata?.namespace ?? '';
+      for (const rule of r.rules ?? []) {
+        if (
+          hasWildcard(rule.resources) ||
+          hasWildcard(rule.verbs) ||
+          hasWildcard(rule.apiGroups)
+        ) {
+          wildcardViolations.push(`Role/${namespace}/${name}`);
+          break;
+        }
+      }
+    }
+
+    const adminViolations: string[] = [];
+    for (const crb of crbList?.items ?? []) {
+      if (crb.roleRef?.name !== 'cluster-admin' || crb.roleRef?.kind !== 'ClusterRole') {
+        continue;
+      }
+      const name = crb.metadata?.name ?? 'unknown';
+      const subjects = crb.subjects ?? [];
+      const allSystem =
+        subjects.length > 0 &&
+        subjects.every(
+          (s) =>
+            s.kind === 'ServiceAccount' &&
+            s.namespace !== undefined &&
+            SYSTEM_NAMESPACES.has(s.namespace)
+        );
+      if (subjects.length === 0 || !allSystem) {
+        adminViolations.push(`ClusterRoleBinding/${name}`);
+      }
+    }
+    for (const rb of rbList?.items ?? []) {
+      if (rb.roleRef?.name !== 'cluster-admin' || rb.roleRef?.kind !== 'ClusterRole') {
+        continue;
+      }
+      const namespace = rb.metadata?.namespace ?? '';
+      if (!SYSTEM_NAMESPACES.has(namespace)) {
+        adminViolations.push(`RoleBinding/${namespace}/${rb.metadata?.name ?? 'unknown'}`);
+      }
+    }
+
+    const issues = [...wildcardViolations, ...adminViolations];
+    if (issues.length === 0) {
+      return result(
+        requirement,
+        'passed',
+        'No wildcard RBAC rules or cluster-admin misuse detected in observable roles and bindings.',
+        'k8s.rbac.authorization/v1'
+      );
+    }
+
+    const summary =
+      issues.length <= 3
+        ? issues.join(', ')
+        : `${issues.length} RBAC issue(s): ${issues.slice(0, 2).join(', ')}...`;
+
+    return result(
+      requirement,
+      'failed',
+      `Least-privilege violations found: ${summary}`,
+      'k8s.rbac.authorization/v1'
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    ctx.logger?.error?.('RBAC least-privilege evaluation failed', { error: msg });
+    return result(
+      requirement,
+      'not-evaluated',
+      `Could not list RBAC resources: ${boundConformanceText(msg, 200)}`,
+      null
+    );
+  }
+}
+
+function isDefaultDenyPolicy(np: k8s.V1NetworkPolicy): boolean {
+  const selector = np.spec?.podSelector;
+  const hasEmptySelector =
+    selector !== undefined &&
+    (selector.matchLabels === undefined || Object.keys(selector.matchLabels).length === 0) &&
+    (selector.matchExpressions === undefined || selector.matchExpressions.length === 0);
+  const policyTypes = np.spec?.policyTypes ?? [];
+  return hasEmptySelector && policyTypes.includes('Ingress') && policyTypes.includes('Egress');
+}
+
+async function evaluateNetworkPolicyDefaultDeny(
+  requirement: AiConformanceChecklistRequirement,
+  ctx: AiConformanceEvaluatorContext
+): Promise<EvaluatedRequirementResult> {
+  try {
+    const [deploymentsRes, networkPoliciesRes] = await Promise.all([
+      ctx.kubernetes.appsApi.listDeploymentForAllNamespaces(),
+      ctx.kubernetes.networkingApi.listNetworkPolicyForAllNamespaces(),
+    ]);
+
+    const workloadNamespaces = new Set<string>();
+    for (const d of deploymentsRes.items ?? []) {
+      const ns = d.metadata?.namespace ?? '';
+      if (ns && !SYSTEM_NAMESPACES.has(ns)) {
+        workloadNamespaces.add(ns);
+      }
+    }
+
+    if (workloadNamespaces.size === 0) {
+      return result(
+        requirement,
+        'not-applicable',
+        'No user workload namespaces with Deployments were found to evaluate default-deny network policies.',
+        'k8s.apps/v1'
+      );
+    }
+
+    const defaultDenyNamespaces = new Set<string>();
+    for (const np of networkPoliciesRes.items ?? []) {
+      const ns = np.metadata?.namespace ?? '';
+      if (ns && isDefaultDenyPolicy(np)) {
+        defaultDenyNamespaces.add(ns);
+      }
+    }
+
+    const uncovered = [...workloadNamespaces].filter((ns) => !defaultDenyNamespaces.has(ns));
+    if (uncovered.length === 0) {
+      return result(
+        requirement,
+        'passed',
+        'All workload namespaces have a default-deny NetworkPolicy (empty podSelector with Ingress and Egress policy types).',
+        'k8s.networking/v1'
+      );
+    }
+    if (uncovered.length === workloadNamespaces.size) {
+      const sample = uncovered.slice(0, 3).join(', ');
+      return result(
+        requirement,
+        'failed',
+        `No default-deny NetworkPolicy found in workload namespaces: ${sample}${uncovered.length > 3 ? '...' : ''}`,
+        'k8s.networking/v1'
+      );
+    }
+
+    const sample = uncovered.slice(0, 3).join(', ');
+    return result(
+      requirement,
+      'warning',
+      `${uncovered.length} of ${workloadNamespaces.size} workload namespace(s) lack default-deny NetworkPolicy: ${sample}${uncovered.length > 3 ? '...' : ''}`,
+      'k8s.networking/v1'
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    ctx.logger?.error?.('Network policy evaluation failed', { error: msg });
+    return result(
+      requirement,
+      'not-evaluated',
+      `Could not list NetworkPolicies or Deployments: ${boundConformanceText(msg, 200)}`,
+      null
+    );
+  }
+}
+
+function evaluateSecretsEncryptionAtRest(
+  requirement: AiConformanceChecklistRequirement
+): EvaluatedRequirementResult {
+  return result(
+    requirement,
+    'needs-evidence',
+    'etcd secrets encryption configuration is not observable through the Kubernetes API from the operator. Provide encryption-at-rest configuration evidence per organizational policy.',
+    'external:etcd-encryption-config'
+  );
+}
+
+function pdbCoversWorkload(
+  pdb: k8s.V1PodDisruptionBudget,
+  namespace: string,
+  podLabels: Record<string, string> | undefined
+): boolean {
+  if ((pdb.metadata?.namespace ?? '') !== namespace) {
+    return false;
+  }
+  const matchLabels = pdb.spec?.selector?.matchLabels ?? {};
+  const workloadLabels = podLabels ?? {};
+  if (Object.keys(matchLabels).length === 0) {
+    return false;
+  }
+  for (const [k, v] of Object.entries(matchLabels)) {
+    if (workloadLabels[k] !== v) {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function evaluatePodDisruptionBudgets(
+  requirement: AiConformanceChecklistRequirement,
+  ctx: AiConformanceEvaluatorContext
+): Promise<EvaluatedRequirementResult> {
+  try {
+    const [deploymentsRes, statefulSetsRes, pdbsRes] = await Promise.all([
+      ctx.kubernetes.appsApi.listDeploymentForAllNamespaces(),
+      ctx.kubernetes.appsApi.listStatefulSetForAllNamespaces(),
+      ctx.kubernetes.policyApi.listPodDisruptionBudgetForAllNamespaces(),
+    ]);
+
+    const pdbs = pdbsRes.items ?? [];
+    const violations: string[] = [];
+
+    for (const d of deploymentsRes.items ?? []) {
+      const ns = d.metadata?.namespace ?? '';
+      const name = d.metadata?.name ?? 'unknown';
+      const replicas = d.spec?.replicas ?? 1;
+      if (replicas < 2) {
+        continue;
+      }
+      const podLabels = d.spec?.template?.metadata?.labels as Record<string, string> | undefined;
+      const covered = pdbs.some((p) => pdbCoversWorkload(p, ns, podLabels));
+      if (!covered) {
+        violations.push(`${ns}/${name}`);
+      }
+    }
+
+    for (const s of statefulSetsRes.items ?? []) {
+      const ns = s.metadata?.namespace ?? '';
+      const name = s.metadata?.name ?? 'unknown';
+      const replicas = s.spec?.replicas ?? 1;
+      if (replicas < 2) {
+        continue;
+      }
+      const podLabels = s.spec?.template?.metadata?.labels as Record<string, string> | undefined;
+      const covered = pdbs.some((p) => pdbCoversWorkload(p, ns, podLabels));
+      if (!covered) {
+        violations.push(`${ns}/${name}`);
+      }
+    }
+
+    if (violations.length === 0) {
+      return result(
+        requirement,
+        'passed',
+        'All multi-replica Deployments and StatefulSets have matching PodDisruptionBudget coverage.',
+        'k8s.policy/v1'
+      );
+    }
+
+    const sample =
+      violations.length <= 3
+        ? violations.join(', ')
+        : `${violations.length} workload(s): ${violations.slice(0, 2).join(', ')}...`;
+
+    return result(
+      requirement,
+      'warning',
+      `HA workloads without PodDisruptionBudget: ${sample}`,
+      'k8s.policy/v1'
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    ctx.logger?.error?.('PDB evaluation failed', { error: msg });
+    return result(
+      requirement,
+      'not-evaluated',
+      `Could not list workloads or PodDisruptionBudgets: ${boundConformanceText(msg, 200)}`,
+      null
+    );
+  }
+}
+
+function evaluateAuditLogging(
+  requirement: AiConformanceChecklistRequirement
+): EvaluatedRequirementResult {
+  return result(
+    requirement,
+    'needs-evidence',
+    'Cluster audit logging policy and retention are not observable through the Kubernetes API. Provide audit configuration evidence per organizational policy.',
+    'external:kubernetes-audit-policy'
+  );
+}
+
+const REQUIREMENT_EVALUATORS: Record<string, RequirementEvaluator> = {
+  'security.rbac-least-privilege': evaluateRbacLeastPrivilege,
+  'security.network-policy-default-deny': evaluateNetworkPolicyDefaultDeny,
+  'security.secrets-encryption-at-rest': async (req) => evaluateSecretsEncryptionAtRest(req),
+  'reliability.pod-disruption-budgets': evaluatePodDisruptionBudgets,
+  'observability.audit-logging': async (req) => evaluateAuditLogging(req),
+};
+
+/**
+ * Evaluate a single checklist requirement with exception isolation.
+ */
+export async function evaluateRequirement(
+  requirement: AiConformanceChecklistRequirement,
+  ctx: AiConformanceEvaluatorContext
+): Promise<EvaluatedRequirementResult> {
+  const handler = REQUIREMENT_EVALUATORS[requirement.id];
+  if (!handler) {
+    return result(
+      requirement,
+      'not-evaluated',
+      `No evaluator registered for requirement ${requirement.id}.`,
+      null
+    );
+  }
+
+  try {
+    return await handler(requirement, ctx);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    ctx.logger?.error?.('Requirement evaluation failed', {
+      requirementId: requirement.id,
+      error: msg,
+    });
+    return result(
+      requirement,
+      'not-evaluated',
+      `Evaluator error: ${boundConformanceText(msg, 200)}`,
+      null
+    );
+  }
+}
+
+/**
+ * Evaluate all requirements in a checklist.
+ */
+export async function evaluateChecklistRequirements(
+  requirements: AiConformanceChecklistRequirement[],
+  ctx: AiConformanceEvaluatorContext
+): Promise<EvaluatedRequirementResult[]> {
+  const results: EvaluatedRequirementResult[] = [];
+  for (const requirement of requirements) {
+    results.push(await evaluateRequirement(requirement, ctx));
+  }
+  return results;
+}

--- a/src/ai-conformance/index.ts
+++ b/src/ai-conformance/index.ts
@@ -1,0 +1,41 @@
+export {
+  parseKubernetesMinorFromGitVersion,
+  normalizeKubernetesMinor,
+  checklistFilenameForMinor,
+} from './kubernetes-version.js';
+
+export {
+  AiConformanceRequirementLevelSchema,
+  AiConformanceChecklistRequirementSchema,
+  AiConformanceChecklistDocumentSchema,
+  AiConformanceBundleManifestSchema,
+} from './checklist/contracts.js';
+export type {
+  AiConformanceChecklistRequirement,
+  AiConformanceChecklistDocument,
+  AiConformanceBundleManifest,
+} from './checklist/contracts.js';
+
+export {
+  ChecklistLoadError,
+  boundChecklistErrorDetail,
+} from './checklist/errors.js';
+export type { ChecklistErrorCode } from './checklist/errors.js';
+
+export type {
+  SelectedChecklistMetadata,
+  LoadedChecklist,
+  ChecklistSelectionOptions,
+} from './checklist/types.js';
+
+export {
+  loadBundleManifest,
+  parseChecklistYaml,
+  loadChecklistFile,
+} from './checklist/loader.js';
+
+export {
+  resolveKubernetesMinorForSelection,
+  selectChecklistForCluster,
+} from './checklist/selector.js';
+export type { ChecklistSelectionInput } from './checklist/selector.js';

--- a/src/ai-conformance/index.ts
+++ b/src/ai-conformance/index.ts
@@ -39,3 +39,43 @@ export {
   selectChecklistForCluster,
 } from './checklist/selector.js';
 export type { ChecklistSelectionInput } from './checklist/selector.js';
+
+export {
+  AiConformanceRunStateSchema,
+  AiConformanceRequirementStatusSchema,
+  AiConformanceTotalsSchema,
+  AiConformanceCategorySummarySchema,
+  AiConformanceRequirementSummarySchema,
+  AiConformanceLatestSummarySchema,
+  EvaluatedRequirementResultSchema,
+  boundConformanceText,
+  CONFORMANCE_STATUS_FIELD_MAX,
+  CONFORMANCE_FAILURE_REASON_MAX,
+} from './contracts.js';
+export type {
+  AiConformanceRunState,
+  AiConformanceRequirementStatus,
+  AiConformanceTotals,
+  AiConformanceCategorySummary,
+  AiConformanceRequirementSummary,
+  AiConformanceLatestSummary,
+  EvaluatedRequirementResult,
+} from './contracts.js';
+
+export {
+  evaluateRequirement,
+  evaluateChecklistRequirements,
+} from './evaluator.js';
+export type {
+  AiConformanceEvaluatorContext,
+  RequirementEvaluator,
+} from './evaluator.js';
+
+export { AiConformanceRunner } from './runner.js';
+export type { AiConformanceRunInput, AiConformanceRunnerDeps } from './runner.js';
+
+export {
+  buildTotalsFromResults,
+  buildCategoryRollups,
+  buildBoundedRequirementSummaries,
+} from './summary.js';

--- a/src/ai-conformance/kubernetes-version.test.ts
+++ b/src/ai-conformance/kubernetes-version.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  checklistFilenameForMinor,
+  normalizeKubernetesMinor,
+  parseKubernetesMinorFromGitVersion,
+} from './kubernetes-version.js';
+
+describe('kubernetes-version', () => {
+  it('parses Kubernetes minor from common gitVersion formats', () => {
+    expect(parseKubernetesMinorFromGitVersion('v1.31.2')).toBe('1.31');
+    expect(parseKubernetesMinorFromGitVersion('1.32.0')).toBe('1.32');
+    expect(parseKubernetesMinorFromGitVersion('v1.30.5-gke.123')).toBe('1.30');
+    expect(parseKubernetesMinorFromGitVersion('v1.29.0+build')).toBe('1.29');
+  });
+
+  it('returns null for unsupported gitVersion values', () => {
+    expect(parseKubernetesMinorFromGitVersion('')).toBeNull();
+    expect(parseKubernetesMinorFromGitVersion('unknown')).toBeNull();
+    expect(parseKubernetesMinorFromGitVersion('v1')).toBeNull();
+  });
+
+  it('normalizes Kubernetes minor overrides', () => {
+    expect(normalizeKubernetesMinor('v1.31')).toBe('1.31');
+    expect(normalizeKubernetesMinor('1.32')).toBe('1.32');
+    expect(() => normalizeKubernetesMinor('1')).toThrow(/Invalid Kubernetes minor/);
+  });
+
+  it('builds checklist filenames from Kubernetes minor', () => {
+    expect(checklistFilenameForMinor('1.31')).toBe('KubernetesAIConformance-1.31.yaml');
+    expect(checklistFilenameForMinor('v1.32')).toBe('KubernetesAIConformance-1.32.yaml');
+  });
+});

--- a/src/ai-conformance/kubernetes-version.ts
+++ b/src/ai-conformance/kubernetes-version.ts
@@ -1,0 +1,52 @@
+/**
+ * Kubernetes version helpers for deterministic checklist selection.
+ */
+
+const KUBERNETES_MINOR_PATTERN = /^(\d+)\.(\d+)$/;
+
+/**
+ * Parse a Kubernetes minor version string (e.g. "1.31") from a gitVersion value.
+ */
+export function parseKubernetesMinorFromGitVersion(gitVersion: string): string | null {
+  const trimmed = gitVersion.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const withoutPrefix = trimmed.startsWith('v') ? trimmed.slice(1) : trimmed;
+  const core = withoutPrefix.split('+')[0]?.split('-')[0] ?? '';
+  const parts = core.split('.');
+  if (parts.length < 2) {
+    return null;
+  }
+
+  const major = parts[0];
+  const minor = parts[1];
+  if (!/^\d+$/.test(major) || !/^\d+$/.test(minor)) {
+    return null;
+  }
+
+  return `${major}.${minor}`;
+}
+
+/**
+ * Normalize a Kubernetes minor override for tests and CLI usage.
+ */
+export function normalizeKubernetesMinor(minor: string): string {
+  const trimmed = minor.trim();
+  const normalized = trimmed.startsWith('v') ? trimmed.slice(1) : trimmed;
+  if (!KUBERNETES_MINOR_PATTERN.test(normalized)) {
+    throw new Error(
+      `Invalid Kubernetes minor "${minor}". Expected format like "1.31".`
+    );
+  }
+  return normalized;
+}
+
+/**
+ * Build the bundled checklist filename for a Kubernetes minor.
+ */
+export function checklistFilenameForMinor(kubernetesMinor: string): string {
+  const normalized = normalizeKubernetesMinor(kubernetesMinor);
+  return `KubernetesAIConformance-${normalized}.yaml`;
+}

--- a/src/ai-conformance/runner.test.ts
+++ b/src/ai-conformance/runner.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { existsSync, rmSync, mkdirSync, unlinkSync } from 'fs';
+import path from 'path';
+import { vi } from 'vitest';
+import { SchemaManager } from '../database/schema.js';
+import { DatabaseManager } from '../database/manager.js';
+import { AiConformanceRepository } from '../database/ai-conformance-repository.js';
+import { AiConformanceRunner } from './runner.js';
+import type { KubernetesClient } from '../kubernetes/client.js';
+
+const testDbDir = path.join(process.cwd(), 'test-ai-conformance-runner-temp');
+
+function mockKubernetes(): KubernetesClient {
+  return {
+    rbacApi: {
+      listClusterRole: vi.fn().mockResolvedValue({ items: [] }),
+      listRoleForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+      listClusterRoleBinding: vi.fn().mockResolvedValue({ items: [] }),
+      listRoleBindingForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+    },
+    appsApi: {
+      listDeploymentForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+      listStatefulSetForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+    },
+    policyApi: {
+      listPodDisruptionBudgetForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+    },
+    networkingApi: {
+      listNetworkPolicyForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+    },
+  } as unknown as KubernetesClient;
+}
+
+describe('AiConformanceRunner', () => {
+  beforeAll(() => {
+    if (existsSync(testDbDir)) {
+      rmSync(testDbDir, { recursive: true, force: true });
+    }
+    mkdirSync(testDbDir, { recursive: true });
+    process.env.DB_PATH = testDbDir;
+  });
+
+  afterAll(() => {
+    DatabaseManager.reset();
+    if (existsSync(testDbDir)) {
+      rmSync(testDbDir, { recursive: true, force: true });
+    }
+    delete process.env.DB_PATH;
+  });
+
+  beforeEach(() => {
+    DatabaseManager.reset();
+    const dbBase = path.join(testDbDir, 'kube9.db');
+    for (const file of [dbBase, `${dbBase}-wal`, `${dbBase}-shm`]) {
+      if (existsSync(file)) {
+        unlinkSync(file);
+      }
+    }
+    const schema = new SchemaManager();
+    schema.initialize();
+  });
+
+  afterEach(() => {
+    DatabaseManager.reset();
+  });
+
+  it('persists a completed run with requirement results', async () => {
+    const repo = new AiConformanceRepository();
+    const runner = new AiConformanceRunner({
+      kubernetes: mockKubernetes(),
+      storage: repo,
+    });
+
+    const record = await runner.run({
+      selection: {
+        gitVersion: 'v1.31.0',
+        options: { kubernetesMinorOverride: '1.31' },
+      },
+    });
+
+    expect(record.state).toBe('completed');
+    expect(record.total_requirements).toBe(5);
+    expect(record.needs_evidence_count).toBeGreaterThanOrEqual(2);
+
+    const results = repo.getRequirementResultsForRun(record.run_id);
+    expect(results).toHaveLength(5);
+    expect(results.some((r) => r.status === 'needs-evidence')).toBe(true);
+  });
+
+  it('persists failed run when checklist selection fails', async () => {
+    const repo = new AiConformanceRepository();
+    const runner = new AiConformanceRunner({
+      kubernetes: mockKubernetes(),
+      storage: repo,
+    });
+
+    const record = await runner.run({
+      selection: {
+        options: { kubernetesMinorOverride: '9.99' },
+      },
+    });
+
+    expect(record.state).toBe('failed');
+    expect(record.failure_reason).toBeTruthy();
+    expect(record.failure_reason!.length).toBeLessThanOrEqual(120);
+
+    const results = repo.getRequirementResultsForRun(record.run_id);
+    expect(results).toHaveLength(0);
+  });
+
+  it('does not throw when evaluation dependencies fail at run level', async () => {
+    const repo = new AiConformanceRepository();
+    const brokenK8s = {
+      rbacApi: {
+        listClusterRole: vi.fn().mockRejectedValue(new Error('cluster unreachable')),
+        listRoleForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+        listClusterRoleBinding: vi.fn().mockResolvedValue({ items: [] }),
+        listRoleBindingForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+      },
+      appsApi: {
+        listDeploymentForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+        listStatefulSetForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+      },
+      policyApi: {
+        listPodDisruptionBudgetForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+      },
+      networkingApi: {
+        listNetworkPolicyForAllNamespaces: vi.fn().mockResolvedValue({ items: [] }),
+      },
+    } as unknown as KubernetesClient;
+
+    const runner = new AiConformanceRunner({
+      kubernetes: brokenK8s,
+      storage: repo,
+    });
+
+    const record = await runner.run({
+      selection: {
+        options: { kubernetesMinorOverride: '1.31' },
+      },
+    });
+
+    expect(record.state).toBe('partial');
+    const results = repo.getRequirementResultsForRun(record.run_id);
+    expect(results.some((r) => r.status === 'not-evaluated')).toBe(true);
+  });
+});

--- a/src/ai-conformance/runner.ts
+++ b/src/ai-conformance/runner.ts
@@ -1,0 +1,200 @@
+/**
+ * Kubernetes AI Conformance run orchestrator.
+ *
+ * Selects checklist, evaluates requirements, and persists outcomes.
+ * Run-level failures are persisted without throwing through the operator loop.
+ */
+
+import { randomUUID } from 'crypto';
+import type { Logger } from 'winston';
+import type { KubernetesClient } from '../kubernetes/client.js';
+import { AiConformanceRepository } from '../database/ai-conformance-repository.js';
+import type { AiConformanceRunRecord } from '../database/ai-conformance-contracts.js';
+import {
+  ChecklistLoadError,
+  boundChecklistErrorDetail,
+} from './checklist/errors.js';
+import { selectChecklistForCluster } from './checklist/selector.js';
+import type { ChecklistSelectionInput } from './checklist/selector.js';
+import { evaluateChecklistRequirements } from './evaluator.js';
+import {
+  boundConformanceText,
+  CONFORMANCE_FAILURE_REASON_MAX,
+  type AiConformanceRunState,
+  type EvaluatedRequirementResult,
+} from './contracts.js';
+import { buildTotalsFromResults } from './summary.js';
+
+export interface AiConformanceRunInput {
+  runId?: string;
+  selection: ChecklistSelectionInput;
+}
+
+export interface AiConformanceRunnerDeps {
+  kubernetes: KubernetesClient;
+  logger?: Logger;
+  storage?: AiConformanceRepository;
+}
+
+function countByLevel(requirements: { level: string }[]): {
+  must: number;
+  should: number;
+} {
+  let must = 0;
+  let should = 0;
+  for (const req of requirements) {
+    if (req.level === 'MUST') {
+      must++;
+    } else {
+      should++;
+    }
+  }
+  return { must, should };
+}
+
+function buildFailedRunRecord(params: {
+  runId: string;
+  checklistVersion: string;
+  kubernetesMinor: string;
+  sourceRevision: string | null;
+  requestedAt: string;
+  totalRequirements: number;
+  mustRequirements: number;
+  shouldRequirements: number;
+  failureReason: string;
+}): AiConformanceRunRecord {
+  return {
+    run_id: params.runId,
+    checklist_version: params.checklistVersion,
+    kubernetes_minor: params.kubernetesMinor,
+    source_revision: params.sourceRevision,
+    state: 'failed',
+    requested_at: params.requestedAt,
+    started_at: params.requestedAt,
+    completed_at: new Date().toISOString(),
+    total_requirements: params.totalRequirements,
+    must_requirements: params.mustRequirements,
+    should_requirements: params.shouldRequirements,
+    passed_count: 0,
+    failed_count: 0,
+    warning_count: 0,
+    not_applicable_count: 0,
+    not_evaluated_count: 0,
+    needs_evidence_count: 0,
+    failure_reason: boundConformanceText(params.failureReason, CONFORMANCE_FAILURE_REASON_MAX),
+  };
+}
+
+function computeRunState(results: EvaluatedRequirementResult[]): AiConformanceRunState {
+  const hasNotEvaluated = results.some((r) => r.status === 'not-evaluated');
+  if (hasNotEvaluated) {
+    return 'partial';
+  }
+  return 'completed';
+}
+
+/**
+ * Orchestrates checklist selection, evaluation, and persistence.
+ */
+export class AiConformanceRunner {
+  private readonly deps: AiConformanceRunnerDeps;
+  private readonly storage: AiConformanceRepository;
+
+  constructor(deps: AiConformanceRunnerDeps) {
+    this.deps = deps;
+    this.storage = deps.storage ?? new AiConformanceRepository();
+  }
+
+  /**
+   * Execute a conformance run. Does not throw on evaluation failures.
+   */
+  async run(input: AiConformanceRunInput): Promise<AiConformanceRunRecord> {
+    const runId = input.runId ?? randomUUID();
+    const requestedAt = new Date().toISOString();
+
+    try {
+      const loaded = selectChecklistForCluster(input.selection);
+      const requirements = loaded.document.requirements;
+      const levelCounts = countByLevel(requirements);
+      const startedAt = new Date().toISOString();
+
+      const evaluationResults = await evaluateChecklistRequirements(requirements, {
+        kubernetes: this.deps.kubernetes,
+        logger: this.deps.logger,
+      });
+
+      const totals = buildTotalsFromResults(requirements, evaluationResults);
+      const finalState = computeRunState(evaluationResults);
+
+      const runRecord: AiConformanceRunRecord = {
+        run_id: runId,
+        checklist_version: loaded.metadata.checklistVersion,
+        kubernetes_minor: loaded.metadata.kubernetesMinor,
+        source_revision: loaded.metadata.sourceRevision,
+        state: finalState,
+        requested_at: requestedAt,
+        started_at: startedAt,
+        completed_at: new Date().toISOString(),
+        total_requirements: totals.totalRequirements,
+        must_requirements: totals.mustRequirements,
+        should_requirements: totals.shouldRequirements,
+        passed_count: totals.passed,
+        failed_count: totals.failed,
+        warning_count: totals.warning,
+        not_applicable_count: totals.notApplicable,
+        not_evaluated_count: totals.notEvaluated,
+        needs_evidence_count: totals.needsEvidence,
+        failure_reason: null,
+      };
+
+      this.storage.upsertRun(runRecord);
+      this.storage.insertRequirementResults(runId, evaluationResults);
+      return runRecord;
+    } catch (err) {
+      const failureReason =
+        err instanceof ChecklistLoadError
+          ? boundChecklistErrorDetail(err)
+          : boundConformanceText(
+              err instanceof Error ? err.message : String(err),
+              CONFORMANCE_FAILURE_REASON_MAX
+            );
+
+      let kubernetesMinor = 'unknown';
+      let checklistVersion = 'unknown';
+      let sourceRevision: string | null = null;
+
+      if (err instanceof ChecklistLoadError && err.kubernetesMinor) {
+        kubernetesMinor = err.kubernetesMinor;
+        checklistVersion = `KubernetesAIConformance-${kubernetesMinor}`;
+      }
+
+      const failedRecord = buildFailedRunRecord({
+        runId,
+        checklistVersion,
+        kubernetesMinor,
+        sourceRevision,
+        requestedAt,
+        totalRequirements: 0,
+        mustRequirements: 0,
+        shouldRequirements: 0,
+        failureReason,
+      });
+
+      this.deps.logger?.error?.('AI conformance run failed', {
+        runId,
+        error: failureReason,
+      });
+
+      try {
+        this.storage.upsertRun(failedRecord);
+      } catch (persistErr) {
+        this.deps.logger?.error?.('Failed to persist failed conformance run', {
+          runId,
+          error: persistErr instanceof Error ? persistErr.message : String(persistErr),
+        });
+      }
+
+      return failedRecord;
+    }
+  }
+}

--- a/src/ai-conformance/scheduled-tick.ts
+++ b/src/ai-conformance/scheduled-tick.ts
@@ -1,0 +1,84 @@
+/**
+ * Periodic scheduled Kubernetes AI Conformance evaluation (operator CollectionScheduler task).
+ */
+
+import type { Config } from '../config/types.js';
+import type { KubernetesClient } from '../kubernetes/client.js';
+import type { Logger } from 'winston';
+import { AiConformanceRunner } from './runner.js';
+import { AiConformanceRepository } from '../database/ai-conformance-repository.js';
+
+export type ScheduledAiConformanceRunOutcome = 'success' | 'failed';
+
+export interface ScheduledAiConformanceLastRunSnapshot {
+  startedAt: string;
+  completedAt: string;
+  outcome: ScheduledAiConformanceRunOutcome;
+  runId?: string;
+  runState?: string;
+  errorMessage?: string;
+}
+
+let lastRunSnapshot: ScheduledAiConformanceLastRunSnapshot | null = null;
+
+/** @internal */
+export function resetScheduledAiConformanceStateForTests(): void {
+  lastRunSnapshot = null;
+}
+
+export function getScheduledAiConformanceLastRunSnapshot(): ScheduledAiConformanceLastRunSnapshot | null {
+  return lastRunSnapshot;
+}
+
+export interface ScheduledAiConformanceTickDeps {
+  kubernetes: KubernetesClient;
+  config: Config;
+  logger: Logger;
+}
+
+/**
+ * Executes one scheduled conformance run. Swallows errors so scheduler callbacks never throw.
+ */
+export async function runScheduledAiConformanceTick(
+  deps: ScheduledAiConformanceTickDeps
+): Promise<void> {
+  const startedAt = new Date().toISOString();
+  try {
+    const clusterInfo = await deps.kubernetes.getClusterInfo();
+    const storage = new AiConformanceRepository();
+    const runner = new AiConformanceRunner({
+      kubernetes: deps.kubernetes,
+      logger: deps.logger,
+      storage,
+    });
+
+    const record = await runner.run({
+      selection: {
+        gitVersion: clusterInfo.version,
+      },
+    });
+
+    const outcome: ScheduledAiConformanceRunOutcome =
+      record.state === 'failed' ? 'failed' : 'success';
+
+    lastRunSnapshot = {
+      startedAt,
+      completedAt: record.completed_at ?? new Date().toISOString(),
+      outcome,
+      runId: record.run_id,
+      runState: record.state,
+      ...(record.state === 'failed' && record.failure_reason
+        ? { errorMessage: record.failure_reason }
+        : {}),
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    deps.logger.error('Scheduled AI conformance tick failed', { error: errorMessage });
+    lastRunSnapshot = {
+      startedAt,
+      completedAt: new Date().toISOString(),
+      outcome: 'failed',
+      errorMessage,
+    };
+  }
+}

--- a/src/ai-conformance/summary.ts
+++ b/src/ai-conformance/summary.ts
@@ -1,0 +1,123 @@
+import type { AiConformanceChecklistRequirement } from './checklist/contracts.js';
+import type {
+  AiConformanceCategorySummary,
+  AiConformanceRequirementSummary,
+  AiConformanceTotals,
+  EvaluatedRequirementResult,
+} from './contracts.js';
+import { boundConformanceText } from './contracts.js';
+
+export function buildTotalsFromResults(
+  requirements: AiConformanceChecklistRequirement[],
+  results: EvaluatedRequirementResult[]
+): AiConformanceTotals {
+  const levelCounts = { must: 0, should: 0 };
+  for (const req of requirements) {
+    if (req.level === 'MUST') {
+      levelCounts.must++;
+    } else {
+      levelCounts.should++;
+    }
+  }
+
+  const totals: AiConformanceTotals = {
+    totalRequirements: requirements.length,
+    mustRequirements: levelCounts.must,
+    shouldRequirements: levelCounts.should,
+    passed: 0,
+    failed: 0,
+    warning: 0,
+    notApplicable: 0,
+    notEvaluated: 0,
+    needsEvidence: 0,
+  };
+
+  for (const result of results) {
+    switch (result.status) {
+      case 'passed':
+        totals.passed++;
+        break;
+      case 'failed':
+        totals.failed++;
+        break;
+      case 'warning':
+        totals.warning++;
+        break;
+      case 'not-applicable':
+        totals.notApplicable++;
+        break;
+      case 'not-evaluated':
+        totals.notEvaluated++;
+        break;
+      case 'needs-evidence':
+        totals.needsEvidence++;
+        break;
+    }
+  }
+
+  return totals;
+}
+
+export function buildCategoryRollups(
+  results: EvaluatedRequirementResult[]
+): Record<string, AiConformanceCategorySummary> {
+  const categories: Record<string, AiConformanceCategorySummary> = {};
+
+  for (const result of results) {
+    const existing = categories[result.category] ?? {
+      total: 0,
+      passed: 0,
+      failed: 0,
+      warning: 0,
+      notApplicable: 0,
+      notEvaluated: 0,
+      needsEvidence: 0,
+    };
+    existing.total++;
+    switch (result.status) {
+      case 'passed':
+        existing.passed++;
+        break;
+      case 'failed':
+        existing.failed++;
+        break;
+      case 'warning':
+        existing.warning++;
+        break;
+      case 'not-applicable':
+        existing.notApplicable++;
+        break;
+      case 'not-evaluated':
+        existing.notEvaluated++;
+        break;
+      case 'needs-evidence':
+        existing.needsEvidence++;
+        break;
+    }
+    categories[result.category] = existing;
+  }
+
+  return categories;
+}
+
+export function buildBoundedRequirementSummaries(
+  results: EvaluatedRequirementResult[]
+): AiConformanceRequirementSummary[] {
+  return results
+    .map((row) => ({
+      id: row.requirement_id,
+      category: row.category,
+      level: row.level,
+      title: boundConformanceText(row.title),
+      status: row.status,
+      rationale: boundConformanceText(row.rationale),
+      evidenceRef: row.evidence_ref ?? null,
+    }))
+    .sort((a, b) => {
+      const byCategory = a.category.localeCompare(b.category);
+      if (byCategory !== 0) {
+        return byCategory;
+      }
+      return a.id.localeCompare(b.id);
+    });
+}

--- a/src/assessment/scheduled-tick.test.ts
+++ b/src/assessment/scheduled-tick.test.ts
@@ -27,6 +27,9 @@ const baseConfig = {
   assessmentEnabled: true,
   assessmentIntervalSeconds: 86400,
   assessmentMode: 'full' as const,
+  aiConformanceEnabled: false,
+  aiConformanceIntervalSeconds: 86400,
+  aiConformanceChecklistSource: 'bundled' as const,
 } satisfies Config;
 
 const mockKubernetes = {

--- a/src/cli/commands/ai-conformance.ts
+++ b/src/cli/commands/ai-conformance.ts
@@ -1,0 +1,198 @@
+/**
+ * CLI Kubernetes AI Conformance commands
+ */
+
+import { z } from 'zod';
+import { DatabaseManager } from '../../database/manager.js';
+import { SchemaManager } from '../../database/schema.js';
+import { AiConformanceRepository } from '../../database/ai-conformance-repository.js';
+import type { AiConformanceRunRecord } from '../../database/ai-conformance-contracts.js';
+import { AiConformanceRunner } from '../../ai-conformance/runner.js';
+import { buildBoundedRequirementSummaries } from '../../ai-conformance/summary.js';
+import { kubernetesClient } from '../../kubernetes/client.js';
+import { loadConfig, setConfig } from '../../config/loader.js';
+import { logger } from '../../logging/logger.js';
+import { formatOutput } from '../formatters.js';
+import { normalizeKubernetesMinor } from '../../ai-conformance/kubernetes-version.js';
+
+const FormatSchema = z.enum(['json', 'yaml', 'table', 'compact']).default('json');
+
+const RunOptionsSchema = z.object({
+  kubernetesMinor: z.string().optional(),
+  format: FormatSchema,
+});
+
+const LatestOptionsSchema = z.object({
+  format: FormatSchema,
+});
+
+const GetOptionsSchema = z.object({
+  format: FormatSchema,
+});
+
+const RequirementsOptionsSchema = z.object({
+  runId: z.string().optional(),
+  category: z.string().optional(),
+  status: z
+    .enum(['passed', 'failed', 'warning', 'not-applicable', 'not-evaluated', 'needs-evidence'])
+    .optional(),
+  level: z.enum(['MUST', 'SHOULD']).optional(),
+  format: FormatSchema,
+});
+
+function writeError(message: string, details?: string) {
+  const err = details ? { error: message, details } : { error: message };
+  console.error(JSON.stringify(err));
+  process.exit(1);
+}
+
+function ensureDb() {
+  DatabaseManager.getInstance();
+  const schema = new SchemaManager();
+  schema.initialize();
+}
+
+function toApiRunRecord(record: AiConformanceRunRecord) {
+  return {
+    run_id: record.run_id,
+    checklist_version: record.checklist_version,
+    kubernetes_minor: record.kubernetes_minor,
+    source_revision: record.source_revision ?? null,
+    state: record.state,
+    requested_at: record.requested_at,
+    started_at: record.started_at ?? undefined,
+    completed_at: record.completed_at ?? undefined,
+    total_requirements: record.total_requirements,
+    must_requirements: record.must_requirements,
+    should_requirements: record.should_requirements,
+    passed_count: record.passed_count,
+    failed_count: record.failed_count,
+    warning_count: record.warning_count,
+    not_applicable_count: record.not_applicable_count,
+    not_evaluated_count: record.not_evaluated_count,
+    needs_evidence_count: record.needs_evidence_count,
+    failure_reason: record.failure_reason ?? undefined,
+  };
+}
+
+export async function aiConformanceRun(options: Record<string, unknown>) {
+  try {
+    const validated = RunOptionsSchema.parse(options);
+    ensureDb();
+
+    const config = await loadConfig();
+    setConfig(config);
+
+    let gitVersion: string | undefined;
+    if (validated.kubernetesMinor) {
+      normalizeKubernetesMinor(validated.kubernetesMinor);
+    } else {
+      const clusterInfo = await kubernetesClient.getClusterInfo();
+      gitVersion = clusterInfo.version;
+    }
+
+    const runner = new AiConformanceRunner({
+      kubernetes: kubernetesClient,
+      logger,
+      storage: new AiConformanceRepository(),
+    });
+
+    const record = await runner.run({
+      selection: {
+        gitVersion,
+        options: validated.kubernetesMinor
+          ? { kubernetesMinorOverride: validated.kubernetesMinor }
+          : undefined,
+      },
+    });
+
+    const output = formatOutput(toApiRunRecord(record), validated.format);
+    console.log(output);
+    process.exit(0);
+  } catch (error) {
+    writeError(
+      'Failed to run AI conformance evaluation',
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+}
+
+export async function aiConformanceLatest(options: Record<string, unknown>) {
+  try {
+    const validated = LatestOptionsSchema.parse(options);
+    ensureDb();
+
+    const repo = new AiConformanceRepository();
+    const summary = repo.buildLatestSummary();
+    const output = formatOutput(summary, validated.format);
+    console.log(output);
+    process.exit(0);
+  } catch (error) {
+    writeError(
+      'Failed to load latest AI conformance summary',
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+}
+
+export async function aiConformanceGet(runId: string, options: Record<string, unknown>) {
+  try {
+    const validated = GetOptionsSchema.parse(options);
+    ensureDb();
+
+    const repo = new AiConformanceRepository();
+    const record = repo.getRunById(runId);
+    if (!record) {
+      writeError(`AI conformance run not found: ${runId}`);
+      return;
+    }
+
+    const output = formatOutput(toApiRunRecord(record), validated.format);
+    console.log(output);
+    process.exit(0);
+  } catch (error) {
+    writeError(
+      'Failed to get AI conformance run',
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+}
+
+export async function aiConformanceRequirements(options: Record<string, unknown>) {
+  try {
+    const validated = RequirementsOptionsSchema.parse(options);
+    ensureDb();
+
+    const repo = new AiConformanceRepository();
+    let runId = validated.runId;
+    if (!runId) {
+      const latest = repo.getLatestRun();
+      if (!latest) {
+        writeError('No AI conformance runs found');
+        return;
+      }
+      runId = latest.run_id;
+    }
+
+    let rows = repo.getRequirementResultsForRun(runId);
+    if (validated.category) {
+      rows = rows.filter((row) => row.category === validated.category);
+    }
+    if (validated.status) {
+      rows = rows.filter((row) => row.status === validated.status);
+    }
+    if (validated.level) {
+      rows = rows.filter((row) => row.level === validated.level);
+    }
+
+    const requirements = buildBoundedRequirementSummaries(rows);
+    const output = formatOutput({ run_id: runId, requirements }, validated.format);
+    console.log(output);
+    process.exit(0);
+  } catch (error) {
+    writeError(
+      'Failed to list AI conformance requirement results',
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,54 @@ import {
 import { listVulnerabilities, summarizeVulnerabilities } from './commands/vulnerabilities.js';
 import { listCollections, getCollection } from './commands/collections.js';
 import { listArgoCDApplications, getArgoCDApplication } from './commands/argocd-apps.js';
+import {
+  aiConformanceRun,
+  aiConformanceLatest,
+  aiConformanceGet,
+  aiConformanceRequirements,
+} from './commands/ai-conformance.js';
+
+/**
+ * Create the ai-conformance command structure
+ */
+export function createAiConformanceCommands(): Command {
+  const aiConformance = new Command('ai-conformance')
+    .description('Kubernetes AI Conformance readiness commands');
+
+  aiConformance
+    .command('run')
+    .description('Run readiness evaluation for the current cluster')
+    .option('--kubernetes-minor <minor>', 'Override detected Kubernetes minor (e.g. 1.31)')
+    .option('--format <format>', 'Output format (json|yaml|table|compact)', 'json')
+    .action(aiConformanceRun);
+
+  aiConformance
+    .command('latest')
+    .description('Get the latest persisted readiness summary')
+    .option('--format <format>', 'Output format (json|yaml|table|compact)', 'json')
+    .action(aiConformanceLatest);
+
+  aiConformance
+    .command('get <runId>')
+    .description('Get one persisted conformance run')
+    .option('--format <format>', 'Output format (json|yaml|table|compact)', 'json')
+    .action(aiConformanceGet);
+
+  aiConformance
+    .command('requirements')
+    .description('List bounded per-requirement results for a run')
+    .option('--run-id <runId>', 'Run id (defaults to latest run when omitted)')
+    .option('--category <category>', 'Filter by checklist category')
+    .option(
+      '--status <status>',
+      'Filter by readiness status (passed|failed|warning|not-applicable|not-evaluated|needs-evidence)'
+    )
+    .option('--level <level>', 'Filter by requirement level (MUST|SHOULD)')
+    .option('--format <format>', 'Output format (json|yaml|table|compact)', 'json')
+    .action(aiConformanceRequirements);
+
+  return aiConformance;
+}
 
 /**
  * Create the assess command structure

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -6,6 +6,7 @@ const ASSESSMENT_MODES = ['full', 'pillar', 'single-check'] as const;
 type AssessmentMode = (typeof ASSESSMENT_MODES)[number];
 
 const ASSESSMENT_INTERVAL_MIN_SECONDS = 3600;
+const AI_CONFORMANCE_INTERVAL_MIN_SECONDS = 3600;
 const ASSESSMENT_TIMEOUT_MIN_SECONDS = 60;
 const ASSESSMENT_TIMEOUT_MAX_SECONDS = 7 * 24 * 3600;
 /** Matches operator scheduler minimum for `resource-inventory` (30 minutes). */
@@ -33,7 +34,11 @@ function parsePositiveInt(
   return n;
 }
 
-function parseEnvBool(raw: string | undefined, defaultValue: boolean): boolean {
+function parseEnvBool(
+  raw: string | undefined,
+  defaultValue: boolean,
+  envName: string = 'environment variable'
+): boolean {
   if (raw === undefined || raw === '') {
     return defaultValue;
   }
@@ -45,7 +50,17 @@ function parseEnvBool(raw: string | undefined, defaultValue: boolean): boolean {
     return false;
   }
   throw new Error(
-    `Invalid boolean for ASSESSMENT_ENABLED: "${raw}" (use true/false, 1/0, yes/no)`
+    `Invalid boolean for ${envName}: "${raw}" (use true/false, 1/0, yes/no)`
+  );
+}
+
+function parseAiConformanceChecklistSource(raw: string | undefined): 'bundled' {
+  const v = (raw ?? 'bundled').trim().toLowerCase();
+  if (v === 'bundled') {
+    return 'bundled';
+  }
+  throw new Error(
+    `AI_CONFORMANCE_CHECKLIST_SOURCE must be "bundled"; got "${raw ?? ''}"`
   );
 }
 
@@ -108,7 +123,7 @@ export async function loadConfig(): Promise<Config> {
     process.env.EVENT_RETENTION_ERROR_CRITICAL_DAYS,
     '30'
   );
-  const assessmentEnabled = parseEnvBool(process.env.ASSESSMENT_ENABLED, true);
+  const assessmentEnabled = parseEnvBool(process.env.ASSESSMENT_ENABLED, true, 'ASSESSMENT_ENABLED');
   const assessmentIntervalSeconds = parsePositiveInt(
     'ASSESSMENT_INTERVAL_SECONDS',
     process.env.ASSESSMENT_INTERVAL_SECONDS,
@@ -153,6 +168,21 @@ export async function loadConfig(): Promise<Config> {
     assessmentPillar = raw;
   }
 
+  const aiConformanceEnabled = parseEnvBool(
+    process.env.AI_CONFORMANCE_ENABLED,
+    true,
+    'AI_CONFORMANCE_ENABLED'
+  );
+  const aiConformanceIntervalSeconds = parsePositiveInt(
+    'AI_CONFORMANCE_INTERVAL_SECONDS',
+    process.env.AI_CONFORMANCE_INTERVAL_SECONDS,
+    '86400',
+    AI_CONFORMANCE_INTERVAL_MIN_SECONDS
+  );
+  const aiConformanceChecklistSource = parseAiConformanceChecklistSource(
+    process.env.AI_CONFORMANCE_CHECKLIST_SOURCE
+  );
+
   const config: Config = {
     logLevel,
     statusUpdateIntervalSeconds,
@@ -170,6 +200,9 @@ export async function loadConfig(): Promise<Config> {
     ...(assessmentTimeoutSeconds !== undefined
       ? { assessmentTimeoutSeconds }
       : {}),
+    aiConformanceEnabled,
+    aiConformanceIntervalSeconds,
+    aiConformanceChecklistSource,
   };
 
   logger.info('Collection intervals configured', {
@@ -196,6 +229,16 @@ export async function loadConfig(): Promise<Config> {
     assessmentModeOverridden: process.env.ASSESSMENT_MODE !== undefined,
     assessmentPillarOverridden: process.env.ASSESSMENT_PILLAR !== undefined,
     assessmentTimeoutOverridden: process.env.ASSESSMENT_TIMEOUT_SECONDS !== undefined,
+  });
+
+  logger.info('AI conformance schedule configured', {
+    aiConformanceEnabled: config.aiConformanceEnabled,
+    aiConformanceIntervalSeconds: config.aiConformanceIntervalSeconds,
+    aiConformanceChecklistSource: config.aiConformanceChecklistSource,
+    aiConformanceEnabledOverridden: process.env.AI_CONFORMANCE_ENABLED !== undefined,
+    aiConformanceIntervalOverridden: process.env.AI_CONFORMANCE_INTERVAL_SECONDS !== undefined,
+    aiConformanceChecklistSourceOverridden:
+      process.env.AI_CONFORMANCE_CHECKLIST_SOURCE !== undefined,
   });
 
   return config;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -85,4 +85,20 @@ export interface Config {
    * When unset, runners use their own defaults.
    */
   assessmentTimeoutSeconds?: number;
+
+  /**
+   * When true, the operator may run periodic Kubernetes AI Conformance readiness evaluation.
+   */
+  aiConformanceEnabled: boolean;
+
+  /**
+   * Seconds between scheduled conformance runs when {@link aiConformanceEnabled} is true.
+   * Default: 86400 (24 hours). Minimum: 3600 (1 hour).
+   */
+  aiConformanceIntervalSeconds: number;
+
+  /**
+   * Checklist source for conformance evaluation. Only bundled data is supported today.
+   */
+  aiConformanceChecklistSource: 'bundled';
 }

--- a/src/database/ai-conformance-contracts.ts
+++ b/src/database/ai-conformance-contracts.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+import {
+  AiConformanceRequirementLevelSchema,
+  AiConformanceRequirementStatusSchema,
+  AiConformanceRunStateSchema,
+} from '../ai-conformance/contracts.js';
+
+export const AiConformanceRunRecordSchema = z.object({
+  run_id: z.string().min(1),
+  checklist_version: z.string().min(1),
+  kubernetes_minor: z.string().min(1),
+  source_revision: z.string().nullable().optional(),
+  state: AiConformanceRunStateSchema,
+  requested_at: z.string().min(1),
+  started_at: z.string().nullable().optional(),
+  completed_at: z.string().nullable().optional(),
+  total_requirements: z.number().int().nonnegative(),
+  must_requirements: z.number().int().nonnegative(),
+  should_requirements: z.number().int().nonnegative(),
+  passed_count: z.number().int().nonnegative(),
+  failed_count: z.number().int().nonnegative(),
+  warning_count: z.number().int().nonnegative(),
+  not_applicable_count: z.number().int().nonnegative(),
+  not_evaluated_count: z.number().int().nonnegative(),
+  needs_evidence_count: z.number().int().nonnegative(),
+  failure_reason: z.string().nullable().optional(),
+});
+
+export const AiConformanceRequirementResultRecordSchema = z.object({
+  id: z.string().min(1),
+  run_id: z.string().min(1),
+  requirement_id: z.string().min(1),
+  category: z.string().min(1),
+  level: AiConformanceRequirementLevelSchema,
+  title: z.string().min(1),
+  status: AiConformanceRequirementStatusSchema,
+  rationale: z.string().min(1),
+  evidence_ref: z.string().nullable().optional(),
+  evaluated_at: z.string().min(1),
+});
+
+export type AiConformanceRunRecord = z.infer<typeof AiConformanceRunRecordSchema>;
+export type AiConformanceRequirementResultRecord = z.infer<
+  typeof AiConformanceRequirementResultRecordSchema
+>;

--- a/src/database/ai-conformance-repository.test.ts
+++ b/src/database/ai-conformance-repository.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { SchemaManager } from './schema.js';
+import { DatabaseManager } from './manager.js';
+import { AiConformanceRepository } from './ai-conformance-repository.js';
+import { existsSync, rmSync, mkdirSync, unlinkSync } from 'fs';
+import path from 'path';
+
+const testDbDir = path.join(process.cwd(), 'test-ai-conformance-repo-temp');
+
+describe('AiConformanceRepository', () => {
+  beforeAll(() => {
+    if (existsSync(testDbDir)) {
+      rmSync(testDbDir, { recursive: true, force: true });
+    }
+    mkdirSync(testDbDir, { recursive: true });
+    process.env.DB_PATH = testDbDir;
+  });
+
+  afterAll(() => {
+    DatabaseManager.reset();
+    if (existsSync(testDbDir)) {
+      rmSync(testDbDir, { recursive: true, force: true });
+    }
+    delete process.env.DB_PATH;
+  });
+
+  beforeEach(() => {
+    DatabaseManager.reset();
+    const dbBase = path.join(testDbDir, 'kube9.db');
+    for (const file of [dbBase, `${dbBase}-wal`, `${dbBase}-shm`]) {
+      if (existsSync(file)) {
+        unlinkSync(file);
+      }
+    }
+    const schema = new SchemaManager();
+    schema.initialize();
+  });
+
+  afterEach(() => {
+    DatabaseManager.reset();
+  });
+
+  it('upserts runs and inserts requirement results', () => {
+    const repo = new AiConformanceRepository();
+    const runId = 'run-001';
+    const evaluatedAt = '2026-06-11T12:00:00.000Z';
+
+    repo.upsertRun({
+      run_id: runId,
+      checklist_version: 'KubernetesAIConformance-1.31',
+      kubernetes_minor: '1.31',
+      source_revision: 'bundle-2026.1',
+      state: 'completed',
+      requested_at: evaluatedAt,
+      started_at: evaluatedAt,
+      completed_at: evaluatedAt,
+      total_requirements: 2,
+      must_requirements: 1,
+      should_requirements: 1,
+      passed_count: 1,
+      failed_count: 1,
+      warning_count: 0,
+      not_applicable_count: 0,
+      not_evaluated_count: 0,
+      needs_evidence_count: 0,
+      failure_reason: null,
+    });
+
+    repo.insertRequirementResults(runId, [
+      {
+        requirement_id: 'security.rbac-least-privilege',
+        category: 'security',
+        level: 'MUST',
+        title: 'Enforce least-privilege RBAC',
+        status: 'passed',
+        rationale: 'No wildcard RBAC detected.',
+        evidence_ref: 'k8s.rbac.authorization/v1',
+        evaluated_at: evaluatedAt,
+      },
+      {
+        requirement_id: 'reliability.pod-disruption-budgets',
+        category: 'reliability',
+        level: 'SHOULD',
+        title: 'Pod disruption budgets',
+        status: 'failed',
+        rationale: 'Missing PDB on app/default/api.',
+        evidence_ref: 'k8s.policy/v1',
+        evaluated_at: evaluatedAt,
+      },
+    ]);
+
+    const run = repo.getRunById(runId);
+    expect(run?.state).toBe('completed');
+    expect(run?.passed_count).toBe(1);
+    expect(run?.failed_count).toBe(1);
+
+    const results = repo.getRequirementResultsForRun(runId);
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.requirement_id).sort()).toEqual([
+      'reliability.pod-disruption-budgets',
+      'security.rbac-least-privilege',
+    ]);
+  });
+
+  it('returns latest run and builds bounded summary', () => {
+    const repo = new AiConformanceRepository();
+    const older = '2026-06-10T12:00:00.000Z';
+    const newer = '2026-06-11T12:00:00.000Z';
+
+    repo.upsertRun({
+      run_id: 'run-old',
+      checklist_version: 'KubernetesAIConformance-1.30',
+      kubernetes_minor: '1.30',
+      source_revision: 'bundle-2026.1',
+      state: 'completed',
+      requested_at: older,
+      started_at: older,
+      completed_at: older,
+      total_requirements: 1,
+      must_requirements: 1,
+      should_requirements: 0,
+      passed_count: 1,
+      failed_count: 0,
+      warning_count: 0,
+      not_applicable_count: 0,
+      not_evaluated_count: 0,
+      needs_evidence_count: 0,
+    });
+
+    repo.upsertRun({
+      run_id: 'run-new',
+      checklist_version: 'KubernetesAIConformance-1.31',
+      kubernetes_minor: '1.31',
+      source_revision: 'bundle-2026.1',
+      state: 'partial',
+      requested_at: newer,
+      started_at: newer,
+      completed_at: newer,
+      total_requirements: 2,
+      must_requirements: 1,
+      should_requirements: 1,
+      passed_count: 0,
+      failed_count: 0,
+      warning_count: 0,
+      not_applicable_count: 0,
+      not_evaluated_count: 1,
+      needs_evidence_count: 1,
+    });
+
+    repo.insertRequirementResults('run-new', [
+      {
+        requirement_id: 'security.secrets-encryption-at-rest',
+        category: 'security',
+        level: 'MUST',
+        title: 'Secrets encryption at rest',
+        status: 'needs-evidence',
+        rationale: 'Requires external etcd encryption evidence.',
+        evidence_ref: 'external:etcd-encryption-config',
+        evaluated_at: newer,
+      },
+      {
+        requirement_id: 'observability.audit-logging',
+        category: 'operational-excellence',
+        level: 'SHOULD',
+        title: 'Audit logging enabled',
+        status: 'not-evaluated',
+        rationale: 'Audit policy not observable from API.',
+        evidence_ref: null,
+        evaluated_at: newer,
+      },
+    ]);
+
+    const latest = repo.getLatestRun();
+    expect(latest?.run_id).toBe('run-new');
+
+    const summary = repo.buildLatestSummary();
+    expect(summary.runId).toBe('run-new');
+    expect(summary.lastOutcome).toBe('success');
+    expect(summary.totals.needsEvidence).toBe(1);
+    expect(summary.totals.notEvaluated).toBe(1);
+    expect(summary.categories.security?.needsEvidence).toBe(1);
+    expect(summary.requirements).toHaveLength(2);
+    expect(summary.requirements[0]?.rationale.length).toBeLessThanOrEqual(420);
+  });
+
+  it('persists failed runs with bounded failure reason', () => {
+    const repo = new AiConformanceRepository();
+    const longReason = 'x'.repeat(200);
+
+    repo.upsertRun({
+      run_id: 'run-failed',
+      checklist_version: 'unknown',
+      kubernetes_minor: 'unknown',
+      source_revision: null,
+      state: 'failed',
+      requested_at: '2026-06-11T12:00:00.000Z',
+      started_at: '2026-06-11T12:00:00.000Z',
+      completed_at: '2026-06-11T12:00:00.000Z',
+      total_requirements: 0,
+      must_requirements: 0,
+      should_requirements: 0,
+      passed_count: 0,
+      failed_count: 0,
+      warning_count: 0,
+      not_applicable_count: 0,
+      not_evaluated_count: 0,
+      needs_evidence_count: 0,
+      failure_reason: longReason.slice(0, 120),
+    });
+
+    const summary = repo.buildLatestSummary();
+    expect(summary.lastOutcome).toBe('failed');
+    expect(summary.error?.length).toBeLessThanOrEqual(420);
+  });
+});

--- a/src/database/ai-conformance-repository.ts
+++ b/src/database/ai-conformance-repository.ts
@@ -1,0 +1,299 @@
+/**
+ * SQLite persistence for Kubernetes AI Conformance runs and requirement results.
+ */
+
+import { randomUUID } from 'crypto';
+import Database from 'better-sqlite3';
+import { DatabaseManager } from './manager.js';
+import {
+  AiConformanceRequirementResultRecordSchema,
+  AiConformanceRunRecordSchema,
+  type AiConformanceRequirementResultRecord,
+  type AiConformanceRunRecord,
+} from './ai-conformance-contracts.js';
+import type { EvaluatedRequirementResult } from '../ai-conformance/contracts.js';
+import type { AiConformanceLatestSummary } from '../ai-conformance/contracts.js';
+import {
+  buildBoundedRequirementSummaries,
+  buildCategoryRollups,
+} from '../ai-conformance/summary.js';
+import { boundConformanceText } from '../ai-conformance/contracts.js';
+
+export interface AiConformanceRunRow {
+  run_id: string;
+  checklist_version: string;
+  kubernetes_minor: string;
+  source_revision: string | null;
+  state: string;
+  requested_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+  total_requirements: number;
+  must_requirements: number;
+  should_requirements: number;
+  passed_count: number;
+  failed_count: number;
+  warning_count: number;
+  not_applicable_count: number;
+  not_evaluated_count: number;
+  needs_evidence_count: number;
+  failure_reason: string | null;
+}
+
+export interface AiConformanceRequirementResultRow {
+  id: string;
+  run_id: string;
+  requirement_id: string;
+  category: string;
+  level: string;
+  title: string;
+  status: string;
+  rationale: string;
+  evidence_ref: string | null;
+  evaluated_at: string;
+}
+
+const EMPTY_SUMMARY: AiConformanceLatestSummary = {
+  checklistVersion: 'unknown',
+  kubernetesMinor: 'unknown',
+  sourceRevision: null,
+  lastCompletedAt: null,
+  lastOutcome: 'none',
+  runState: null,
+  runId: null,
+  totals: {
+    totalRequirements: 0,
+    mustRequirements: 0,
+    shouldRequirements: 0,
+    passed: 0,
+    failed: 0,
+    warning: 0,
+    notApplicable: 0,
+    notEvaluated: 0,
+    needsEvidence: 0,
+  },
+  categories: {},
+  requirements: [],
+  error: null,
+};
+
+export class AiConformanceRepository {
+  private db: Database.Database;
+
+  constructor() {
+    const manager = DatabaseManager.getInstance();
+    this.db = manager.getDatabase();
+  }
+
+  private tableReady(): boolean {
+    const row = this.db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='ai_conformance_runs'`)
+      .get() as { name: string } | undefined;
+    return row !== undefined;
+  }
+
+  public upsertRun(record: AiConformanceRunRecord): void {
+    const validated = AiConformanceRunRecordSchema.parse(record);
+    const stmt = this.db.prepare(`
+      INSERT INTO ai_conformance_runs (
+        run_id, checklist_version, kubernetes_minor, source_revision, state,
+        requested_at, started_at, completed_at,
+        total_requirements, must_requirements, should_requirements,
+        passed_count, failed_count, warning_count,
+        not_applicable_count, not_evaluated_count, needs_evidence_count,
+        failure_reason
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(run_id) DO UPDATE SET
+        state = excluded.state,
+        started_at = COALESCE(excluded.started_at, started_at),
+        completed_at = COALESCE(excluded.completed_at, completed_at),
+        total_requirements = excluded.total_requirements,
+        must_requirements = excluded.must_requirements,
+        should_requirements = excluded.should_requirements,
+        passed_count = excluded.passed_count,
+        failed_count = excluded.failed_count,
+        warning_count = excluded.warning_count,
+        not_applicable_count = excluded.not_applicable_count,
+        not_evaluated_count = excluded.not_evaluated_count,
+        needs_evidence_count = excluded.needs_evidence_count,
+        failure_reason = excluded.failure_reason
+    `);
+
+    stmt.run(
+      validated.run_id,
+      validated.checklist_version,
+      validated.kubernetes_minor,
+      validated.source_revision ?? null,
+      validated.state,
+      validated.requested_at,
+      validated.started_at ?? null,
+      validated.completed_at ?? null,
+      validated.total_requirements,
+      validated.must_requirements,
+      validated.should_requirements,
+      validated.passed_count,
+      validated.failed_count,
+      validated.warning_count,
+      validated.not_applicable_count,
+      validated.not_evaluated_count,
+      validated.needs_evidence_count,
+      validated.failure_reason ?? null
+    );
+  }
+
+  public insertRequirementResults(
+    runId: string,
+    results: EvaluatedRequirementResult[]
+  ): void {
+    const stmt = this.db.prepare(`
+      INSERT INTO ai_conformance_requirement_results (
+        id, run_id, requirement_id, category, level, title,
+        status, rationale, evidence_ref, evaluated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    const insertMany = this.db.transaction((rows: EvaluatedRequirementResult[]) => {
+      for (const row of rows) {
+        const record: AiConformanceRequirementResultRecord = {
+          id: randomUUID(),
+          run_id: runId,
+          requirement_id: row.requirement_id,
+          category: row.category,
+          level: row.level,
+          title: row.title,
+          status: row.status,
+          rationale: row.rationale,
+          evidence_ref: row.evidence_ref ?? null,
+          evaluated_at: row.evaluated_at,
+        };
+        const validated = AiConformanceRequirementResultRecordSchema.parse(record);
+        stmt.run(
+          validated.id,
+          validated.run_id,
+          validated.requirement_id,
+          validated.category,
+          validated.level,
+          validated.title,
+          validated.status,
+          validated.rationale,
+          validated.evidence_ref ?? null,
+          validated.evaluated_at
+        );
+      }
+    });
+
+    insertMany(results);
+  }
+
+  public getRunById(runId: string): AiConformanceRunRecord | null {
+    const row = this.db
+      .prepare('SELECT * FROM ai_conformance_runs WHERE run_id = ?')
+      .get(runId) as AiConformanceRunRow | undefined;
+    if (!row) {
+      return null;
+    }
+    return this.rowToRunRecord(row);
+  }
+
+  public getLatestRun(): AiConformanceRunRecord | null {
+    const row = this.db
+      .prepare(`
+        SELECT * FROM ai_conformance_runs
+        ORDER BY COALESCE(completed_at, requested_at) DESC
+        LIMIT 1
+      `)
+      .get() as AiConformanceRunRow | undefined;
+    if (!row) {
+      return null;
+    }
+    return this.rowToRunRecord(row);
+  }
+
+  public getRequirementResultsForRun(runId: string): EvaluatedRequirementResult[] {
+    const rows = this.db
+      .prepare(`
+        SELECT * FROM ai_conformance_requirement_results
+        WHERE run_id = ?
+        ORDER BY category ASC, requirement_id ASC
+      `)
+      .all(runId) as AiConformanceRequirementResultRow[];
+
+    return rows.map((row) => ({
+      requirement_id: row.requirement_id,
+      category: row.category,
+      level: row.level as EvaluatedRequirementResult['level'],
+      title: row.title,
+      status: row.status as EvaluatedRequirementResult['status'],
+      rationale: row.rationale,
+      evidence_ref: row.evidence_ref,
+      evaluated_at: row.evaluated_at,
+    }));
+  }
+
+  public buildLatestSummary(): AiConformanceLatestSummary {
+    if (!this.tableReady()) {
+      return EMPTY_SUMMARY;
+    }
+
+    const run = this.getLatestRun();
+    if (!run) {
+      return EMPTY_SUMMARY;
+    }
+
+    const results = this.getRequirementResultsForRun(run.run_id);
+    const lastOutcome =
+      run.state === 'failed' ? 'failed' : run.state === 'completed' || run.state === 'partial'
+        ? 'success'
+        : 'none';
+
+    return {
+      checklistVersion: run.checklist_version,
+      kubernetesMinor: run.kubernetes_minor,
+      sourceRevision: run.source_revision ?? null,
+      lastCompletedAt: run.completed_at ?? null,
+      lastOutcome,
+      runState: run.state,
+      runId: run.run_id,
+      totals: {
+        totalRequirements: run.total_requirements,
+        mustRequirements: run.must_requirements,
+        shouldRequirements: run.should_requirements,
+        passed: run.passed_count,
+        failed: run.failed_count,
+        warning: run.warning_count,
+        notApplicable: run.not_applicable_count,
+        notEvaluated: run.not_evaluated_count,
+        needsEvidence: run.needs_evidence_count,
+      },
+      categories: buildCategoryRollups(results),
+      requirements: buildBoundedRequirementSummaries(results),
+      error:
+        run.state === 'failed' && run.failure_reason
+          ? boundConformanceText(run.failure_reason)
+          : null,
+    };
+  }
+
+  private rowToRunRecord(row: AiConformanceRunRow): AiConformanceRunRecord {
+    return AiConformanceRunRecordSchema.parse({
+      run_id: row.run_id,
+      checklist_version: row.checklist_version,
+      kubernetes_minor: row.kubernetes_minor,
+      source_revision: row.source_revision,
+      state: row.state,
+      requested_at: row.requested_at,
+      started_at: row.started_at,
+      completed_at: row.completed_at,
+      total_requirements: row.total_requirements,
+      must_requirements: row.must_requirements,
+      should_requirements: row.should_requirements,
+      passed_count: row.passed_count,
+      failed_count: row.failed_count,
+      warning_count: row.warning_count,
+      not_applicable_count: row.not_applicable_count,
+      not_evaluated_count: row.not_evaluated_count,
+      needs_evidence_count: row.needs_evidence_count,
+      failure_reason: row.failure_reason,
+    });
+  }
+}

--- a/src/database/schema.test.ts
+++ b/src/database/schema.test.ts
@@ -349,12 +349,76 @@ describe('SchemaManager', () => {
     expect(meta?.sql).toContain('PRIMARY KEY (cluster_id, app_namespace, app_name)');
   });
 
+  it('creates ai_conformance tables when migrating to v6', () => {
+    const schema = new SchemaManager();
+    schema.initialize();
+
+    const manager = DatabaseManager.getInstance();
+    const db = manager.getDatabase();
+
+    const runsTable = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='ai_conformance_runs'`)
+      .get() as { name: string } | undefined;
+    expect(runsTable?.name).toBe('ai_conformance_runs');
+
+    const resultsTable = db
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='ai_conformance_requirement_results'`
+      )
+      .get() as { name: string } | undefined;
+    expect(resultsTable?.name).toBe('ai_conformance_requirement_results');
+
+    const runColumns = db
+      .prepare(`PRAGMA table_info(ai_conformance_runs)`)
+      .all() as Array<{ name: string }>;
+    expect(runColumns.map((c) => c.name)).toEqual(
+      expect.arrayContaining([
+        'run_id',
+        'checklist_version',
+        'kubernetes_minor',
+        'source_revision',
+        'state',
+        'failure_reason',
+        'needs_evidence_count',
+      ])
+    );
+
+    const resultColumns = db
+      .prepare(`PRAGMA table_info(ai_conformance_requirement_results)`)
+      .all() as Array<{ name: string }>;
+    expect(resultColumns.map((c) => c.name)).toEqual(
+      expect.arrayContaining([
+        'run_id',
+        'requirement_id',
+        'category',
+        'level',
+        'status',
+        'rationale',
+        'evidence_ref',
+      ])
+    );
+
+    const indexes = db
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='ai_conformance_requirement_results' AND name NOT LIKE 'sqlite_%'`
+      )
+      .all() as Array<{ name: string }>;
+    expect(indexes.map((i) => i.name)).toEqual(
+      expect.arrayContaining([
+        'idx_ai_conformance_requirement_results_run_id',
+        'idx_ai_conformance_requirement_results_category',
+        'idx_ai_conformance_requirement_results_status',
+        'idx_ai_conformance_requirement_results_run_requirement',
+      ])
+    );
+  });
+
   it('migration runs cleanly on fresh database', () => {
     DatabaseManager.reset();
     const schema = new SchemaManager();
     schema.initialize();
 
-    expect(schema.getVersion()).toBeGreaterThanOrEqual(5);
+    expect(schema.getVersion()).toBeGreaterThanOrEqual(6);
 
     const manager = DatabaseManager.getInstance();
     const db = manager.getDatabase();

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -7,7 +7,7 @@ import Database from 'better-sqlite3';
 import { logger } from '../logging/logger.js';
 
 /** Latest schema version - bump when adding migrations */
-const LATEST_SCHEMA_VERSION = 5;
+const LATEST_SCHEMA_VERSION = 6;
 
 /**
  * SchemaManager handles database schema initialization and migrations
@@ -61,6 +61,10 @@ export class SchemaManager {
       {
         version: 5,
         apply: () => this.migrateToV5(),
+      },
+      {
+        version: 6,
+        apply: () => this.migrateToV6(),
       },
     ];
 
@@ -207,6 +211,64 @@ export class SchemaManager {
 
       CREATE INDEX IF NOT EXISTS idx_argocd_apps_cluster_observed
         ON argocd_apps(cluster_id, observed_at DESC);
+    `);
+  }
+
+  /**
+   * Migration v6: M10 Kubernetes AI Conformance runs and requirement results.
+   */
+  private migrateToV6(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS ai_conformance_runs (
+        run_id TEXT PRIMARY KEY,
+        checklist_version TEXT NOT NULL,
+        kubernetes_minor TEXT NOT NULL,
+        source_revision TEXT,
+        state TEXT NOT NULL CHECK (state IN ('completed', 'failed', 'partial')),
+        requested_at TEXT NOT NULL,
+        started_at TEXT,
+        completed_at TEXT,
+        total_requirements INTEGER NOT NULL DEFAULT 0,
+        must_requirements INTEGER NOT NULL DEFAULT 0,
+        should_requirements INTEGER NOT NULL DEFAULT 0,
+        passed_count INTEGER NOT NULL DEFAULT 0,
+        failed_count INTEGER NOT NULL DEFAULT 0,
+        warning_count INTEGER NOT NULL DEFAULT 0,
+        not_applicable_count INTEGER NOT NULL DEFAULT 0,
+        not_evaluated_count INTEGER NOT NULL DEFAULT 0,
+        needs_evidence_count INTEGER NOT NULL DEFAULT 0,
+        failure_reason TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_ai_conformance_runs_completed_at
+        ON ai_conformance_runs(completed_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_ai_conformance_runs_kubernetes_minor
+        ON ai_conformance_runs(kubernetes_minor);
+
+      CREATE TABLE IF NOT EXISTS ai_conformance_requirement_results (
+        id TEXT PRIMARY KEY,
+        run_id TEXT NOT NULL,
+        requirement_id TEXT NOT NULL,
+        category TEXT NOT NULL,
+        level TEXT NOT NULL CHECK (level IN ('MUST', 'SHOULD')),
+        title TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN (
+          'passed', 'failed', 'warning', 'not-applicable', 'not-evaluated', 'needs-evidence'
+        )),
+        rationale TEXT NOT NULL,
+        evidence_ref TEXT,
+        evaluated_at TEXT NOT NULL,
+        FOREIGN KEY (run_id) REFERENCES ai_conformance_runs(run_id) ON DELETE CASCADE
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_ai_conformance_requirement_results_run_id
+        ON ai_conformance_requirement_results(run_id);
+      CREATE INDEX IF NOT EXISTS idx_ai_conformance_requirement_results_category
+        ON ai_conformance_requirement_results(category);
+      CREATE INDEX IF NOT EXISTS idx_ai_conformance_requirement_results_status
+        ON ai_conformance_requirement_results(status);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_conformance_requirement_results_run_requirement
+        ON ai_conformance_requirement_results(run_id, requirement_id);
     `);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { program } from 'commander';
-import { createQueryCommands, createAssessCommands } from './cli/index.js';
+import { createQueryCommands, createAssessCommands, createAiConformanceCommands } from './cli/index.js';
 import { getConfig } from './config/loader.js';
 import type { Config } from './config/types.js';
 
@@ -29,6 +29,9 @@ program.addCommand(createQueryCommands());
 
 // Assess command - Well-Architected Framework assessment
 program.addCommand(createAssessCommands());
+
+// AI conformance command - Kubernetes AI Conformance readiness evaluation
+program.addCommand(createAiConformanceCommands());
 
 program.parse(process.argv);
 

--- a/src/kubernetes/client.ts
+++ b/src/kubernetes/client.ts
@@ -15,8 +15,8 @@ export interface ClusterInfo {
  * 
  * Uses in-cluster configuration when running as a pod.
  * Falls back to default kubeconfig (from KUBECONFIG env var or ~/.kube/config) for local development.
- * Provides CoreV1Api, VersionApi, AppsV1Api, PolicyV1Api, AutoscalingV2Api,
- * ApiextensionsV1Api, CustomObjectsApi, and RbacAuthorizationV1Api clients
+ * Provides CoreV1Api, VersionApi, AppsV1Api, PolicyV1Api, NetworkingV1Api,
+ * AutoscalingV2Api, ApiextensionsV1Api, CustomObjectsApi, and RbacAuthorizationV1Api clients
  * for cluster operations.
  */
 export class KubernetesClient {
@@ -25,6 +25,7 @@ export class KubernetesClient {
   public readonly versionApi: k8s.VersionApi;
   public readonly appsApi: k8s.AppsV1Api;
   public readonly policyApi: k8s.PolicyV1Api;
+  public readonly networkingApi: k8s.NetworkingV1Api;
   public readonly autoscalingApi: k8s.AutoscalingV2Api;
   public readonly apiextensionsApi: k8s.ApiextensionsV1Api;
   public readonly customObjectsApi: k8s.CustomObjectsApi;
@@ -69,6 +70,7 @@ export class KubernetesClient {
       this.versionApi = this.kubeConfig.makeApiClient(k8s.VersionApi);
       this.appsApi = this.kubeConfig.makeApiClient(k8s.AppsV1Api);
       this.policyApi = this.kubeConfig.makeApiClient(k8s.PolicyV1Api);
+      this.networkingApi = this.kubeConfig.makeApiClient(k8s.NetworkingV1Api);
       this.autoscalingApi = this.kubeConfig.makeApiClient(k8s.AutoscalingV2Api);
       this.apiextensionsApi = this.kubeConfig.makeApiClient(k8s.ApiextensionsV1Api);
       this.customObjectsApi = this.kubeConfig.makeApiClient(k8s.CustomObjectsApi);

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -37,6 +37,10 @@ import {
   runScheduledAssessmentTick,
   getScheduledAssessmentLastRunSnapshot,
 } from './assessment/scheduled-tick.js';
+import {
+  runScheduledAiConformanceTick,
+  getScheduledAiConformanceLastRunSnapshot,
+} from './ai-conformance/scheduled-tick.js';
 
 // Module-level references for shutdown handler
 let statusWriterInstance: StatusWriter | null = null;
@@ -381,6 +385,46 @@ export async function startOperator() {
             const durationSeconds = (Date.now() - startTime) / 1000;
             recordCollection('well-architected-assessment', 'failed', durationSeconds);
             collectionStatsTracker.recordFailure('well-architected-assessment');
+          }
+        }
+      );
+    }
+
+    if (config.aiConformanceEnabled) {
+      collectionScheduler.register(
+        'kubernetes-ai-conformance',
+        config.aiConformanceIntervalSeconds,
+        3600,
+        3600,
+        async () => {
+          const startTime = Date.now();
+          try {
+            await runScheduledAiConformanceTick({
+              kubernetes: kubernetesClient,
+              config,
+              logger,
+            });
+            const durationSeconds = (Date.now() - startTime) / 1000;
+            const snap = getScheduledAiConformanceLastRunSnapshot();
+            const tickOk = snap?.outcome !== 'failed';
+            recordCollection(
+              'kubernetes-ai-conformance',
+              tickOk ? 'success' : 'failed',
+              durationSeconds
+            );
+            if (tickOk) {
+              collectionStatsTracker.recordSuccess('kubernetes-ai-conformance');
+            } else {
+              collectionStatsTracker.recordFailure('kubernetes-ai-conformance');
+            }
+          } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            logger.error('Scheduled AI conformance tick failed unexpectedly', {
+              error: errorMessage,
+            });
+            const durationSeconds = (Date.now() - startTime) / 1000;
+            recordCollection('kubernetes-ai-conformance', 'failed', durationSeconds);
+            collectionStatsTracker.recordFailure('kubernetes-ai-conformance');
           }
         }
       );

--- a/src/shutdown/handler.ts
+++ b/src/shutdown/handler.ts
@@ -17,9 +17,16 @@ import {
   DEFAULT_ASSESSMENT_SCHEDULE_CONTEXT,
   loadLatestPersistedAssessment,
 } from '../status/assessment-summary.js';
+import {
+  buildAiConformanceScheduleContextFromConfig,
+  buildAiConformanceStatusSummary,
+  DEFAULT_AI_CONFORMANCE_SCHEDULE_CONTEXT,
+  loadLatestPersistedAiConformanceSummary,
+} from '../status/ai-conformance-summary.js';
 import { getConfig } from '../config/loader.js';
 import { getScheduledAssessmentLastRunSnapshot } from '../assessment/scheduled-tick.js';
 import { AssessmentRepository } from '../database/assessment-repository.js';
+import { AiConformanceRepository } from '../database/ai-conformance-repository.js';
 
 /**
  * Operator version (semver)
@@ -110,6 +117,16 @@ export async function gracefulShutdown(
       latestDbRun,
       dbChecks
     );
+    let aiConformanceSchedule = DEFAULT_AI_CONFORMANCE_SCHEDULE_CONTEXT;
+    try {
+      aiConformanceSchedule = buildAiConformanceScheduleContextFromConfig(getConfig());
+    } catch {
+      // ignore
+    }
+    const aiConformanceSummary = buildAiConformanceStatusSummary(
+      loadLatestPersistedAiConformanceSummary(new AiConformanceRepository()),
+      aiConformanceSchedule
+    );
     const finalStatus: OperatorStatus = {
       mode: 'operated',
       version: OPERATOR_VERSION,
@@ -129,6 +146,14 @@ export async function gracefulShutdown(
         ...assessmentSummary,
         lastScheduledTotals: { ...assessmentSummary.lastScheduledTotals },
         lastScheduledChecks: assessmentSummary.lastScheduledChecks.map((c) => ({ ...c })),
+      },
+      aiConformance: {
+        ...aiConformanceSummary,
+        totals: { ...aiConformanceSummary.totals },
+        categories: Object.fromEntries(
+          Object.entries(aiConformanceSummary.categories).map(([key, value]) => [key, { ...value }])
+        ),
+        requirements: aiConformanceSummary.requirements.map((row) => ({ ...row })),
       },
     };
 

--- a/src/status/ai-conformance-summary.test.ts
+++ b/src/status/ai-conformance-summary.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { existsSync, rmSync, mkdirSync, unlinkSync } from 'fs';
+import path from 'path';
+import { DatabaseManager } from '../database/manager.js';
+import { SchemaManager } from '../database/schema.js';
+import { AiConformanceRepository } from '../database/ai-conformance-repository.js';
+import { CONFORMANCE_STATUS_FIELD_MAX } from '../ai-conformance/contracts.js';
+import { calculateStatus } from './calculator.js';
+import {
+  DEFAULT_AI_CONFORMANCE_SUMMARY,
+  buildAiConformanceScheduleContextFromConfig,
+  buildAiConformanceStatusSummary,
+  loadLatestPersistedAiConformanceSummary,
+} from './ai-conformance-summary.js';
+import type { Config } from '../config/types.js';
+
+const testDbDir = path.join(process.cwd(), 'test-ai-conformance-status-temp');
+
+const baseConfig: Config = {
+  logLevel: 'info',
+  statusUpdateIntervalSeconds: 60,
+  clusterMetadataIntervalSeconds: 86400,
+  resourceInventoryIntervalSeconds: 21600,
+  resourceConfigurationPatternsIntervalSeconds: 43200,
+  workloadImageScanIntervalSeconds: 86400,
+  argocdApplicationStatusIntervalSeconds: 3600,
+  eventRetentionInfoWarningDays: 7,
+  eventRetentionErrorCriticalDays: 30,
+  assessmentEnabled: false,
+  assessmentIntervalSeconds: 86400,
+  assessmentMode: 'full',
+  aiConformanceEnabled: true,
+  aiConformanceIntervalSeconds: 86400,
+  aiConformanceChecklistSource: 'bundled',
+};
+
+describe('ai-conformance status summary', () => {
+  beforeAll(() => {
+    if (existsSync(testDbDir)) {
+      rmSync(testDbDir, { recursive: true, force: true });
+    }
+    mkdirSync(testDbDir, { recursive: true });
+    process.env.DB_PATH = testDbDir;
+  });
+
+  afterAll(() => {
+    DatabaseManager.reset();
+    if (existsSync(testDbDir)) {
+      rmSync(testDbDir, { recursive: true, force: true });
+    }
+    delete process.env.DB_PATH;
+  });
+
+  beforeEach(() => {
+    DatabaseManager.reset();
+    const dbBase = path.join(testDbDir, 'kube9.db');
+    for (const file of [dbBase, `${dbBase}-wal`, `${dbBase}-shm`]) {
+      if (existsSync(file)) {
+        unlinkSync(file);
+      }
+    }
+    const schema = new SchemaManager();
+    schema.initialize();
+  });
+
+  afterEach(() => {
+    DatabaseManager.reset();
+  });
+
+  it('returns stable no-run summary before any persisted run', () => {
+    const repo = new AiConformanceRepository();
+    const latest = loadLatestPersistedAiConformanceSummary(repo);
+    expect(latest.lastOutcome).toBe('none');
+    expect(latest.requirements).toEqual([]);
+
+    const summary = buildAiConformanceStatusSummary(
+      latest,
+      buildAiConformanceScheduleContextFromConfig(baseConfig)
+    );
+    expect(summary).toMatchObject({
+      checklistVersion: 'unknown',
+      kubernetesMinor: 'unknown',
+      lastOutcome: 'none',
+      schedulingEnabled: true,
+      scheduleIntervalSeconds: 86400,
+      checklistSource: 'bundled',
+    });
+  });
+
+  it('maps failed persisted runs with bounded error text into status', () => {
+    const repo = new AiConformanceRepository();
+    const longError = 'x'.repeat(CONFORMANCE_STATUS_FIELD_MAX + 50);
+    repo.upsertRun({
+      run_id: 'run-failed',
+      checklist_version: 'KubernetesAIConformance-1.31',
+      kubernetes_minor: '1.31',
+      source_revision: 'bundle-test',
+      state: 'failed',
+      requested_at: '2026-06-11T12:00:00.000Z',
+      started_at: '2026-06-11T12:00:01.000Z',
+      completed_at: '2026-06-11T12:00:02.000Z',
+      total_requirements: 0,
+      must_requirements: 0,
+      should_requirements: 0,
+      passed_count: 0,
+      failed_count: 0,
+      warning_count: 0,
+      not_applicable_count: 0,
+      not_evaluated_count: 0,
+      needs_evidence_count: 0,
+      failure_reason: longError,
+    });
+
+    const summary = buildAiConformanceStatusSummary(
+      loadLatestPersistedAiConformanceSummary(repo),
+      buildAiConformanceScheduleContextFromConfig({
+        ...baseConfig,
+        aiConformanceEnabled: false,
+      })
+    );
+
+    expect(summary.lastOutcome).toBe('failed');
+    expect(summary.runState).toBe('failed');
+    expect(summary.error).toBeTruthy();
+    expect(summary.error!.length).toBeLessThanOrEqual(CONFORMANCE_STATUS_FIELD_MAX);
+    expect(summary.schedulingEnabled).toBe(false);
+    expect(summary.scheduleIntervalSeconds).toBeNull();
+  });
+
+  it('includes bounded requirement rows in calculateStatus serialization', () => {
+    const repo = new AiConformanceRepository();
+    const evaluatedAt = '2026-06-11T12:00:00.000Z';
+    repo.upsertRun({
+      run_id: 'run-ok',
+      checklist_version: 'KubernetesAIConformance-1.31',
+      kubernetes_minor: '1.31',
+      source_revision: 'bundle-test',
+      state: 'completed',
+      requested_at: evaluatedAt,
+      started_at: evaluatedAt,
+      completed_at: evaluatedAt,
+      total_requirements: 1,
+      must_requirements: 1,
+      should_requirements: 0,
+      passed_count: 1,
+      failed_count: 0,
+      warning_count: 0,
+      not_applicable_count: 0,
+      not_evaluated_count: 0,
+      needs_evidence_count: 0,
+      failure_reason: null,
+    });
+    repo.insertRequirementResults('run-ok', [
+      {
+        requirement_id: 'security.example',
+        category: 'security',
+        level: 'MUST',
+        title: 'Example requirement',
+        status: 'passed',
+        rationale: 'Observable signal satisfied.',
+        evidence_ref: 'k8s.rbac.authorization/v1',
+        evaluated_at: evaluatedAt,
+      },
+    ]);
+
+    const aiConformance = buildAiConformanceStatusSummary(
+      loadLatestPersistedAiConformanceSummary(repo),
+      buildAiConformanceScheduleContextFromConfig(baseConfig)
+    );
+    const status = calculateStatus(null, true, undefined, undefined, undefined, undefined, aiConformance);
+    const parsed = JSON.parse(JSON.stringify(status));
+
+    expect(parsed.aiConformance.lastOutcome).toBe('success');
+    expect(parsed.aiConformance.requirements).toHaveLength(1);
+    expect(parsed.aiConformance.requirements[0].id).toBe('security.example');
+    expect(parsed.aiConformance.categories.security.total).toBe(1);
+  });
+
+  it('uses default no-run aiConformance when calculateStatus omits override', () => {
+    const status = calculateStatus();
+    expect(status.aiConformance).toEqual(DEFAULT_AI_CONFORMANCE_SUMMARY);
+  });
+});

--- a/src/status/ai-conformance-summary.ts
+++ b/src/status/ai-conformance-summary.ts
@@ -1,0 +1,108 @@
+import type { AiConformanceLatestSummary } from '../ai-conformance/contracts.js';
+import type { Config } from '../config/types.js';
+import { AiConformanceRepository } from '../database/ai-conformance-repository.js';
+import type { AiConformanceSummary } from './types.js';
+
+/** Operator schedule fields published alongside conformance run summaries. */
+export interface AiConformanceScheduleStatusContext {
+  schedulingEnabled: boolean;
+  scheduleIntervalSeconds: number | null;
+  checklistSource: string | null;
+}
+
+export const DEFAULT_AI_CONFORMANCE_SCHEDULE_CONTEXT: AiConformanceScheduleStatusContext = {
+  schedulingEnabled: false,
+  scheduleIntervalSeconds: null,
+  checklistSource: null,
+};
+
+const ZERO_TOTALS: AiConformanceSummary['totals'] = {
+  totalRequirements: 0,
+  mustRequirements: 0,
+  shouldRequirements: 0,
+  passed: 0,
+  failed: 0,
+  warning: 0,
+  notApplicable: 0,
+  notEvaluated: 0,
+  needsEvidence: 0,
+};
+
+/**
+ * Default conformance summary before the first persisted run exists.
+ */
+export const DEFAULT_AI_CONFORMANCE_SUMMARY: AiConformanceSummary = {
+  checklistVersion: 'unknown',
+  kubernetesMinor: 'unknown',
+  sourceRevision: null,
+  lastCompletedAt: null,
+  lastOutcome: 'none',
+  runState: null,
+  runId: null,
+  totals: { ...ZERO_TOTALS },
+  categories: {},
+  requirements: [],
+  error: null,
+  ...DEFAULT_AI_CONFORMANCE_SCHEDULE_CONTEXT,
+};
+
+/**
+ * Derives published schedule fields from loaded operator configuration.
+ */
+export function buildAiConformanceScheduleContextFromConfig(
+  config: Config
+): AiConformanceScheduleStatusContext {
+  return {
+    schedulingEnabled: config.aiConformanceEnabled,
+    scheduleIntervalSeconds: config.aiConformanceEnabled
+      ? config.aiConformanceIntervalSeconds
+      : null,
+    checklistSource: config.aiConformanceChecklistSource,
+  };
+}
+
+function cloneSummary(summary: AiConformanceLatestSummary): AiConformanceLatestSummary {
+  return {
+    ...summary,
+    totals: { ...summary.totals },
+    categories: Object.fromEntries(
+      Object.entries(summary.categories).map(([key, value]) => [key, { ...value }])
+    ),
+    requirements: summary.requirements.map((row) => ({ ...row })),
+  };
+}
+
+/**
+ * Maps persisted repository summary and schedule context into the status payload.
+ */
+export function buildAiConformanceStatusSummary(
+  latest: AiConformanceLatestSummary,
+  schedule: AiConformanceScheduleStatusContext = DEFAULT_AI_CONFORMANCE_SCHEDULE_CONTEXT
+): AiConformanceSummary {
+  const persisted = cloneSummary(latest);
+  return {
+    checklistVersion: persisted.checklistVersion,
+    kubernetesMinor: persisted.kubernetesMinor,
+    sourceRevision: persisted.sourceRevision,
+    lastCompletedAt: persisted.lastCompletedAt,
+    lastOutcome: persisted.lastOutcome,
+    runState: persisted.runState,
+    runId: persisted.runId,
+    totals: { ...persisted.totals },
+    categories: persisted.categories,
+    requirements: persisted.requirements.map((row) => ({ ...row })),
+    error: persisted.error,
+    schedulingEnabled: schedule.schedulingEnabled,
+    scheduleIntervalSeconds: schedule.scheduleIntervalSeconds,
+    checklistSource: schedule.checklistSource,
+  };
+}
+
+/**
+ * Loads the latest persisted conformance summary from SQLite.
+ */
+export function loadLatestPersistedAiConformanceSummary(
+  repo: AiConformanceRepository
+): AiConformanceLatestSummary {
+  return repo.buildLatestSummary();
+}

--- a/src/status/calculator.ts
+++ b/src/status/calculator.ts
@@ -4,8 +4,10 @@ import type {
   ArgoCDStatus,
   TrivyStatus,
   AssessmentStatusSummary,
+  AiConformanceSummary,
 } from './types.js';
 import { DEFAULT_ASSESSMENT_STATUS_SUMMARY } from './assessment-summary.js';
+import { DEFAULT_AI_CONFORMANCE_SUMMARY } from './ai-conformance-summary.js';
 
 /**
  * Operator version (semver)
@@ -52,6 +54,7 @@ const DEFAULT_TRIVY_STATUS: TrivyStatus = {
  * @param argocdStatus - Optional ArgoCD detection status (defaults to not detected)
  * @param trivyStatus - Optional Trivy detection status (defaults to unavailable)
  * @param assessmentSummary - Bounded last scheduled assessment tick summary (defaults to no-run state)
+ * @param aiConformanceSummary - Bounded latest conformance readiness summary (defaults to no-run state)
  * @returns OperatorStatus object with current operator state
  */
 export function calculateStatus(
@@ -65,7 +68,8 @@ export function calculateStatus(
   },
   argocdStatus: ArgoCDStatus = DEFAULT_ARGOCD_STATUS,
   trivyStatus: TrivyStatus = DEFAULT_TRIVY_STATUS,
-  assessmentSummary: AssessmentStatusSummary = DEFAULT_ASSESSMENT_STATUS_SUMMARY
+  assessmentSummary: AssessmentStatusSummary = DEFAULT_ASSESSMENT_STATUS_SUMMARY,
+  aiConformanceSummary: AiConformanceSummary = DEFAULT_AI_CONFORMANCE_SUMMARY
 ): OperatorStatus {
   // Published status uses fixed mode; this function does not read config or credentials.
   const mode: 'operated' | 'enabled' = 'operated';
@@ -107,6 +111,14 @@ export function calculateStatus(
       ...assessmentSummary,
       lastScheduledTotals: { ...assessmentSummary.lastScheduledTotals },
       lastScheduledChecks: assessmentSummary.lastScheduledChecks.map((c) => ({ ...c })),
+    },
+    aiConformance: {
+      ...aiConformanceSummary,
+      totals: { ...aiConformanceSummary.totals },
+      categories: Object.fromEntries(
+        Object.entries(aiConformanceSummary.categories).map(([key, value]) => [key, { ...value }])
+      ),
+      requirements: aiConformanceSummary.requirements.map((row) => ({ ...row })),
     },
   };
 }

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -177,6 +177,74 @@ export interface AssessmentStatusSummary {
 }
 
 /**
+ * Aggregate counts for the latest Kubernetes AI Conformance readiness run.
+ */
+export interface AiConformanceTotals {
+  totalRequirements: number;
+  mustRequirements: number;
+  shouldRequirements: number;
+  passed: number;
+  failed: number;
+  warning: number;
+  notApplicable: number;
+  notEvaluated: number;
+  needsEvidence: number;
+}
+
+/**
+ * Rollup counts for one checklist category in the published status payload.
+ */
+export interface AiConformanceCategorySummary {
+  total: number;
+  passed: number;
+  failed: number;
+  warning: number;
+  notApplicable: number;
+  notEvaluated: number;
+  needsEvidence: number;
+}
+
+/**
+ * Bounded per-requirement row for status ConfigMap JSON.
+ */
+export interface AiConformanceRequirementSummary {
+  id: string;
+  category: string;
+  level: 'MUST' | 'SHOULD';
+  title: string;
+  status:
+    | 'passed'
+    | 'failed'
+    | 'warning'
+    | 'not-applicable'
+    | 'not-evaluated'
+    | 'needs-evidence';
+  rationale: string;
+  evidenceRef?: string | null;
+}
+
+/**
+ * Bounded Kubernetes AI Conformance readiness summary for kube9-vscode and kube9-desktop.
+ * Kube9 readiness assessment, not official CNCF certification.
+ */
+export interface AiConformanceSummary {
+  checklistVersion: string;
+  kubernetesMinor: string;
+  sourceRevision: string | null;
+  lastCompletedAt: string | null;
+  lastOutcome: 'none' | 'success' | 'failed';
+  runState: 'completed' | 'failed' | 'partial' | null;
+  runId: string | null;
+  totals: AiConformanceTotals;
+  categories: Record<string, AiConformanceCategorySummary>;
+  requirements: AiConformanceRequirementSummary[];
+  error: string | null;
+  schedulingEnabled: boolean;
+  scheduleIntervalSeconds: number | null;
+  checklistSource: string | null;
+}
+
+/**
  * Operator Status Model
  * Represents the current state and health of the kube9 operator
  */
@@ -240,4 +308,9 @@ export interface OperatorStatus {
    * Last scheduled Well-Architected assessment tick summary (counts, schedule, per-check statuses).
    */
   assessment: AssessmentStatusSummary;
+
+  /**
+   * Latest Kubernetes AI Conformance readiness summary (bounded; not CNCF certification).
+   */
+  aiConformance: AiConformanceSummary;
 }

--- a/src/status/writer.ts
+++ b/src/status/writer.ts
@@ -7,10 +7,18 @@ import {
   DEFAULT_ASSESSMENT_SCHEDULE_CONTEXT,
   loadLatestPersistedAssessment,
 } from './assessment-summary.js';
+import {
+  buildAiConformanceScheduleContextFromConfig,
+  buildAiConformanceStatusSummary,
+  DEFAULT_AI_CONFORMANCE_SCHEDULE_CONTEXT,
+  DEFAULT_AI_CONFORMANCE_SUMMARY,
+  loadLatestPersistedAiConformanceSummary,
+} from './ai-conformance-summary.js';
 import { getConfig } from '../config/loader.js';
 import type { OperatorStatus } from './types.js';
 import { getScheduledAssessmentLastRunSnapshot } from '../assessment/scheduled-tick.js';
 import { AssessmentRepository } from '../database/assessment-repository.js';
+import { AiConformanceRepository } from '../database/ai-conformance-repository.js';
 import { logger } from '../logging/logger.js';
 import { collectionStatsTracker } from '../collection/stats-tracker.js';
 import { argocdStatusTracker } from '../argocd/state.js';
@@ -182,13 +190,40 @@ export class StatusWriter {
         dbChecks
       );
 
+      let aiConformanceSchedule = DEFAULT_AI_CONFORMANCE_SCHEDULE_CONTEXT;
+      try {
+        aiConformanceSchedule = buildAiConformanceScheduleContextFromConfig(getConfig());
+      } catch {
+        // Config not initialized; omit schedule fields
+      }
+      let aiConformanceSummary = DEFAULT_AI_CONFORMANCE_SUMMARY;
+      try {
+        const conformanceRepo = new AiConformanceRepository();
+        aiConformanceSummary = buildAiConformanceStatusSummary(
+          loadLatestPersistedAiConformanceSummary(conformanceRepo),
+          aiConformanceSchedule
+        );
+      } catch (conformanceErr) {
+        logger.warn('Failed to load AI conformance summary for status', {
+          error:
+            conformanceErr instanceof Error ? conformanceErr.message : String(conformanceErr),
+        });
+        aiConformanceSummary = {
+          ...DEFAULT_AI_CONFORMANCE_SUMMARY,
+          schedulingEnabled: aiConformanceSchedule.schedulingEnabled,
+          scheduleIntervalSeconds: aiConformanceSchedule.scheduleIntervalSeconds,
+          checklistSource: aiConformanceSchedule.checklistSource,
+        };
+      }
+
       const status = calculateStatus(
         this.lastWriteError,
         canWriteConfigMap,
         collectionStats,
         argocdStatus,
         trivyStatus,
-        assessmentSummary
+        assessmentSummary,
+        aiConformanceSummary
       );
 
       const statusJson = JSON.stringify(status, null, 2);


### PR DESCRIPTION
## Description

Implements the Kubernetes AI Conformance epic on `feature/issue-141`:

- **#146** (done): Bundle checklist data and deterministic selection by Kubernetes minor
- **#147** (done): Evaluator and SQLite persistence for conformance runs
- **#148** (this build): Publish summary in OperatorStatus, CLI, scheduler, and Helm

Issue #148 adds `OperatorStatus.aiConformance` on the status ConfigMap, scheduled evaluation via `aiConformance.*` Helm values, `kube9-operator ai-conformance` CLI commands, and tests for no-run/failed-run serialization plus Helm template rendering.

## Motivation and Context

Fixes #141
Closes #146
Closes #147
Closes #148

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update
- [x] Documentation update

## How Has This Been Tested?

- [x] Unit tests added/updated
- [x] All new and existing tests pass (`npm test`)
- [x] Linter passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] Helm template test for `AI_CONFORMANCE_*` env vars

```bash
npm ci
npm run lint
npm run build
npm test
helm lint charts/kube9-operator
helm template kube9-operator charts/kube9-operator --namespace kube9-system
```

## How to Test this Work

1. Run `npm test` and confirm ai-conformance status, CLI, scheduler, and Helm tests pass.
2. Deploy to a cluster and inspect status: `kubectl get configmap kube9-operator-status -n kube9-system -o jsonpath='{.data.status}' | jq '.aiConformance'`
3. Run on-demand evaluation: `kubectl exec -n kube9-system deploy/kube9-operator -- kube9-operator ai-conformance run`

## Additional Notes

`aiConformance` is a Kube9 readiness assessment against bundled checklist data, not proof of official CNCF certification.