### PR TITLE
feat(argocd): on-demand resource-tree query CLI (#151)

### DIFF
--- a/src/argocd/api-http.ts
+++ b/src/argocd/api-http.ts
@@ -56,6 +56,75 @@ function httpsGetInsecure(
 }
 
 /**
+ * GET returning raw response body text and HTTP status (for passthrough stdout).
+ */
+export async function textGet(
+  urlString: string,
+  options: JsonGetOptions
+): Promise<{ status: number; body: string }> {
+  const url = new URL(urlString);
+  if (url.protocol === 'http:') {
+    const ac = new AbortController();
+    const t = setTimeout(() => ac.abort(), options.timeoutMs);
+    try {
+      const res = await fetch(urlString, {
+        method: 'GET',
+        headers: options.headers,
+        signal: ac.signal,
+      });
+      const body = await res.text();
+      return { status: res.status, body };
+    } finally {
+      clearTimeout(t);
+    }
+  }
+
+  if (url.protocol === 'https:') {
+    if (options.tlsInsecure) {
+      return new Promise((resolve, reject) => {
+        const req = https.request(
+          {
+            hostname: url.hostname,
+            port: url.port || 443,
+            path: `${url.pathname}${url.search}`,
+            method: 'GET',
+            headers: options.headers,
+            rejectUnauthorized: false,
+          },
+          (res) => {
+            const chunks: Buffer[] = [];
+            res.on('data', (c) => chunks.push(c as Buffer));
+            res.on('end', () => {
+              resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf8') });
+            });
+          }
+        );
+        req.on('error', reject);
+        req.setTimeout(options.timeoutMs, () => {
+          req.destroy(new Error('Request timeout'));
+        });
+        req.end();
+      });
+    }
+    const ac = new AbortController();
+    const t = setTimeout(() => ac.abort(), options.timeoutMs);
+    try {
+      const res = await fetch(urlString, {
+        method: 'GET',
+        headers: options.headers,
+        signal: ac.signal,
+      });
+      const body = await res.text();
+      return { status: res.status, body };
+    } finally {
+      clearTimeout(t);
+    }
+  }
+
+  throw new Error(`Unsupported URL protocol: ${url.protocol}`);
+}
+
+/**
  * GET returning parsed JSON (or null body) and HTTP status.
  */
 export async function jsonGet(urlString: string, options: JsonGetOptions): Promise<{ status: number; json: unknown }> {

--- a/src/argocd/resource-tree-api-client.test.ts
+++ b/src/argocd/resource-tree-api-client.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchArgoCdResourceTree,
+  probeArgoCdResourceTreeCapability,
+} from './resource-tree-api-client.js';
+import { ResourceTreeError } from './resource-tree-errors.js';
+
+describe('resource-tree-api-client', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{"nodes":[]}', { status: 200 }))
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetchArgoCdResourceTree returns raw body on success', async () => {
+    const raw = '{"nodes":[{"kind":"Pod"}]}';
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(raw, { status: 200 })));
+
+    const body = await fetchArgoCdResourceTree({
+      baseUrl: 'https://argocd.local',
+      appName: 'guestbook',
+      appNamespace: 'argocd',
+      bearerToken: 'tok',
+      timeoutMs: 5000,
+      tlsInsecure: false,
+    });
+
+    expect(body).toBe(raw);
+    expect(fetch).toHaveBeenCalledWith(
+      'https://argocd.local/api/v1/applications/guestbook/resource-tree?appNamespace=argocd',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({ Authorization: 'Bearer tok' }),
+      })
+    );
+  });
+
+  it('fetchArgoCdResourceTree maps 404 to APPLICATION_NOT_FOUND', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('not found', { status: 404 })));
+
+    await expect(
+      fetchArgoCdResourceTree({
+        baseUrl: 'https://argocd.local',
+        appName: 'missing',
+        appNamespace: 'argocd',
+        bearerToken: 'tok',
+        timeoutMs: 5000,
+        tlsInsecure: false,
+      })
+    ).rejects.toMatchObject({ code: 'APPLICATION_NOT_FOUND' });
+  });
+
+  it('probeArgoCdResourceTreeCapability succeeds on 200 list', async () => {
+    await expect(
+      probeArgoCdResourceTreeCapability({
+        baseUrl: 'https://argocd.local',
+        bearerToken: 'tok',
+        timeoutMs: 5000,
+        tlsInsecure: false,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://argocd.local/api/v1/applications',
+      expect.any(Object)
+    );
+  });
+
+  it('probeArgoCdResourceTreeCapability maps 403 to RBAC denied', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('denied', { status: 403 })));
+
+    await expect(
+      probeArgoCdResourceTreeCapability({
+        baseUrl: 'https://argocd.local',
+        bearerToken: 'tok',
+        timeoutMs: 5000,
+        tlsInsecure: false,
+      })
+    ).rejects.toBeInstanceOf(ResourceTreeError);
+  });
+});

--- a/src/argocd/resource-tree-api-client.ts
+++ b/src/argocd/resource-tree-api-client.ts
@@ -1,0 +1,86 @@
+/**
+ * Argo CD REST: GET /api/v1/applications/{name}/resource-tree (raw JSON passthrough).
+ */
+
+import { textGet } from './api-http.js';
+import {
+  mapHttpStatusToResourceTreeError,
+  mapNetworkErrorToResourceTreeError,
+  ResourceTreeError,
+} from './resource-tree-errors.js';
+
+export interface FetchArgoCdResourceTreeParams {
+  baseUrl: string;
+  appName: string;
+  appNamespace: string;
+  bearerToken: string;
+  timeoutMs: number;
+  tlsInsecure: boolean;
+}
+
+/**
+ * Fetch resource-tree JSON body without parsing or reshaping.
+ */
+export async function fetchArgoCdResourceTree(
+  params: FetchArgoCdResourceTreeParams
+): Promise<string> {
+  const base = params.baseUrl.replace(/\/+$/, '');
+  const url = `${base}/api/v1/applications/${encodeURIComponent(params.appName)}/resource-tree?appNamespace=${encodeURIComponent(params.appNamespace)}`;
+
+  try {
+    const { status, body } = await textGet(url, {
+      headers: {
+        Authorization: `Bearer ${params.bearerToken}`,
+        Accept: 'application/json',
+      },
+      timeoutMs: params.timeoutMs,
+      tlsInsecure: params.tlsInsecure,
+    });
+
+    if (status >= 200 && status < 300) {
+      return body;
+    }
+
+    throw mapHttpStatusToResourceTreeError(status, 'cli');
+  } catch (err) {
+    if (err instanceof ResourceTreeError) {
+      throw err;
+    }
+    throw mapNetworkErrorToResourceTreeError(err);
+  }
+}
+
+/**
+ * Lightweight probe: list Applications to verify dedicated token and connectivity.
+ */
+export async function probeArgoCdResourceTreeCapability(params: {
+  baseUrl: string;
+  bearerToken: string;
+  timeoutMs: number;
+  tlsInsecure: boolean;
+}): Promise<void> {
+  const base = params.baseUrl.replace(/\/+$/, '');
+  const url = `${base}/api/v1/applications`;
+
+  try {
+    const { status } = await textGet(url, {
+      headers: {
+        Authorization: `Bearer ${params.bearerToken}`,
+        Accept: 'application/json',
+      },
+      timeoutMs: params.timeoutMs,
+      tlsInsecure: params.tlsInsecure,
+    });
+
+    if (status >= 200 && status < 300) {
+      return;
+    }
+
+    throw mapHttpStatusToResourceTreeError(status, 'probe');
+  } catch (err) {
+    if (err instanceof ResourceTreeError) {
+      throw err;
+    }
+    throw mapNetworkErrorToResourceTreeError(err);
+  }
+}

--- a/src/argocd/resource-tree-auth.test.ts
+++ b/src/argocd/resource-tree-auth.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { resolveDedicatedArgoCdApiToken } from './resource-tree-auth.js';
+import type { ArgoCdApiCollectionEnvConfig } from './application-status-env.js';
+
+describe('resource-tree-auth', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'kube9-rt-auth-'));
+    delete process.env.ARGOCD_API_BEARER_TOKEN;
+  });
+
+  afterEach(() => {
+    delete process.env.ARGOCD_API_BEARER_TOKEN;
+  });
+
+  const baseConfig = (): ArgoCdApiCollectionEnvConfig => ({
+    collectionEnabled: true,
+    baseUrl: '',
+    timeoutMs: 30000,
+    tlsInsecure: false,
+    serverServiceName: 'argocd-server',
+  });
+
+  it('prefers ARGOCD_API_BEARER_TOKEN', () => {
+    process.env.ARGOCD_API_BEARER_TOKEN = ' inline-token ';
+    expect(resolveDedicatedArgoCdApiToken(baseConfig())).toBe('inline-token');
+  });
+
+  it('reads ARGOCD_API_TOKEN_FILE when bearer env is unset', () => {
+    const tokenPath = join(tempDir, 'token');
+    writeFileSync(tokenPath, 'file-token\n');
+    expect(
+      resolveDedicatedArgoCdApiToken({ ...baseConfig(), tokenFile: tokenPath })
+    ).toBe('file-token');
+  });
+
+  it('does not fall back to service account token', () => {
+    const saPath = '/var/run/secrets/kubernetes.io/serviceaccount/token';
+    if (existsSync(saPath)) {
+      expect(resolveDedicatedArgoCdApiToken(baseConfig())).toBeNull();
+    } else {
+      expect(resolveDedicatedArgoCdApiToken(baseConfig())).toBeNull();
+    }
+  });
+
+  it('returns null when neither bearer nor token file is configured', () => {
+    expect(resolveDedicatedArgoCdApiToken(baseConfig())).toBeNull();
+  });
+});

--- a/src/argocd/resource-tree-auth.ts
+++ b/src/argocd/resource-tree-auth.ts
@@ -1,0 +1,29 @@
+import { existsSync, readFileSync } from 'node:fs';
+import type { ArgoCdApiCollectionEnvConfig } from './application-status-env.js';
+
+/**
+ * Resolve dedicated Argo CD API bearer for resource-tree (M17).
+ * No Kubernetes ServiceAccount token fallback on this path.
+ */
+export function resolveDedicatedArgoCdApiToken(config: ArgoCdApiCollectionEnvConfig): string | null {
+  const fromEnv = process.env.ARGOCD_API_BEARER_TOKEN;
+  if (fromEnv !== undefined && fromEnv.trim() !== '') {
+    return fromEnv.trim();
+  }
+
+  const path = config.tokenFile?.trim();
+  if (!path) {
+    return null;
+  }
+
+  if (!existsSync(path)) {
+    return null;
+  }
+
+  try {
+    const token = readFileSync(path, 'utf8').trim();
+    return token === '' ? null : token;
+  } catch {
+    return null;
+  }
+}

--- a/src/argocd/resource-tree-context.test.ts
+++ b/src/argocd/resource-tree-context.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveResourceTreeRequestContext } from './resource-tree-context.js';
+import { ResourceTreeError } from './resource-tree-errors.js';
+import type { ArgoCDStatus } from '../status/types.js';
+import type { ArgoCdApiCollectionEnvConfig } from './application-status-env.js';
+
+describe('resource-tree-context', () => {
+  afterEach(() => {
+    delete process.env.ARGOCD_API_BEARER_TOKEN;
+    delete process.env.ARGOCD_API_BASE_URL;
+  });
+
+  const detected = (): ArgoCDStatus => ({
+    detected: true,
+    namespace: 'gitops',
+    version: 'v2.14.0',
+    lastChecked: new Date().toISOString(),
+  });
+
+  const env = (): ArgoCdApiCollectionEnvConfig => ({
+    collectionEnabled: true,
+    baseUrl: '',
+    timeoutMs: 30000,
+    tlsInsecure: false,
+    serverServiceName: 'argocd-server',
+  });
+
+  it('derives base URL from detection when ARGOCD_API_BASE_URL unset', () => {
+    process.env.ARGOCD_API_BEARER_TOKEN = 'tok';
+    const ctx = resolveResourceTreeRequestContext(detected(), env());
+    expect(ctx.baseUrl).toBe('https://argocd-server.gitops.svc.cluster.local');
+    expect(ctx.bearerToken).toBe('tok');
+  });
+
+  it('throws ARGOCD_NOT_DETECTED when base URL unavailable', () => {
+    process.env.ARGOCD_API_BEARER_TOKEN = 'tok';
+    expect(() =>
+      resolveResourceTreeRequestContext(
+        { detected: false, namespace: null, version: null, lastChecked: 't' },
+        env()
+      )
+    ).toThrowError(ResourceTreeError);
+  });
+
+  it('throws ARGOCD_TOKEN_MISSING when bearer unset', () => {
+    expect(() => resolveResourceTreeRequestContext(detected(), env())).toThrowError(
+      expect.objectContaining({ code: 'ARGOCD_TOKEN_MISSING' })
+    );
+  });
+});

--- a/src/argocd/resource-tree-context.ts
+++ b/src/argocd/resource-tree-context.ts
@@ -1,0 +1,40 @@
+import type { ArgoCDStatus } from '../status/types.js';
+import {
+  parseArgoCdApiCollectionConfigFromEnv,
+  type ArgoCdApiCollectionEnvConfig,
+} from './application-status-env.js';
+import { deriveArgoCdApiBaseUrl } from './application-status-cycle.js';
+import { resolveDedicatedArgoCdApiToken } from './resource-tree-auth.js';
+import { ResourceTreeError } from './resource-tree-errors.js';
+
+export interface ResourceTreeRequestContext {
+  env: ArgoCdApiCollectionEnvConfig;
+  baseUrl: string;
+  bearerToken: string;
+}
+
+/**
+ * Resolve base URL and dedicated bearer for resource-tree CLI or probe.
+ */
+export function resolveResourceTreeRequestContext(
+  argocdStatus: ArgoCDStatus,
+  env: ArgoCdApiCollectionEnvConfig = parseArgoCdApiCollectionConfigFromEnv()
+): ResourceTreeRequestContext {
+  const baseUrl = deriveArgoCdApiBaseUrl(env, argocdStatus);
+  if (!baseUrl) {
+    throw new ResourceTreeError(
+      'ARGOCD_NOT_DETECTED',
+      'Argo CD is not detected and ARGOCD_API_BASE_URL is not set'
+    );
+  }
+
+  const bearerToken = resolveDedicatedArgoCdApiToken(env);
+  if (!bearerToken) {
+    throw new ResourceTreeError(
+      'ARGOCD_TOKEN_MISSING',
+      'Dedicated Argo CD API bearer token is not configured (set ARGOCD_API_BEARER_TOKEN or ARGOCD_API_TOKEN_FILE)'
+    );
+  }
+
+  return { env, baseUrl, bearerToken };
+}

--- a/src/argocd/resource-tree-errors.test.ts
+++ b/src/argocd/resource-tree-errors.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  exitCodeForResourceTreeError,
+  isClusterWideResourceTreeFailure,
+  mapHttpStatusToResourceTreeError,
+  ResourceTreeError,
+} from './resource-tree-errors.js';
+
+describe('resource-tree-errors', () => {
+  it('maps exit codes per contract', () => {
+    expect(exitCodeForResourceTreeError('INVALID_ARGUMENT')).toBe(2);
+    expect(exitCodeForResourceTreeError('APPLICATION_NOT_FOUND')).toBe(3);
+    expect(exitCodeForResourceTreeError('ARGOCD_TOKEN_MISSING')).toBe(4);
+    expect(exitCodeForResourceTreeError('ARGOCD_AUTH_FAILED')).toBe(4);
+    expect(exitCodeForResourceTreeError('ARGOCD_RBAC_DENIED')).toBe(5);
+    expect(exitCodeForResourceTreeError('TIMEOUT')).toBe(6);
+    expect(exitCodeForResourceTreeError('ARGOCD_NOT_DETECTED')).toBe(7);
+    expect(exitCodeForResourceTreeError('ARGOCD_API_UNREACHABLE')).toBe(7);
+    expect(exitCodeForResourceTreeError('INTERNAL_ERROR')).toBe(1);
+  });
+
+  it('maps HTTP statuses to resource-tree codes', () => {
+    expect(mapHttpStatusToResourceTreeError(401).code).toBe('ARGOCD_AUTH_FAILED');
+    expect(mapHttpStatusToResourceTreeError(403).code).toBe('ARGOCD_RBAC_DENIED');
+    expect(mapHttpStatusToResourceTreeError(404).code).toBe('APPLICATION_NOT_FOUND');
+    expect(mapHttpStatusToResourceTreeError(500).code).toBe('ARGOCD_API_UNREACHABLE');
+  });
+
+  it('serializes stderr envelope', () => {
+    const err = new ResourceTreeError('ARGOCD_TOKEN_MISSING', 'token missing');
+    expect(err.toEnvelope()).toEqual({
+      ok: false,
+      code: 'ARGOCD_TOKEN_MISSING',
+      message: 'token missing',
+    });
+  });
+
+  it('classifies cluster-wide vs per-app failures for demotion', () => {
+    expect(isClusterWideResourceTreeFailure('ARGOCD_AUTH_FAILED')).toBe(true);
+    expect(isClusterWideResourceTreeFailure('APPLICATION_NOT_FOUND')).toBe(false);
+    expect(isClusterWideResourceTreeFailure('TIMEOUT')).toBe(false);
+  });
+});

--- a/src/argocd/resource-tree-errors.ts
+++ b/src/argocd/resource-tree-errors.ts
@@ -1,0 +1,125 @@
+export type ResourceTreeErrorCode =
+  | 'INVALID_ARGUMENT'
+  | 'ARGOCD_NOT_DETECTED'
+  | 'ARGOCD_TOKEN_MISSING'
+  | 'ARGOCD_API_UNREACHABLE'
+  | 'ARGOCD_AUTH_FAILED'
+  | 'ARGOCD_RBAC_DENIED'
+  | 'APPLICATION_NOT_FOUND'
+  | 'TIMEOUT'
+  | 'INTERNAL_ERROR';
+
+export interface ResourceTreeErrorEnvelope {
+  ok: false;
+  code: ResourceTreeErrorCode;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export class ResourceTreeError extends Error {
+  readonly code: ResourceTreeErrorCode;
+  readonly exitCode: number;
+  readonly details?: Record<string, unknown>;
+
+  constructor(
+    code: ResourceTreeErrorCode,
+    message: string,
+    exitCode?: number,
+    details?: Record<string, unknown>
+  ) {
+    super(message);
+    this.name = 'ResourceTreeError';
+    this.code = code;
+    this.exitCode = exitCode ?? exitCodeForResourceTreeError(code);
+    this.details = details;
+  }
+
+  toEnvelope(): ResourceTreeErrorEnvelope {
+    const envelope: ResourceTreeErrorEnvelope = {
+      ok: false,
+      code: this.code,
+      message: this.message,
+    };
+    if (this.details && Object.keys(this.details).length > 0) {
+      envelope.details = this.details;
+    }
+    return envelope;
+  }
+}
+
+export function exitCodeForResourceTreeError(code: ResourceTreeErrorCode): number {
+  switch (code) {
+    case 'INVALID_ARGUMENT':
+      return 2;
+    case 'APPLICATION_NOT_FOUND':
+      return 3;
+    case 'ARGOCD_TOKEN_MISSING':
+    case 'ARGOCD_AUTH_FAILED':
+      return 4;
+    case 'ARGOCD_RBAC_DENIED':
+      return 5;
+    case 'TIMEOUT':
+      return 6;
+    case 'ARGOCD_API_UNREACHABLE':
+    case 'ARGOCD_NOT_DETECTED':
+      return 7;
+    case 'INTERNAL_ERROR':
+    default:
+      return 1;
+  }
+}
+
+/** Cluster-wide probe failures demote global capability. Per-app CLI outcomes do not. */
+export function isClusterWideResourceTreeFailure(code: ResourceTreeErrorCode): boolean {
+  return (
+    code === 'ARGOCD_TOKEN_MISSING' ||
+    code === 'ARGOCD_API_UNREACHABLE' ||
+    code === 'ARGOCD_AUTH_FAILED' ||
+    code === 'ARGOCD_RBAC_DENIED' ||
+    code === 'ARGOCD_NOT_DETECTED' ||
+    code === 'INTERNAL_ERROR'
+  );
+}
+
+export function mapHttpStatusToResourceTreeError(
+  status: number,
+  context: 'cli' | 'probe' = 'cli'
+): ResourceTreeError {
+  if (status === 401) {
+    return new ResourceTreeError('ARGOCD_AUTH_FAILED', 'Argo CD API rejected the bearer token');
+  }
+  if (status === 403) {
+    return new ResourceTreeError(
+      'ARGOCD_RBAC_DENIED',
+      context === 'probe'
+        ? 'Argo CD API denied access during capability probe'
+        : 'Argo CD API denied access to resource-tree'
+    );
+  }
+  if (status === 404) {
+    return new ResourceTreeError('APPLICATION_NOT_FOUND', 'Argo CD Application not found');
+  }
+  return new ResourceTreeError(
+    'ARGOCD_API_UNREACHABLE',
+    `Argo CD API request failed with HTTP ${status}`
+  );
+}
+
+export function mapNetworkErrorToResourceTreeError(err: unknown): ResourceTreeError {
+  const message = err instanceof Error ? err.message : String(err);
+  const lower = message.toLowerCase();
+  if (
+    lower.includes('timeout') ||
+    lower.includes('aborted') ||
+    lower.includes('abort') ||
+    err instanceof Error && err.name === 'AbortError'
+  ) {
+    return new ResourceTreeError('TIMEOUT', 'Argo CD API request timed out');
+  }
+  return new ResourceTreeError('ARGOCD_API_UNREACHABLE', `Cannot reach Argo CD API: ${message}`);
+}
+
+export function writeResourceTreeCliError(error: ResourceTreeError): never {
+  console.error(JSON.stringify(error.toEnvelope()));
+  process.exit(error.exitCode);
+}

--- a/src/argocd/resource-tree-probe.test.ts
+++ b/src/argocd/resource-tree-probe.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ArgoCDStatus } from '../status/types.js';
+import {
+  mergeResourceTreeProbeIntoStatus,
+  runResourceTreeCapabilityProbe,
+} from './resource-tree-probe.js';
+import type { ArgoCdApiCollectionEnvConfig } from './application-status-env.js';
+
+describe('resource-tree-probe', () => {
+  const detected = (): ArgoCDStatus => ({
+    detected: true,
+    namespace: 'argocd',
+    version: 'v2.14.0',
+    lastChecked: new Date().toISOString(),
+  });
+
+  const baseEnv = (): ArgoCdApiCollectionEnvConfig => ({
+    collectionEnabled: true,
+    baseUrl: 'https://argocd.local',
+    timeoutMs: 5000,
+    tlsInsecure: false,
+    serverServiceName: 'argocd-server',
+  });
+
+  it('omits capability fields when Argo CD is not detected', async () => {
+    const result = await runResourceTreeCapabilityProbe({
+      detected: false,
+      namespace: null,
+      version: null,
+      lastChecked: new Date().toISOString(),
+    });
+    expect(result).toEqual({});
+  });
+
+  it('demotes when dedicated token is missing', async () => {
+    const result = await runResourceTreeCapabilityProbe(detected(), {
+      env: baseEnv(),
+    });
+    expect(result).toEqual({
+      resourceTreeCapable: false,
+      resourceTreeLastError: {
+        code: 'ARGOCD_TOKEN_MISSING',
+        message: 'Dedicated Argo CD API bearer token is not configured',
+      },
+    });
+  });
+
+  it('sets capable true after successful probe with token env', async () => {
+    process.env.ARGOCD_API_BEARER_TOKEN = 'probe-token';
+    try {
+      const result = await runResourceTreeCapabilityProbe(detected(), {
+        env: baseEnv(),
+        probe: vi.fn(async () => undefined),
+      });
+      expect(result).toEqual({ resourceTreeCapable: true });
+    } finally {
+      delete process.env.ARGOCD_API_BEARER_TOKEN;
+    }
+  });
+
+  it('demotes on cluster-wide probe auth failure', async () => {
+    process.env.ARGOCD_API_BEARER_TOKEN = 'bad';
+    try {
+      const result = await runResourceTreeCapabilityProbe(detected(), {
+        env: baseEnv(),
+        probe: vi.fn(async () => {
+          const { ResourceTreeError } = await import('./resource-tree-errors.js');
+          throw new ResourceTreeError('ARGOCD_AUTH_FAILED', 'auth failed');
+        }),
+      });
+      expect(result.resourceTreeCapable).toBe(false);
+      expect(result.resourceTreeLastError?.code).toBe('ARGOCD_AUTH_FAILED');
+    } finally {
+      delete process.env.ARGOCD_API_BEARER_TOKEN;
+    }
+  });
+
+  it('mergeResourceTreeProbeIntoStatus omits fields when not detected', () => {
+    const merged = mergeResourceTreeProbeIntoStatus(
+      {
+        detected: false,
+        namespace: null,
+        version: null,
+        lastChecked: 't',
+        resourceTreeCapable: false,
+      },
+      { resourceTreeCapable: false }
+    );
+    expect(merged.resourceTreeCapable).toBeUndefined();
+    expect(merged.resourceTreeLastError).toBeUndefined();
+  });
+
+  it('mergeResourceTreeProbeIntoStatus clears lastError when capable', () => {
+    const merged = mergeResourceTreeProbeIntoStatus(
+      {
+        ...detected(),
+        resourceTreeCapable: false,
+        resourceTreeLastError: { code: 'ARGOCD_TOKEN_MISSING', message: 'x' },
+      },
+      { resourceTreeCapable: true }
+    );
+    expect(merged.resourceTreeCapable).toBe(true);
+    expect(merged.resourceTreeLastError).toBeUndefined();
+  });
+});

--- a/src/argocd/resource-tree-probe.ts
+++ b/src/argocd/resource-tree-probe.ts
@@ -1,0 +1,120 @@
+/**
+ * Lightweight resource-tree capability probe for status ConfigMap publishing.
+ */
+
+import { logger } from '../logging/logger.js';
+import type { ArgoCDStatus, ArgoCDResourceTreeLastError } from '../status/types.js';
+import {
+  parseArgoCdApiCollectionConfigFromEnv,
+  type ArgoCdApiCollectionEnvConfig,
+} from './application-status-env.js';
+import { probeArgoCdResourceTreeCapability } from './resource-tree-api-client.js';
+import { resolveDedicatedArgoCdApiToken } from './resource-tree-auth.js';
+import { deriveArgoCdApiBaseUrl } from './application-status-cycle.js';
+import { ResourceTreeError } from './resource-tree-errors.js';
+
+export interface ResourceTreeProbeResult {
+  resourceTreeCapable?: boolean;
+  resourceTreeLastError?: ArgoCDResourceTreeLastError;
+}
+
+export interface ResourceTreeProbeDeps {
+  env: ArgoCdApiCollectionEnvConfig;
+  probe: typeof probeArgoCdResourceTreeCapability;
+}
+
+/**
+ * Run capability probe and return fields to merge into {@link ArgoCDStatus}.
+ * Omits both fields when Argo CD is not detected.
+ */
+export async function runResourceTreeCapabilityProbe(
+  detection: ArgoCDStatus,
+  deps: Partial<ResourceTreeProbeDeps> = {}
+): Promise<ResourceTreeProbeResult> {
+  if (!detection.detected) {
+    return {};
+  }
+
+  const env = deps.env ?? parseArgoCdApiCollectionConfigFromEnv();
+  const token = resolveDedicatedArgoCdApiToken(env);
+
+  if (!token) {
+    return {
+      resourceTreeCapable: false,
+      resourceTreeLastError: {
+        code: 'ARGOCD_TOKEN_MISSING',
+        message: 'Dedicated Argo CD API bearer token is not configured',
+      },
+    };
+  }
+
+  const baseUrl = deriveArgoCdApiBaseUrl(env, detection);
+  if (!baseUrl) {
+    return {
+      resourceTreeCapable: false,
+      resourceTreeLastError: {
+        code: 'ARGOCD_NOT_DETECTED',
+        message: 'Argo CD API base URL is unavailable',
+      },
+    };
+  }
+
+  const probeFn = deps.probe ?? probeArgoCdResourceTreeCapability;
+
+  try {
+    await probeFn({
+      baseUrl,
+      bearerToken: token,
+      timeoutMs: env.timeoutMs,
+      tlsInsecure: env.tlsInsecure,
+    });
+    return { resourceTreeCapable: true };
+  } catch (err) {
+    if (err instanceof ResourceTreeError) {
+      logger.debug('Argo CD resource-tree capability probe failed', {
+        code: err.code,
+        message: err.message,
+      });
+      return {
+        resourceTreeCapable: false,
+        resourceTreeLastError: { code: err.code, message: err.message },
+      };
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    logger.debug('Argo CD resource-tree capability probe failed', { message });
+    return {
+      resourceTreeCapable: false,
+      resourceTreeLastError: { code: 'INTERNAL_ERROR', message },
+    };
+  }
+}
+
+/**
+ * Merge probe outcome into detection status for ConfigMap publish.
+ */
+export function mergeResourceTreeProbeIntoStatus(
+  detection: ArgoCDStatus,
+  probe: ResourceTreeProbeResult
+): ArgoCDStatus {
+  if (!detection.detected) {
+    const { resourceTreeCapable: _c, resourceTreeLastError: _e, ...rest } = detection;
+    return rest;
+  }
+
+  const merged: ArgoCDStatus = { ...detection };
+
+  if (probe.resourceTreeCapable === true) {
+    merged.resourceTreeCapable = true;
+    delete merged.resourceTreeLastError;
+    return merged;
+  }
+
+  if (probe.resourceTreeCapable === false) {
+    merged.resourceTreeCapable = false;
+    if (probe.resourceTreeLastError) {
+      merged.resourceTreeLastError = probe.resourceTreeLastError;
+    }
+  }
+
+  return merged;
+}

--- a/src/cli/commands/argocd-resource-tree.ts
+++ b/src/cli/commands/argocd-resource-tree.ts
@@ -1,0 +1,71 @@
+/**
+ * CLI: on-demand Argo CD resource-tree query (M17).
+ */
+
+import { z } from 'zod';
+import { detectArgoCDWithTimeout, parseArgoCDConfigFromEnv } from '../../argocd/detection.js';
+import { fetchArgoCdResourceTree } from '../../argocd/resource-tree-api-client.js';
+import { resolveResourceTreeRequestContext } from '../../argocd/resource-tree-context.js';
+import {
+  ResourceTreeError,
+  writeResourceTreeCliError,
+} from '../../argocd/resource-tree-errors.js';
+import { kubernetesClient } from '../../kubernetes/client.js';
+import type { ArgoCDStatus } from '../../status/types.js';
+
+const GetOptionsSchema = z.object({
+  namespace: z.string().min(1, 'Application namespace is required'),
+  format: z.enum(['json']).optional().default('json'),
+});
+
+export async function getArgoCDResourceTree(
+  appName: string | undefined,
+  options: Record<string, unknown>
+) {
+  try {
+    const parsed = GetOptionsSchema.safeParse(options);
+    if (!parsed.success || !appName || appName.trim() === '') {
+      throw new ResourceTreeError(
+        'INVALID_ARGUMENT',
+        'Usage: query argocd resource-tree get <appName> --namespace=<appNamespace> [--format=json]'
+      );
+    }
+
+    if (parsed.data.format !== 'json') {
+      throw new ResourceTreeError(
+        'INVALID_ARGUMENT',
+        'Only --format=json is supported for resource-tree get'
+      );
+    }
+
+    let argocdStatus: ArgoCDStatus;
+    try {
+      argocdStatus = await detectArgoCDWithTimeout(
+        kubernetesClient,
+        parseArgoCDConfigFromEnv(),
+        10000
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new ResourceTreeError('INTERNAL_ERROR', `Argo CD detection failed: ${message}`);
+    }
+
+    const ctx = resolveResourceTreeRequestContext(argocdStatus);
+    const body = await fetchArgoCdResourceTree({
+      baseUrl: ctx.baseUrl,
+      appName: appName.trim(),
+      appNamespace: parsed.data.namespace.trim(),
+      bearerToken: ctx.bearerToken,
+      timeoutMs: ctx.env.timeoutMs,
+      tlsInsecure: ctx.env.tlsInsecure,
+    });
+
+    process.stdout.write(body.endsWith('\n') ? body : `${body}\n`);
+  } catch (err) {
+    if (err instanceof ResourceTreeError) {
+      writeResourceTreeCliError(err);
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    writeResourceTreeCliError(new ResourceTreeError('INTERNAL_ERROR', message));
+  }
+}

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -23,4 +23,14 @@ describe('createQueryCommands', () => {
     expect(names).toContain('events');
     expect(names).toContain('vulnerabilities');
   });
+
+  it('includes argocd resource-tree get subcommand', () => {
+    const queryCmd = createQueryCommands();
+    const argocd = queryCmd.commands.find((c) => c.name() === 'argocd');
+    expect(argocd).toBeTruthy();
+    const resourceTree = argocd!.commands.find((c) => c.name() === 'resource-tree');
+    expect(resourceTree).toBeTruthy();
+    const getCmd = resourceTree!.commands.find((c) => c.name() === 'get');
+    expect(getCmd).toBeTruthy();
+  });
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,7 @@ import {
 import { listVulnerabilities, summarizeVulnerabilities } from './commands/vulnerabilities.js';
 import { listCollections, getCollection } from './commands/collections.js';
 import { listArgoCDApplications, getArgoCDApplication } from './commands/argocd-apps.js';
+import { getArgoCDResourceTree } from './commands/argocd-resource-tree.js';
 import {
   aiConformanceRun,
   aiConformanceLatest,
@@ -240,6 +241,17 @@ export function createQueryCommands(): Command {
     .description('Get one persisted Application snapshot by primary key')
     .option('--format <format>', 'Output format (json|yaml|table|compact)', 'json')
     .action(getArgoCDApplication);
+
+  const resourceTree = argocd
+    .command('resource-tree')
+    .description('On-demand Argo CD Application resource-tree (live API)');
+
+  resourceTree
+    .command('get <appName>')
+    .description('Fetch raw resource-tree JSON for an Application from argocd-server')
+    .requiredOption('--namespace <appNamespace>', 'Argo CD Application namespace (appNamespace)')
+    .option('--format <format>', 'Output format (json only)', 'json')
+    .action(getArgoCDResourceTree);
 
   return query;
 }

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -35,6 +35,14 @@ export interface ArgoCDApplicationsPersistedSummary {
 }
 
 /**
+ * Last global demotion reason for resource-tree capability (bounded; no tokens).
+ */
+export interface ArgoCDResourceTreeLastError {
+  code: string;
+  message: string;
+}
+
+/**
  * ArgoCD Status
  * Represents the current state of ArgoCD detection in the cluster
  */
@@ -67,6 +75,18 @@ export interface ArgoCDStatus {
    * Optional summary derived from SQLite `argocd_apps` when snapshots exist (omitted when none).
    */
   applications?: ArgoCDApplicationsPersistedSummary;
+
+  /**
+   * Whether on-demand resource-tree enrichment is available after probe success.
+   * Omitted when Argo CD is not detected.
+   */
+  resourceTreeCapable?: boolean;
+
+  /**
+   * Last cluster-wide demotion reason when {@link resourceTreeCapable} is false.
+   * Omitted when capable is true or Argo CD is not detected.
+   */
+  resourceTreeLastError?: ArgoCDResourceTreeLastError;
 }
 
 /**

--- a/src/status/writer.ts
+++ b/src/status/writer.ts
@@ -24,6 +24,10 @@ import { collectionStatsTracker } from '../collection/stats-tracker.js';
 import { argocdStatusTracker } from '../argocd/state.js';
 import { trivyStatusTracker } from '../trivy/state.js';
 import { withPersistedArgoApplicationsSummary } from './argocd-for-status.js';
+import {
+  mergeResourceTreeProbeIntoStatus,
+  runResourceTreeCapabilityProbe,
+} from '../argocd/resource-tree-probe.js';
 
 /**
  * ConfigMap name for operator status
@@ -173,7 +177,10 @@ export class StatusWriter {
       const canWriteConfigMap = true;
 
       const collectionStats = collectionStatsTracker.getStats();
-      const argocdStatus = withPersistedArgoApplicationsSummary(argocdStatusTracker.getStatus());
+      const detectionStatus = argocdStatusTracker.getStatus();
+      const probeResult = await runResourceTreeCapabilityProbe(detectionStatus);
+      const argocdWithProbe = mergeResourceTreeProbeIntoStatus(detectionStatus, probeResult);
+      const argocdStatus = withPersistedArgoApplicationsSummary(argocdWithProbe);
       const trivyStatus = trivyStatusTracker.getStatus();
       let assessmentSchedule = DEFAULT_ASSESSMENT_SCHEDULE_CONTEXT;
       try {


### PR DESCRIPTION
## Description

Adds M17 on-demand Argo CD resource-tree query for kube9-vscode graph enrichment without extension REST bearer tokens.

## Motivation and Context

Closes #151

Implements `kube9-operator query argocd resource-tree get <appName> --namespace=<appNamespace>` against in-cluster argocd-server with dedicated bearer auth only (no SA fallback), raw JSON stdout, structured stderr error envelope, and status ConfigMap capability fields updated by a lightweight probe on the status loop.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated
- [x] All new and existing tests pass (`npm test`)
- [x] Linter passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)

## How to Test this Work

```bash
npm install
npm run lint
npm run test:unit
npm run build

# Optional live cluster (dedicated bearer required):
export ARGOCD_API_BEARER_TOKEN=...
node dist/index.js query argocd resource-tree get guestbook --namespace=argocd
```

Expected: exit 0 with raw resource-tree JSON on stdout; missing token yields exit 4 and stderr `{ "ok": false, "code": "ARGOCD_TOKEN_MISSING", ... }`.

## How to Validate this Work

1. Deploy operator with Argo CD detected and dedicated API token configured.
2. Confirm ConfigMap `kube9-operator-status` includes `status.argocd.resourceTreeCapable: true` after probe success.
3. Run CLI via kubectl exec for a known Application; stdout should be unmodified Argo CD resource-tree JSON.

## Additional Notes

- Probe uses `GET /api/v1/applications` as a lightweight auth/connectivity check when token is configured.
- Per-app CLI failures (`APPLICATION_NOT_FOUND`, per-app timeout) do not demote global capability.
- Operator global `health` is unaffected by resource-tree failures.