### PR TITLE
docs(ai): refine issue #152 contract updates

### DIFF
--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -203,9 +203,9 @@ kube9-operator query argocd resource-tree get <appName> --namespace=<appNamespac
 Consumers (kube9-vscode) should key primarily on stderr `code`; exit codes are stable for scripts.
 
 **Authentication to argocd-server:**
-- Platform admin supplies a **dedicated Argo CD API bearer token** via Helm-mounted Secret wired as `ARGOCD_API_BEARER_TOKEN` and/or `ARGOCD_API_TOKEN_FILE` (chart onboarding: sibling issue / Helm docs).
+- Platform admin supplies a **dedicated Argo CD API bearer token** by creating a Kubernetes Secret out-of-band and referencing it from Helm: `argocd.api.token.existingSecret` + `argocd.api.token.existingSecretKey` (default key `token`). When set, the chart mounts the key at `/var/run/secrets/kube9/argocd-api-token` and sets `ARGOCD_API_TOKEN_FILE` to that path. Chart does not create a Secret from plaintext values. Unset `existingSecret` is default-off (no mount/env).
 - Resource-tree resolution order: non-empty `ARGOCD_API_BEARER_TOKEN`, else readable `ARGOCD_API_TOKEN_FILE`. **No** fallback to the Kubernetes ServiceAccount token on this path (even if M9 application-status collection still allows SA fallback until a later hardening story).
-- Missing dedicated token → CLI `ARGOCD_TOKEN_MISSING` and `status.argocd.resourceTreeCapable: false`.
+- Missing dedicated token → CLI `ARGOCD_TOKEN_MISSING` and `status.argocd.resourceTreeCapable: false`. Token present but probe RBAC denied → `ARGOCD_RBAC_DENIED` and `resourceTreeCapable: false`.
 
 **Service discovery:** `ARGOCD_API_BASE_URL` when set; otherwise `https://{ARGOCD_API_SERVER_SERVICE_NAME}.{detectedNamespace}.svc.cluster.local` (default service name `argocd-server`). TLS verification follows `ARGOCD_API_TLS_INSECURE` (default false).
 
@@ -215,7 +215,7 @@ Consumers (kube9-vscode) should key primarily on stderr `code`; exit codes are s
 - **Do not demote** for per-application CLI outcomes: `APPLICATION_NOT_FOUND`, per-app RBAC deny, or per-app `TIMEOUT`. Those return structured CLI errors only; global capability stays `true` when the last probe succeeded.
 - Probe or query auth/connectivity failures that are cluster-wide demote capability as above.
 
-**Minimum Argo CD RBAC** (platform admin; chart does not mutate Argo CD roles): the dedicated token identity must be allowed to `get` Applications (including resource-tree) for the Applications/projects intended for enrichment. Exact policy snippets live in Helm / platform onboarding docs.
+**Minimum Argo CD RBAC** (platform admin; chart does not mutate Argo CD roles): the dedicated token identity must be allowed to `get` Applications (including resource-tree) for the Applications/projects intended for enrichment. Example policy (attach to the account that issued the token): `p, role:kube9-resource-tree, applications, get, */*, allow` (or a project-scoped variant). Chart README documents this onboarding; the chart does not apply Argo CD roles.
 
 **Consumer:** kube9-vscode extension host via `kubectl exec` on graph open/refresh when `resourceTreeCapable` is true. Webview receives normalized `ApplicationResourceGraph` only (`topologySource: argocd_resource_tree` on success).
 

--- a/.ai/integration/authorization.md
+++ b/.ai/integration/authorization.md
@@ -113,7 +113,7 @@ rules:
 - Kubernetes API: Operator-initiated API calls
 - Prometheus: Metrics endpoint exposed, scraped by Prometheus (no ingress needed)
 - Argo CD: Detection uses the Kubernetes API (`src/argocd/detection.ts`). **M9** adds read-only HTTP to in-cluster `argocd-server` for Application list/status into SQLite. **M17** adds on-demand `GET /api/v1/applications/{name}/resource-tree` at CLI query time. All Argo CD HTTP is **zero ingress** (cluster-internal egress).
-- **M17 resource-tree auth:** Dedicated Argo CD API bearer only (`ARGOCD_API_BEARER_TOKEN` or `ARGOCD_API_TOKEN_FILE`). The resource-tree path **must not** fall back to the operator Kubernetes ServiceAccount token. Platform admin grants Argo CD RBAC `get` on Applications (resource-tree) for the token identity; the kube9-operator chart does not mutate Argo CD roles. Helm Secret mount / values onboarding is documented with chart platform docs (sibling onboarding issue).
+- **M17 resource-tree auth:** Dedicated Argo CD API bearer only (`ARGOCD_API_BEARER_TOKEN` or `ARGOCD_API_TOKEN_FILE`). The resource-tree path **must not** fall back to the operator Kubernetes ServiceAccount token. Platform admin creates a Secret out-of-band and sets Helm `argocd.api.token.existingSecret` / `existingSecretKey` (default key `token`); the chart mounts the key at `/var/run/secrets/kube9/argocd-api-token` and sets `ARGOCD_API_TOKEN_FILE`. Unset `existingSecret` is default-off. Platform admin grants Argo CD RBAC `get` on Applications (resource-tree) for the token identity; the kube9-operator chart does not mutate Argo CD roles.
 
 **Extension → Operator** (via kubectl):
 - ConfigMap read: Direct Kubernetes API access (no ingress)

--- a/.ai/operations/build_packaging.md
+++ b/.ai/operations/build_packaging.md
@@ -43,6 +43,14 @@ The Helm chart supports comprehensive configuration through `values.yaml`:
 - `argocd.namespace`: Custom namespace where ArgoCD is installed (default: `argocd`)
 - `argocd.selector`: Custom label selector for ArgoCD server deployment (optional)
 - `argocd.detectionInterval`: Detection check interval in hours (default: `6`)
+- `argocd.api.collectionEnabled`: Schedule M9 Application status collection (default: `true`)
+- `argocd.api.baseUrl`: Optional explicit HTTPS base URL for argocd-server
+- `argocd.api.timeoutMs`: HTTP timeout for Argo CD API requests (default: `30000`)
+- `argocd.api.tlsInsecure`: Skip TLS verification (default: `false`)
+- `argocd.api.serverServiceName`: Service name for derived URL (default: `argocd-server`)
+- `argocd.api.token.existingSecret`: Name of an existing Secret (release namespace) holding a dedicated Argo CD API bearer; empty/unset = default-off (no mount, no `ARGOCD_API_TOKEN_FILE`)
+- `argocd.api.token.existingSecretKey`: Key within that Secret (default: `token`)
+- When `argocd.api.token.existingSecret` is set, the Deployment mounts the Secret key at `/var/run/secrets/kube9/argocd-api-token` and sets `ARGOCD_API_TOKEN_FILE` to that path. Chart does not create a Secret from plaintext values.
 
 #### Metrics Collection Intervals
 - `metrics.intervals.clusterMetadata`: Cluster metadata collection interval in seconds (default: `86400` = 24 hours, minimum: `3600`)

--- a/.ai/operations/security.md
+++ b/.ai/operations/security.md
@@ -57,7 +57,7 @@ The operator requires namespace-scoped permissions via Role:
 ### RBAC Security Principles
 - **Read-Only by Default**: All cluster resources are read-only
 - **Minimal Write Access**: Only ConfigMap write access in operator's namespace
-- **No Secrets API list/get**: Operator ClusterRole does not grant Kubernetes Secrets API access. A dedicated Argo CD API bearer for M17 resource-tree is supplied by platform admins via Helm-mounted file / env (`ARGOCD_API_BEARER_TOKEN` / `ARGOCD_API_TOKEN_FILE`), not by the operator reading Secrets through the API.
+- **No Secrets API list/get**: Operator ClusterRole does not grant Kubernetes Secrets API access. A dedicated Argo CD API bearer for M17 resource-tree is supplied by platform admins via an out-of-band Secret referenced by Helm (`argocd.api.token.existingSecret` / `existingSecretKey`), mounted as a file and exposed as `ARGOCD_API_TOKEN_FILE` (and optionally `ARGOCD_API_BEARER_TOKEN`), not by the operator reading Secrets through the API. Chart does not create Secrets from plaintext values.
 - **Token hygiene**: Bearer tokens must never appear in status ConfigMap fields, CLI success stdout, or stderr `message`/`details` beyond a redacted failure code.
 - **No Pod Execution**: Operator does not execute commands in other pods
 - **No Cluster Admin**: No cluster-admin or elevated privileges required

--- a/.ai/runtime/configuration.md
+++ b/.ai/runtime/configuration.md
@@ -179,10 +179,17 @@ argocd:
     timeoutMs: 30000            # Shared by collection, probe, and resource-tree get
     tlsInsecure: false
     serverServiceName: argocd-server
-    # tokenFile / bearer via Secret mount — platform onboarding (chart docs)
+    token:
+      # Name of an existing Secret in the release namespace (platform-created out-of-band).
+      # Empty/unset = default-off: no volume mount and no ARGOCD_API_TOKEN_FILE.
+      existingSecret: ""
+      # Key within that Secret holding the bearer token string.
+      existingSecretKey: token
 ```
 - Maps to `ARGOCD_*` and `ARGOCD_API_*` environment variables
-- Resource-tree requires a dedicated bearer (`ARGOCD_API_BEARER_TOKEN` or `ARGOCD_API_TOKEN_FILE`); no SA fallback on that path
+- **Dedicated API token (M17 onboarding):** When `argocd.api.token.existingSecret` is non-empty, the chart volume-mounts that Secret key at `/var/run/secrets/kube9/argocd-api-token` and sets `ARGOCD_API_TOKEN_FILE` to that path. Chart does **not** create a Secret from a plaintext bearer value in Helm values.
+- Resource-tree requires a dedicated bearer (`ARGOCD_API_BEARER_TOKEN` or `ARGOCD_API_TOKEN_FILE`); no SA fallback on that path. File mount alone satisfies resolution order (bearer env first, then token file).
+- When `existingSecret` is set but the Secret is absent, Kubernetes fails the pod mount (not a soft runtime miss). When unset, install succeeds; runtime reports `ARGOCD_TOKEN_MISSING` / `resourceTreeCapable: false` for the resource-tree path.
 
 ### Collection Interval Configuration
 ```yaml


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #152
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

Merge before `/build-from-github` when implementation should read merged contracts on `main`.