### PR TITLE
docs(ai): refine issue #151 contract updates

### DIFF
--- a/.ai/business_logic/error_handling.md
+++ b/.ai/business_logic/error_handling.md
@@ -8,9 +8,12 @@
 - **Implementation**: `src/argocd/detection.ts` - detection failures never crash operator
 
 ### ArgoCD Resource-Tree Enrichment Failures (M17)
-- **Failure behavior**: Structured CLI error envelope; `status.argocd.resourceTreeCapable` set false with bounded `resourceTreeLastError`; operator global `health` stays **healthy**
-- **Distinction from detection**: `detected: true` with enrichment unavailable is a separate signal from `detected: false`
-- **Implementation**: Resource-tree fetch errors must not crash operator main loop or block assessments/collections
+- **CLI failures**: Structured stderr JSON envelope (`ok: false`, `code`, `message`, optional `details`); exit codes per integration API contract. Success writes raw Argo CD JSON to stdout only.
+- **Global capability demotion**: Set `resourceTreeCapable: false` and `resourceTreeLastError: { code, message }` only for cluster-wide problems (missing dedicated token, API unreachable, auth failure, cluster-wide RBAC deny on probe). When Argo CD is not detected, omit capable/error fields.
+- **Per-application failures**: `APPLICATION_NOT_FOUND`, per-app RBAC deny, and per-app `TIMEOUT` return CLI errors only; leave `resourceTreeCapable` true when the last probe succeeded.
+- **Health**: Operator global `health` stays **healthy** for all resource-tree enrichment failures (CLI or probe).
+- **Distinction from detection**: `detected: true` with `resourceTreeCapable: false` is a separate signal from `detected: false`.
+- **Implementation**: Resource-tree fetch errors must not crash the operator main loop or block assessments/collections.
 
 ### Storage Write Failures
 - **Collection storage**: Errors logged, metrics recorded, collection retries on next interval

--- a/.ai/business_logic/user_stories.md
+++ b/.ai/business_logic/user_stories.md
@@ -54,10 +54,11 @@
 - VS Code extension reads ArgoCD status for conditional features
 
 ### M17 — Resource-tree enrichment
-- On-demand `GET /api/v1/applications/{name}/resource-tree` via CLI `query argocd resource-tree get`
-- Raw JSON passthrough to kube9-vscode; no durable tree store
-- Dedicated Argo CD API bearer token via Helm Secret
-- `status.argocd.resourceTreeCapable` gates extension topology tier
+- On-demand `GET /api/v1/applications/{name}/resource-tree` via CLI `query argocd resource-tree get <appName> --namespace=<appNs>`
+- Raw unmodified JSON on stdout; structured stderr errors; no `--refresh`; no operator-side tree size cap
+- Dedicated Argo CD API bearer only (no SA fallback on resource-tree path)
+- Lightweight status-loop probe sets `status.argocd.resourceTreeCapable`; demote only on cluster-wide token/auth/unreachable/RBAC-probe failures
+- kube9-vscode gates operator topology tier on `resourceTreeCapable`
 
 ## Event System
 

--- a/.ai/data/data_model.md
+++ b/.ai/data/data_model.md
@@ -35,8 +35,8 @@ Exposed via ConfigMap `kube9-operator-status` in operator namespace.
 | namespace | string \| null | Namespace where ArgoCD is installed (null if not detected) |
 | version | string \| null | ArgoCD version extracted from deployment (null if not detected) |
 | lastChecked | string | ISO 8601 timestamp of last detection check |
-| resourceTreeCapable | boolean \| *omitted* | Whether operator can fetch resource-tree (token configured, Argo CD detected, last probe succeeded). Omitted when Argo CD not detected. |
-| resourceTreeLastError | object \| *omitted* | Bounded last enrichment error: `{ code, message }` when `resourceTreeCapable` is false but Argo CD is detected |
+| resourceTreeCapable | boolean \| *omitted* | `true` after dedicated token is configured, Argo CD is detected, and the last lightweight status-loop / detection-adjacent probe succeeded. `false` when Argo CD is detected but capability is demoted for a **cluster-wide** reason (missing token, API unreachable, auth failure, cluster-wide RBAC deny on probe). Omitted when Argo CD is not detected. Per-application CLI failures (`APPLICATION_NOT_FOUND`, per-app RBAC, per-app timeout) do **not** flip this to `false`. |
+| resourceTreeLastError | object \| *omitted* | Bounded last **global demotion** reason: `{ code, message }` when `resourceTreeCapable` is false and Argo CD is detected. Omitted when capable is true or Argo CD is not detected. Must not contain tokens or unbounded payloads. |
 | applications | object \| *omitted* | When `argocd_apps` has rows: bounded summary (see below); omitted when none |
 
 #### ArgoCDApplicationsPersistedSummary (nested under `argocd.applications`)

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -154,20 +154,70 @@ Returns assessment run record with:
 kube9-operator query argocd resource-tree get <appName> --namespace=<appNamespace> [--format=json]
 ```
 
+**Flags**:
+- `<appName>` (required positional): Argo CD Application name.
+- `--namespace=<appNamespace>` (required): Application namespace (`appNamespace` for the Argo CD API).
+- `--format=json` (optional): Accepted as the only format; default is JSON. `table` and `yaml` are not supported for this subcommand.
+- **Out of scope:** `--refresh` (and any flag that forces an Argo CD Application refresh before returning the tree). The CLI always returns the current resource-tree snapshot from argocd-server.
+
 **Behavior**:
-- **On-demand only:** Fetches `GET /api/v1/applications/{name}/resource-tree` from in-cluster `argocd-server` at query time. No durable tree store in SQLite for M17.
-- **Response:** Raw Argo CD resource-tree JSON (`nodes[]` with `group`, `kind`, `namespace`, `name`, `parentRefs`, optional health/sync). kube9-vscode consumes this via existing `buildResourceTreeApplicationResourceGraph`.
+- **On-demand only:** Fetches `GET /api/v1/applications/{name}/resource-tree?appNamespace={appNamespace}` from in-cluster `argocd-server` at query time. No durable tree store in SQLite for M17.
+- **Success stdout:** Exactly the unmodified Argo CD response body (raw JSON). Typical shape includes `nodes[]` with `group`, `kind`, `namespace`, `name`, `parentRefs`, optional health/sync. No operator-side node or byte truncation; large trees rely on `ARGOCD_API_TIMEOUT_MS` and Kubernetes exec payload limits. Platform operators should size memory and exec timeouts for large Applications.
 - **Application identity:** `appName` + `appNamespace` match `argocd_apps` composite key `(cluster_id, app_namespace, app_name)`.
-- **Failure:** Structured stderr JSON error envelope; operator global `health` remains unaffected. Extension falls back per vscode tier ladder.
+- **Timeout:** Each HTTP fetch uses `ARGOCD_API_TIMEOUT_MS` (default `30000`, minimum `1000`).
+- **Failure:** Structured JSON error envelope on **stderr** only; stdout empty or non-JSON on failure. Operator global `health` remains unaffected. kube9-vscode falls back per its tier ladder.
+
+**Stderr error envelope** (one JSON object):
+```json
+{ "ok": false, "code": "<CODE>", "message": "<human-readable>", "details": {} }
+```
+`details` is optional and must not include tokens, raw Authorization headers, or unbounded upstream bodies.
+
+**Error codes** (minimum set):
+
+| `code` | Meaning |
+|--------|---------|
+| `INVALID_ARGUMENT` | Missing/invalid `appName` or `--namespace` |
+| `ARGOCD_NOT_DETECTED` | Argo CD not detected / resource-tree path unavailable |
+| `ARGOCD_TOKEN_MISSING` | No dedicated bearer (`ARGOCD_API_BEARER_TOKEN` / `ARGOCD_API_TOKEN_FILE`) |
+| `ARGOCD_API_UNREACHABLE` | Cannot reach argocd-server (DNS, connect, TLS hard failure) |
+| `ARGOCD_AUTH_FAILED` | Token rejected (HTTP 401) |
+| `ARGOCD_RBAC_DENIED` | Authorization denied (HTTP 403), including cluster-wide probe deny |
+| `APPLICATION_NOT_FOUND` | Application missing for name/namespace (HTTP 404) |
+| `TIMEOUT` | Exceeded `ARGOCD_API_TIMEOUT_MS` |
+| `INTERNAL_ERROR` | Unexpected operator/runtime failure |
+
+**Exit codes**:
+
+| Exit | When |
+|------|------|
+| `0` | Success; raw resource-tree JSON on stdout |
+| `2` | `INVALID_ARGUMENT` |
+| `3` | `APPLICATION_NOT_FOUND` |
+| `4` | `ARGOCD_TOKEN_MISSING` or `ARGOCD_AUTH_FAILED` |
+| `5` | `ARGOCD_RBAC_DENIED` |
+| `6` | `TIMEOUT` |
+| `7` | `ARGOCD_API_UNREACHABLE` or `ARGOCD_NOT_DETECTED` |
+| `1` | `INTERNAL_ERROR` or unclassified failure |
+
+Consumers (kube9-vscode) should key primarily on stderr `code`; exit codes are stable for scripts.
 
 **Authentication to argocd-server:**
-- Platform admin supplies a **dedicated Argo CD API bearer token** via Helm Secret / `ARGOCD_API_BEARER_TOKEN` or `ARGOCD_API_TOKEN_FILE`.
-- Operator **must not** use its Kubernetes ServiceAccount token against argocd-server unless explicitly documented as a future opt-in; M17 requires dedicated token provisioning.
-- Missing or denied credentials set `status.argocd.resourceTreeCapable: false` (or equivalent); extension uses CRD-flat fallback with actionable copy in kube9-vscode.
+- Platform admin supplies a **dedicated Argo CD API bearer token** via Helm-mounted Secret wired as `ARGOCD_API_BEARER_TOKEN` and/or `ARGOCD_API_TOKEN_FILE` (chart onboarding: sibling issue / Helm docs).
+- Resource-tree resolution order: non-empty `ARGOCD_API_BEARER_TOKEN`, else readable `ARGOCD_API_TOKEN_FILE`. **No** fallback to the Kubernetes ServiceAccount token on this path (even if M9 application-status collection still allows SA fallback until a later hardening story).
+- Missing dedicated token → CLI `ARGOCD_TOKEN_MISSING` and `status.argocd.resourceTreeCapable: false`.
 
-**Service discovery:** `ARGOCD_API_BASE_URL` or derived `https://{ARGOCD_API_SERVER_SERVICE_NAME}.{detectedNamespace}.svc.cluster.local`.
+**Service discovery:** `ARGOCD_API_BASE_URL` when set; otherwise `https://{ARGOCD_API_SERVER_SERVICE_NAME}.{detectedNamespace}.svc.cluster.local` (default service name `argocd-server`). TLS verification follows `ARGOCD_API_TLS_INSECURE` (default false).
 
-**Consumer:** kube9-vscode extension host via `kubectl exec` on graph open/refresh. Webview receives normalized `ApplicationResourceGraph` only.
+**`resourceTreeCapable` probe and demotion:**
+- When Argo CD is `detected` and a dedicated token is configured, the operator runs a **lightweight probe** on the status / detection-adjacent loop (not only on first vscode query). After a successful probe, set `status.argocd.resourceTreeCapable: true` and omit `resourceTreeLastError`.
+- **Demote** `resourceTreeCapable` to `false` only for **cluster-wide** problems: missing dedicated token, Argo CD not detected (omit capable fields when not detected), API unreachable, auth failure, or cluster-wide RBAC deny on probe. On demotion, set bounded `resourceTreeLastError: { code, message }` to the last global demotion reason.
+- **Do not demote** for per-application CLI outcomes: `APPLICATION_NOT_FOUND`, per-app RBAC deny, or per-app `TIMEOUT`. Those return structured CLI errors only; global capability stays `true` when the last probe succeeded.
+- Probe or query auth/connectivity failures that are cluster-wide demote capability as above.
+
+**Minimum Argo CD RBAC** (platform admin; chart does not mutate Argo CD roles): the dedicated token identity must be allowed to `get` Applications (including resource-tree) for the Applications/projects intended for enrichment. Exact policy snippets live in Helm / platform onboarding docs.
+
+**Consumer:** kube9-vscode extension host via `kubectl exec` on graph open/refresh when `resourceTreeCapable` is true. Webview receives normalized `ApplicationResourceGraph` only (`topologySource: argocd_resource_tree` on success).
 
 ### Argo CD Apps Query (existing)
 
@@ -177,16 +227,3 @@ kube9-operator query argocd apps get <appNamespace>/<appName> [--format=json|yam
 ```
 
 Reads SQLite `argocd_apps` snapshots (M9 application status collection). Independent of resource-tree on-demand fetch.
-
-## Open Implementation Decisions
-
-Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
-
-### Argo CD resource-tree (M17)
-
-- Exact CLI flags: `--refresh`, exit codes for not-found vs RBAC-denied vs upstream timeout.
-- Structured stderr JSON error envelope schema (`ARGOCD_NOT_DETECTED`, `ARGOCD_API_UNREACHABLE`, `ARGOCD_RBAC_DENIED`, `APPLICATION_NOT_FOUND`, `TIMEOUT`, etc.).
-- Per-application fetch timeout and max node bounds for oversized trees.
-- `resourceTreeCapable` probe cadence: piggyback on status loop vs on-first-query only.
-- Helm chart docs for Secret mount and Argo CD RBAC prerequisites for resource-tree access.
-- Whether CLI supports `table` format or json-only given payload size.

--- a/.ai/integration/authorization.md
+++ b/.ai/integration/authorization.md
@@ -112,7 +112,8 @@ rules:
 **Operator → In-Cluster Services** (outbound only):
 - Kubernetes API: Operator-initiated API calls
 - Prometheus: Metrics endpoint exposed, scraped by Prometheus (no ingress needed)
-- Argo CD: Detection uses the Kubernetes API (`src/argocd/detection.ts`). **M9** adds read-only HTTP to in-cluster `argocd-server` for Application list/status into SQLite. **M17** adds on-demand `GET /api/v1/applications/{name}/resource-tree` at CLI query time. All Argo CD HTTP is **zero ingress** (cluster-internal egress). M17 requires a **dedicated Argo CD API bearer token** (Helm Secret); operator must not rely on its K8s SA token against argocd-server unless a future story documents opt-in.
+- Argo CD: Detection uses the Kubernetes API (`src/argocd/detection.ts`). **M9** adds read-only HTTP to in-cluster `argocd-server` for Application list/status into SQLite. **M17** adds on-demand `GET /api/v1/applications/{name}/resource-tree` at CLI query time. All Argo CD HTTP is **zero ingress** (cluster-internal egress).
+- **M17 resource-tree auth:** Dedicated Argo CD API bearer only (`ARGOCD_API_BEARER_TOKEN` or `ARGOCD_API_TOKEN_FILE`). The resource-tree path **must not** fall back to the operator Kubernetes ServiceAccount token. Platform admin grants Argo CD RBAC `get` on Applications (resource-tree) for the token identity; the kube9-operator chart does not mutate Argo CD roles. Helm Secret mount / values onboarding is documented with chart platform docs (sibling onboarding issue).
 
 **Extension → Operator** (via kubectl):
 - ConfigMap read: Direct Kubernetes API access (no ingress)

--- a/.ai/integration/external_systems.md
+++ b/.ai/integration/external_systems.md
@@ -62,13 +62,15 @@ Exposed in ConfigMap `kube9-operator-status` under `status.argocd`:
 - `namespace`: string | null - Namespace where ArgoCD was detected
 - `version`: string | null - ArgoCD version extracted from deployment
 - `lastChecked`: string - ISO 8601 timestamp of last detection check
-- `resourceTreeCapable`: boolean (optional) - Whether resource-tree enrichment is available
-- `resourceTreeLastError`: object (optional) - Bounded `{ code, message }` when enrichment unavailable
+- `resourceTreeCapable`: boolean (optional) - Whether resource-tree enrichment is available after a successful lightweight probe (token configured + Argo CD detected). Omitted when Argo CD is not detected.
+- `resourceTreeLastError`: object (optional) - Bounded `{ code, message }` for the last **global** demotion reason when `resourceTreeCapable` is false and Argo CD is detected. Cleared/omitted when capable is true.
 
 **Resource-tree HTTP (M17)**:
 - `GET /api/v1/applications/{name}/resource-tree` with `appNamespace` query parameter
 - On-demand fetch at CLI query time; not persisted to SQLite in M17
-- Authenticates with dedicated bearer token (Helm Secret); not operator K8s SA token
+- Authenticates with dedicated bearer token (`ARGOCD_API_BEARER_TOKEN` or `ARGOCD_API_TOKEN_FILE`); **no** Kubernetes ServiceAccount token fallback on this path
+- HTTP timeout: `ARGOCD_API_TIMEOUT_MS` (default 30000). No operator-side node/byte cap on the response body
+- Capability probe: status-loop / detection-adjacent lightweight probe when token is configured and Argo CD is detected; demote only on cluster-wide token/auth/unreachable/RBAC-probe failures (not on per-app not-found/RBAC/timeout)
 - Consumer: kube9-vscode via `query argocd resource-tree get`
 
 **Application status (M9, existing)**:

--- a/.ai/interface/presentation.md
+++ b/.ai/interface/presentation.md
@@ -21,11 +21,13 @@ The `status` key contains a JSON string with the following `OperatorStatus` stru
   - `totalFailureCount`: Number of failed collections
   - `collectionsStoredCount`: Number of collections stored locally
   - `lastSuccessTime`: ISO 8601 timestamp of most recent successful collection (or null)
-- `argocd`: ArgoCD status object (includes optional `resourceTreeCapable`, `resourceTreeLastError`)
+- `argocd`: ArgoCD status object
   - `detected`: Boolean indicating if ArgoCD is detected
   - `namespace`: Namespace where ArgoCD is installed (or null)
   - `version`: ArgoCD version string (or null)
   - `lastChecked`: ISO 8601 timestamp of last detection check
+  - `resourceTreeCapable` (optional boolean): Present when Argo CD is detected; `true` after successful lightweight resource-tree capability probe with dedicated token configured
+  - `resourceTreeLastError` (optional `{ code, message }`): Last global demotion reason when capable is false and Argo CD is detected; omit when capable is true
 - `trivy`: Trivy detection status object
   - `detected`: Boolean indicating if a Trivy server was probed successfully
   - `serverUrl`: Base URL when detected (or null)

--- a/.ai/operations/security.md
+++ b/.ai/operations/security.md
@@ -57,7 +57,8 @@ The operator requires namespace-scoped permissions via Role:
 ### RBAC Security Principles
 - **Read-Only by Default**: All cluster resources are read-only
 - **Minimal Write Access**: Only ConfigMap write access in operator's namespace
-- **No Secrets Access**: Operator never requests secrets or credentials
+- **No Secrets API list/get**: Operator ClusterRole does not grant Kubernetes Secrets API access. A dedicated Argo CD API bearer for M17 resource-tree is supplied by platform admins via Helm-mounted file / env (`ARGOCD_API_BEARER_TOKEN` / `ARGOCD_API_TOKEN_FILE`), not by the operator reading Secrets through the API.
+- **Token hygiene**: Bearer tokens must never appear in status ConfigMap fields, CLI success stdout, or stderr `message`/`details` beyond a redacted failure code.
 - **No Pod Execution**: Operator does not execute commands in other pods
 - **No Cluster Admin**: No cluster-admin or elevated privileges required
 

--- a/.ai/runtime/configuration.md
+++ b/.ai/runtime/configuration.md
@@ -85,6 +85,35 @@
   - Default: `6` hours
   - How often operator checks for ArgoCD installation changes
 
+### Argo CD API (HTTP) Environment Variables
+
+Used by M9 application-status collection and M17 resource-tree query/probe. Chart wires the same names.
+
+- **ARGOCD_API_COLLECTION_ENABLED**: Enable periodic Application list/status collection (M9)
+  - Default: `true`
+
+- **ARGOCD_API_BASE_URL**: Explicit HTTPS base URL for argocd-server
+  - Default: empty (derive `https://{ARGOCD_API_SERVER_SERVICE_NAME}.{detectedNamespace}.svc.cluster.local`)
+
+- **ARGOCD_API_SERVER_SERVICE_NAME**: Service name segment for derived URL
+  - Default: `argocd-server`
+
+- **ARGOCD_API_TIMEOUT_MS**: HTTP timeout for each Argo CD API request (including resource-tree get and capability probe)
+  - Default: `30000`
+  - Minimum: `1000`
+
+- **ARGOCD_API_TLS_INSECURE**: Skip TLS verification for argocd-server HTTPS
+  - Default: `false`
+  - Not recommended for production
+
+- **ARGOCD_API_BEARER_TOKEN**: Dedicated Argo CD API bearer token (preferred for M17)
+  - Optional string; when non-empty, used for resource-tree auth
+
+- **ARGOCD_API_TOKEN_FILE**: Path to a file containing the dedicated bearer token
+  - Used when `ARGOCD_API_BEARER_TOKEN` is unset/empty
+  - **Resource-tree path (M17):** must resolve a dedicated token from bearer env or this file; **must not** fall back to `/var/run/secrets/kubernetes.io/serviceaccount/token`
+  - M9 application-status collection may still allow SA fallback until a later hardening story; resource-tree does not share that fallback
+
 ## Helm Values
 
 ### Image Configuration
@@ -144,8 +173,16 @@ argocd:
   # namespace: "argocd"         # Custom namespace (default: "argocd")
   # selector: "app.kubernetes.io/name=argocd-server"  # Custom selector
   detectionInterval: 6          # Detection check interval in hours (default: 6)
+  api:
+    collectionEnabled: true     # M9 Application status collection
+    # baseUrl: ""               # Optional explicit HTTPS base URL
+    timeoutMs: 30000            # Shared by collection, probe, and resource-tree get
+    tlsInsecure: false
+    serverServiceName: argocd-server
+    # tokenFile / bearer via Secret mount — platform onboarding (chart docs)
 ```
-- Maps to `ARGOCD_*` environment variables
+- Maps to `ARGOCD_*` and `ARGOCD_API_*` environment variables
+- Resource-tree requires a dedicated bearer (`ARGOCD_API_BEARER_TOKEN` or `ARGOCD_API_TOKEN_FILE`); no SA fallback on that path
 
 ### Collection Interval Configuration
 ```yaml


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #151
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

Merge before `/build-from-github` when implementation should read merged contracts on `main`.