### PR TITLE
docs(ai): argocd-visual-integration-completion contract updates

### DIFF
--- a/.ai/business_logic/error_handling.md
+++ b/.ai/business_logic/error_handling.md
@@ -7,6 +7,11 @@
 - **Failure behavior**: Returns `detected: false`, logs warning, operator continues normally
 - **Implementation**: `src/argocd/detection.ts` - detection failures never crash operator
 
+### ArgoCD Resource-Tree Enrichment Failures (M17)
+- **Failure behavior**: Structured CLI error envelope; `status.argocd.resourceTreeCapable` set false with bounded `resourceTreeLastError`; operator global `health` stays **healthy**
+- **Distinction from detection**: `detected: true` with enrichment unavailable is a separate signal from `detected: false`
+- **Implementation**: Resource-tree fetch errors must not crash operator main loop or block assessments/collections
+
 ### Storage Write Failures
 - **Collection storage**: Errors logged, metrics recorded, collection retries on next interval
 - **Event storage**: Database write failures logged, events dropped (non-blocking queue)

--- a/.ai/business_logic/user_stories.md
+++ b/.ai/business_logic/user_stories.md
@@ -48,10 +48,16 @@
 
 **Implementation**: Detection logic in `src/argocd/detection.ts`, periodic management in `src/argocd/detection-manager.ts`. Status exposed via `status.argocd` field in ConfigMap.
 
-### Future (M9)
-- Application sync/health status
-- Drift detection
+### Future (M9) — implemented
+- Application sync/health status in SQLite `argocd_apps`
+- CLI `query argocd apps list|get`
 - VS Code extension reads ArgoCD status for conditional features
+
+### M17 — Resource-tree enrichment
+- On-demand `GET /api/v1/applications/{name}/resource-tree` via CLI `query argocd resource-tree get`
+- Raw JSON passthrough to kube9-vscode; no durable tree store
+- Dedicated Argo CD API bearer token via Helm Secret
+- `status.argocd.resourceTreeCapable` gates extension topology tier
 
 ## Event System
 

--- a/.ai/data/data_model.md
+++ b/.ai/data/data_model.md
@@ -35,6 +35,8 @@ Exposed via ConfigMap `kube9-operator-status` in operator namespace.
 | namespace | string \| null | Namespace where ArgoCD is installed (null if not detected) |
 | version | string \| null | ArgoCD version extracted from deployment (null if not detected) |
 | lastChecked | string | ISO 8601 timestamp of last detection check |
+| resourceTreeCapable | boolean \| *omitted* | Whether operator can fetch resource-tree (token configured, Argo CD detected, last probe succeeded). Omitted when Argo CD not detected. |
+| resourceTreeLastError | object \| *omitted* | Bounded last enrichment error: `{ code, message }` when `resourceTreeCapable` is false but Argo CD is detected |
 | applications | object \| *omitted* | When `argocd_apps` has rows: bounded summary (see below); omitted when none |
 
 #### ArgoCDApplicationsPersistedSummary (nested under `argocd.applications`)

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -17,7 +17,7 @@
 - `error`: string | null - Error message if unhealthy
 - `namespace`: string - Operator deployment namespace (used for subsequent operations)
 - `collectionStats`: object - Collection activity statistics
-- `argocd`: object - ArgoCD detection status (`detected`, `namespace`, `version`, `lastChecked`)
+- `argocd`: object - ArgoCD detection status (`detected`, `namespace`, `version`, `lastChecked`, optional `resourceTreeCapable`, optional `resourceTreeLastError`)
 - `trivy`: object - Trivy detection status (`detected`, `serverUrl`, `version`, `lastChecked`)
 - `assessment`: object - Bounded Well-Architected assessment status summary
 - `aiConformance`: object - Bounded Kubernetes AI Conformance readiness status summary
@@ -146,3 +146,47 @@ Returns assessment run record with:
 - `--limit <number>`: Limit results (default: 100, max: 1000)
 - `--since <ISO8601>`: Filter since date
 - `--format <format>`: Output format, default: `json`
+
+### Argo CD Resource-Tree Query (M17)
+
+**Command**:
+```bash
+kube9-operator query argocd resource-tree get <appName> --namespace=<appNamespace> [--format=json]
+```
+
+**Behavior**:
+- **On-demand only:** Fetches `GET /api/v1/applications/{name}/resource-tree` from in-cluster `argocd-server` at query time. No durable tree store in SQLite for M17.
+- **Response:** Raw Argo CD resource-tree JSON (`nodes[]` with `group`, `kind`, `namespace`, `name`, `parentRefs`, optional health/sync). kube9-vscode consumes this via existing `buildResourceTreeApplicationResourceGraph`.
+- **Application identity:** `appName` + `appNamespace` match `argocd_apps` composite key `(cluster_id, app_namespace, app_name)`.
+- **Failure:** Structured stderr JSON error envelope; operator global `health` remains unaffected. Extension falls back per vscode tier ladder.
+
+**Authentication to argocd-server:**
+- Platform admin supplies a **dedicated Argo CD API bearer token** via Helm Secret / `ARGOCD_API_BEARER_TOKEN` or `ARGOCD_API_TOKEN_FILE`.
+- Operator **must not** use its Kubernetes ServiceAccount token against argocd-server unless explicitly documented as a future opt-in; M17 requires dedicated token provisioning.
+- Missing or denied credentials set `status.argocd.resourceTreeCapable: false` (or equivalent); extension uses CRD-flat fallback with actionable copy in kube9-vscode.
+
+**Service discovery:** `ARGOCD_API_BASE_URL` or derived `https://{ARGOCD_API_SERVER_SERVICE_NAME}.{detectedNamespace}.svc.cluster.local`.
+
+**Consumer:** kube9-vscode extension host via `kubectl exec` on graph open/refresh. Webview receives normalized `ApplicationResourceGraph` only.
+
+### Argo CD Apps Query (existing)
+
+```bash
+kube9-operator query argocd apps list [--format=json|yaml|table]
+kube9-operator query argocd apps get <appNamespace>/<appName> [--format=json|yaml|table]
+```
+
+Reads SQLite `argocd_apps` snapshots (M9 application status collection). Independent of resource-tree on-demand fetch.
+
+## Open Implementation Decisions
+
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### Argo CD resource-tree (M17)
+
+- Exact CLI flags: `--refresh`, exit codes for not-found vs RBAC-denied vs upstream timeout.
+- Structured stderr JSON error envelope schema (`ARGOCD_NOT_DETECTED`, `ARGOCD_API_UNREACHABLE`, `ARGOCD_RBAC_DENIED`, `APPLICATION_NOT_FOUND`, `TIMEOUT`, etc.).
+- Per-application fetch timeout and max node bounds for oversized trees.
+- `resourceTreeCapable` probe cadence: piggyback on status loop vs on-first-query only.
+- Helm chart docs for Secret mount and Argo CD RBAC prerequisites for resource-tree access.
+- Whether CLI supports `table` format or json-only given payload size.

--- a/.ai/integration/authorization.md
+++ b/.ai/integration/authorization.md
@@ -112,7 +112,7 @@ rules:
 **Operator → In-Cluster Services** (outbound only):
 - Kubernetes API: Operator-initiated API calls
 - Prometheus: Metrics endpoint exposed, scraped by Prometheus (no ingress needed)
-- Argo CD: **Today**, detection uses the Kubernetes API only (`src/argocd/detection.ts`). **M9** adds optional **read-only** HTTP calls to in-cluster `argocd-server` (Service URL / configurable base URL—see issue #55) for Application status and drift-related signals; still **zero ingress** (cluster-internal egress only).
+- Argo CD: Detection uses the Kubernetes API (`src/argocd/detection.ts`). **M9** adds read-only HTTP to in-cluster `argocd-server` for Application list/status into SQLite. **M17** adds on-demand `GET /api/v1/applications/{name}/resource-tree` at CLI query time. All Argo CD HTTP is **zero ingress** (cluster-internal egress). M17 requires a **dedicated Argo CD API bearer token** (Helm Secret); operator must not rely on its K8s SA token against argocd-server unless a future story documents opt-in.
 
 **Extension → Operator** (via kubectl):
 - ConfigMap read: Direct Kubernetes API access (no ingress)

--- a/.ai/integration/external_systems.md
+++ b/.ai/integration/external_systems.md
@@ -62,10 +62,18 @@ Exposed in ConfigMap `kube9-operator-status` under `status.argocd`:
 - `namespace`: string | null - Namespace where ArgoCD was detected
 - `version`: string | null - ArgoCD version extracted from deployment
 - `lastChecked`: string - ISO 8601 timestamp of last detection check
+- `resourceTreeCapable`: boolean (optional) - Whether resource-tree enrichment is available
+- `resourceTreeLastError`: object (optional) - Bounded `{ code, message }` when enrichment unavailable
 
-**Future (M9)**:
-- Application sync status tracking (HTTP API client and collector — issue #55)
-- Drift classification from Application snapshots — issue #56; persistence — issue #57
+**Resource-tree HTTP (M17)**:
+- `GET /api/v1/applications/{name}/resource-tree` with `appNamespace` query parameter
+- On-demand fetch at CLI query time; not persisted to SQLite in M17
+- Authenticates with dedicated bearer token (Helm Secret); not operator K8s SA token
+- Consumer: kube9-vscode via `query argocd resource-tree get`
+
+**Application status (M9, existing)**:
+- `GET /api/v1/applications` list collection into SQLite `argocd_apps`
+- CLI: `query argocd apps list|get`
 
 ## Trivy (optional, M3)
 

--- a/.ai/interface/presentation.md
+++ b/.ai/interface/presentation.md
@@ -21,7 +21,7 @@ The `status` key contains a JSON string with the following `OperatorStatus` stru
   - `totalFailureCount`: Number of failed collections
   - `collectionsStoredCount`: Number of collections stored locally
   - `lastSuccessTime`: ISO 8601 timestamp of most recent successful collection (or null)
-- `argocd`: ArgoCD status object
+- `argocd`: ArgoCD status object (includes optional `resourceTreeCapable`, `resourceTreeLastError`)
   - `detected`: Boolean indicating if ArgoCD is detected
   - `namespace`: Namespace where ArgoCD is installed (or null)
   - `version`: ArgoCD version string (or null)


### PR DESCRIPTION
Contract-only PR from ideation (`/ideate`).

- **Initiative:** argocd-visual-integration-completion (M17 Argo CD Graph Native Parity)
- **Scope:** `.ai` contract updates only; no application code
- **Highlights:** On-demand `query argocd resource-tree get` CLI contract; `resourceTreeCapable` status signal; dedicated Argo CD bearer token auth
- **Review:** confirm timeless contract prose and cross-repo coherence with kube9-vscode peer PR before merge

Merge before `/plan-roadmap` when downstream work should read merged contracts on `main`.