### PR TITLE
feat(helm): mount Argo CD API token Secret for M17 resource-tree (#152)

### DIFF
--- a/charts/kube9-operator/README.md
+++ b/charts/kube9-operator/README.md
@@ -123,7 +123,9 @@ The following table lists the configurable parameters and their default values:
 | `argocd.api.timeoutMs` | HTTP timeout for each Argo CD API request | `30000` |
 | `argocd.api.tlsInsecure` | Skip TLS verification (not recommended for production) | `false` |
 | `argocd.api.serverServiceName` | Kubernetes Service name for derived in-cluster API URL | `argocd-server` |
-| `argocd.api.tokenFile` | Optional path to a bearer token file (defaults to the pod SA token path when omitted and readable) | (unset) |
+| `argocd.api.token.existingSecret` | Name of an existing Secret (release namespace) with a dedicated Argo CD API bearer token. Empty = default-off (no mount) | `""` |
+| `argocd.api.token.existingSecretKey` | Key within `existingSecret` holding the bearer token | `token` |
+| `argocd.api.tokenFile` | Advanced: override `ARGOCD_API_TOKEN_FILE` path without chart-managed Secret mount | (unset) |
 | `metrics.intervals.argocdApplicationStatus` | Argo CD Application API collection interval (seconds); minimum 1800 | `3600` |
 | `trivy.autoDetect` | Probe `trivy.serverUrl` periodically for Trivy HTTP health | `true` |
 | `trivy.serverUrl` | Trivy server base URL (required for detection and scans) | (unset) |
@@ -238,7 +240,42 @@ The operator can detect and integrate with ArgoCD installations in your cluster.
 - **timeoutMs** (default: `30000`): Timeout for listing applications.
 - **tlsInsecure** (default: `false`): Skip TLS verification (labs only).
 - **serverServiceName** (default: `argocd-server`): Kubernetes Service DNS name segment used for the derived URL.
-- **tokenFile** (optional): Bearer token path. If unset, the operator reads the pod service-account token when `/var/run/secrets/kubernetes.io/serviceaccount/token` exists. Grant this identity **Argo CD RBAC** to read Applications (chart does not modify Argo CD `AppProject` / roles).
+
+**Dedicated Argo CD API bearer token (`argocd.api.token.*`)** — required for M17 resource-tree (Application graph) auth. The chart does **not** create a Secret from plaintext Helm values. Platform admins create the Secret out-of-band and reference it here.
+
+- **token.existingSecret** (default: `""`): Name of an existing Secret in the release namespace. When empty/unset, the chart does not mount a token file and does not set `ARGOCD_API_TOKEN_FILE` (install succeeds; runtime reports `ARGOCD_TOKEN_MISSING` / `resourceTreeCapable: false` when Argo CD is detected).
+- **token.existingSecretKey** (default: `token`): Key within that Secret holding the bearer token string.
+- When `existingSecret` is set, the chart mounts the key at `/var/run/secrets/kube9/argocd-api-token` and sets `ARGOCD_API_TOKEN_FILE` to that path. Resolution order at runtime (see operator #151): non-empty `ARGOCD_API_BEARER_TOKEN` env first, else readable `ARGOCD_API_TOKEN_FILE`. The resource-tree path does **not** fall back to the operator Kubernetes ServiceAccount token.
+- **tokenFile** (optional, advanced): Override the `ARGOCD_API_TOKEN_FILE` env path without a chart-managed Secret mount. Not the supported M17 onboarding path.
+
+**Create the Secret (release namespace, typically `kube9-system`):**
+
+```bash
+kubectl -n kube9-system create secret generic kube9-argocd-api-token \
+  --from-literal=token="<argocd-api-bearer-token>"
+```
+
+**Helm values example:**
+
+```yaml
+argocd:
+  api:
+    token:
+      existingSecret: kube9-argocd-api-token
+      existingSecretKey: token
+```
+
+**Mount failure:** If `existingSecret` is set but the Secret does not exist, Kubernetes fails the pod volume mount and the pod does not become Ready. This is expected; create the Secret before or with the install.
+
+**Argo CD RBAC (platform admin; chart does not apply):** Grant the token identity permission to read Applications for resource-tree. Example policy snippet:
+
+```text
+p, role:kube9-resource-tree, applications, get, */*, allow
+```
+
+Attach that role (or a project-scoped variant) to the Argo CD account that issued the token. If the token is present but lacks permission, the operator pod still runs; status shows `ARGOCD_RBAC_DENIED` and `resourceTreeCapable: false`.
+
+**Missing dedicated token:** When Argo CD is detected but no dedicated token is configured (`existingSecret` unset), the operator does not implement the kube9-vscode fallback ladder. The extension may still use REST settings, `kubernetes_owner_ref`, or `crd_flat` when the operator is not resource-tree capable.
 
 **When to use `enabled` vs `autoDetect`:**
 
@@ -603,7 +640,9 @@ Complete reference of all configurable values:
 | `argocd.api.timeoutMs` | HTTP timeout for each Argo CD API request | `30000` |
 | `argocd.api.tlsInsecure` | Skip TLS verification (not recommended for production) | `false` |
 | `argocd.api.serverServiceName` | Kubernetes Service name for derived in-cluster API URL | `argocd-server` |
-| `argocd.api.tokenFile` | Optional path to a bearer token file (defaults to the pod SA token path when omitted and readable) | (unset) |
+| `argocd.api.token.existingSecret` | Name of an existing Secret (release namespace) with a dedicated Argo CD API bearer token. Empty = default-off (no mount) | `""` |
+| `argocd.api.token.existingSecretKey` | Key within `existingSecret` holding the bearer token | `token` |
+| `argocd.api.tokenFile` | Advanced: override `ARGOCD_API_TOKEN_FILE` path without chart-managed Secret mount | (unset) |
 | `metrics.intervals.argocdApplicationStatus` | Argo CD Application API collection interval (seconds); minimum 1800 | `3600` |
 
 ## Additional Resources

--- a/charts/kube9-operator/argocd-api-token-helm.test.ts
+++ b/charts/kube9-operator/argocd-api-token-helm.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+
+const chartDir = path.join(process.cwd(), 'charts/kube9-operator');
+
+function renderChart(extraArgs = ''): string | undefined {
+  try {
+    return execSync(
+      `helm template kube9-operator ${chartDir} --namespace kube9-system ${extraArgs}`.trim(),
+      { encoding: 'utf8', timeout: 15_000 }
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+describe('kube9-operator Helm chart argocd.api.token values', () => {
+  it('default-off: no ARGOCD_API_TOKEN_FILE env or argocd-api-token mount', () => {
+    const rendered = renderChart();
+    if (!rendered) {
+      return;
+    }
+
+    expect(rendered).not.toContain('name: ARGOCD_API_TOKEN_FILE');
+    expect(rendered).not.toContain('name: argocd-api-token');
+    expect(rendered).not.toContain('/var/run/secrets/kube9/argocd-api-token');
+  });
+
+  it('existingSecret: mounts Secret and sets ARGOCD_API_TOKEN_FILE', () => {
+    const rendered = renderChart(
+      '--set argocd.api.token.existingSecret=kube9-argocd-api-token --set argocd.api.token.existingSecretKey=token'
+    );
+    if (!rendered) {
+      return;
+    }
+
+    expect(rendered).toContain('name: ARGOCD_API_TOKEN_FILE');
+    expect(rendered).toContain('value: "/var/run/secrets/kube9/argocd-api-token"');
+    expect(rendered).toContain('secretName: kube9-argocd-api-token');
+    expect(rendered).toContain('mountPath: /var/run/secrets/kube9/argocd-api-token');
+    expect(rendered).toContain('subPath: token');
+  });
+});

--- a/charts/kube9-operator/templates/deployment.yaml
+++ b/charts/kube9-operator/templates/deployment.yaml
@@ -70,6 +70,9 @@ spec:
         - name: ARGOCD_DETECTION_INTERVAL
           value: {{ .Values.argocd.detectionInterval | default 6 | quote }}
         {{- $argapi := .Values.argocd.api | default dict }}
+        {{- $argToken := $argapi.token | default dict }}
+        {{- $argocdApiTokenSecret := $argToken.existingSecret | default "" }}
+        {{- $argocdApiTokenMountPath := "/var/run/secrets/kube9/argocd-api-token" }}
         - name: ARGOCD_API_COLLECTION_ENABLED
           value: {{ $argapi.collectionEnabled | default true | quote }}
         {{- if $argapi.baseUrl }}
@@ -85,6 +88,9 @@ spec:
         {{- if $argapi.tokenFile }}
         - name: ARGOCD_API_TOKEN_FILE
           value: {{ $argapi.tokenFile | quote }}
+        {{- else if $argocdApiTokenSecret }}
+        - name: ARGOCD_API_TOKEN_FILE
+          value: {{ $argocdApiTokenMountPath | quote }}
         {{- end }}
         - name: ARGOCD_APPLICATION_STATUS_INTERVAL_SECONDS
           value: {{ .Values.metrics.intervals.argocdApplicationStatus | default 3600 | quote }}
@@ -164,6 +170,12 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /data
+        {{- if $argocdApiTokenSecret }}
+        - name: argocd-api-token
+          mountPath: {{ $argocdApiTokenMountPath }}
+          subPath: {{ $argToken.existingSecretKey | default "token" }}
+          readOnly: true
+        {{- end }}
       volumes:
       - name: data
         {{- if .Values.events.persistence.enabled }}
@@ -172,4 +184,9 @@ spec:
         {{- else }}
         emptyDir: {}
         {{- end }}
+      {{- if $argocdApiTokenSecret }}
+      - name: argocd-api-token
+        secret:
+          secretName: {{ $argocdApiTokenSecret }}
+      {{- end }}
 

--- a/charts/kube9-operator/values.schema.json
+++ b/charts/kube9-operator/values.schema.json
@@ -40,7 +40,24 @@
             "timeoutMs": { "type": "integer", "minimum": 1000, "default": 30000 },
             "tlsInsecure": { "type": "boolean", "default": false },
             "serverServiceName": { "type": "string", "default": "argocd-server" },
-            "tokenFile": { "type": "string" }
+            "tokenFile": { "type": "string", "description": "Advanced override for ARGOCD_API_TOKEN_FILE without chart-managed Secret mount" },
+            "token": {
+              "type": "object",
+              "description": "Reference an existing Secret for a dedicated Argo CD API bearer token (M17 resource-tree)",
+              "properties": {
+                "existingSecret": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Name of an existing Secret in the release namespace. Empty = default-off (no mount)"
+                },
+                "existingSecretKey": {
+                  "type": "string",
+                  "default": "token",
+                  "description": "Key within existingSecret holding the bearer token"
+                }
+              },
+              "additionalProperties": false
+            }
           },
           "additionalProperties": false
         }

--- a/charts/kube9-operator/values.yaml
+++ b/charts/kube9-operator/values.yaml
@@ -63,7 +63,13 @@ argocd:
     tlsInsecure: false
     # Kubernetes Service name segment for derived URL when baseUrl is empty and Argo CD is detected
     serverServiceName: argocd-server
-    # Optional bearer token file (defaults to in-cluster SA token path when readable)
+    # Dedicated Argo CD API bearer token (M17 resource-tree). Platform admin creates the Secret out-of-band.
+    token:
+      # Name of an existing Secret in the release namespace. Empty/unset = no mount (default-off).
+      existingSecret: ""
+      # Key within that Secret holding the bearer token string.
+      existingSecretKey: token
+    # Advanced: override ARGOCD_API_TOKEN_FILE path without chart-managed Secret mount.
     # tokenFile: ""
 
 # Optional Trivy server detection (does not install Trivy; set serverUrl to probe)


### PR DESCRIPTION
## Summary

- Add `argocd.api.token.existingSecret` / `existingSecretKey` Helm values (default-off) for platform admins to reference an out-of-band Argo CD API bearer Secret.
- When configured, the Deployment volume-mounts the Secret key at `/var/run/secrets/kube9/argocd-api-token` and sets `ARGOCD_API_TOKEN_FILE` to that path (no chart-created Secret, no `secretKeyRef`).
- Update chart README with Secret shape, RBAC example, mount-failure behavior, missing-token onboarding, and helm template tests.

Closes #152

## Test plan

- [x] `npm ci && npm test && npm run lint && npm run build`
- [x] `node scripts/validate-chart.js`
- [x] `helm template` default-off: no `ARGOCD_API_TOKEN_FILE` or `argocd-api-token` mount
- [x] `helm template --set argocd.api.token.existingSecret=kube9-argocd-api-token`: env + Secret volume + mount path present