### PR TITLE
docs(ai): kube9-desktop-ai-debugging-agent-tools-v2 contract updates

### DIFF
--- a/.ai/business_logic/domain_model.md
+++ b/.ai/business_logic/domain_model.md
@@ -87,3 +87,25 @@ The evaluator must prefer `not-evaluated` or `needs-evidence` over inference whe
 5. Security posture (future, 24h)
 
 **Implementation**: Intervals configured via Helm values (`charts/kube9-operator/values.yaml`) and enforced with minimums. Collections scheduled with random offsets (0-1 hour) to distribute load. Default intervals: 86400s (24h), 21600s (6h), 43200s (12h).
+
+## Queryable history for agent and client consumers
+
+Paid Desktop products and vscode extensions may **co-consume** the same operator query surfaces for retained **events** and **assessments history**. The operator owns what those histories mean, which filters apply, and the retention outcomes below. Desktop owns debug playbooks, diagnostic report shape, and tool-loop strategy. This path does **not** add a presence mode beyond basic/operated, and does **not** add AssessmentRunState or CheckStatus values.
+
+### User-visible retention outcomes
+
+| History | User-visible promise | Notes |
+|---------|----------------------|-------|
+| Events | Severity-split defaults: **7** days for info/warning, **30** days for error/critical | Honest advertised window for agent/evidence outcomes that cite Operator history. Knobs and cleanup schedule live in data/runtime contracts. |
+| Assessments history | **No** time-based retention SLA in this product surface | Rows persist until explicit remove or cascade delete of the parent assessment. Consumers may rely only on whatever is still stored. Empty or partial assessment history is a normal gap. |
+
+### Non-goals (agent-consumer path)
+
+- Operator capture, retention, or query of pod/container **logs** (separate product epic; not part of this domain surface)
+- Recovery of logs already pruned from the live Kubernetes API
+- Any agent or query path that mutates cluster state (apply, patch, delete)
+
+### Open implementation decisions
+
+- **Consumer naming in operator docs:** Whether user-facing operator docs list Desktop/agent alongside vscode as first-class query consumers (wording only; integration owns CLI consumer list).
+- **Assessment-history framing in issues:** Exact acceptance phrasing that assessment history is a posture/history signal, not a live incident log stream (see `user_stories.md`).

--- a/.ai/business_logic/error_handling.md
+++ b/.ai/business_logic/error_handling.md
@@ -66,3 +66,19 @@
 - **Retry behavior**: Failed collections retry on next scheduled interval (no immediate retry)
 - **Error handling**: Errors logged, metrics recorded, scheduler continues
 - **Implementation**: Collection tasks registered with `CollectionScheduler` (`src/collection/scheduler.ts`), errors caught in task callbacks
+
+## Queryable history for agent and client consumers
+
+### Empty history vs failure
+- **Success with zero rows**: Valid outcome when filters match nothing or retained rows have aged out / been removed. Does not change operator `health`. Clients report an evidence gap, not an operator failure.
+- **Operator unhealthy or absent**: Consumers fall back per presence/`error_state.md` (toward basic). Tiered agent tooling that depends on history is gated off; live Kubernetes debugging paths remain independent of operator history.
+- **Query / exec / RBAC transport failure**: Distinct from empty history. Surface as consumer-side query failure (integration CLI/exec contracts); do not conflate with "no matching retained rows."
+- **Assessment history gaps**: Empty or partial assessment history after a successful query is a normal gap (no time-based retention SLA). Same success-vs-failure distinction as events.
+
+### Non-goals
+- No error or recovery path that implies operator-held pod/container logs or pruned-log restoration.
+- History query failures must not be framed as cluster-mutation or write failures; query paths remain read-only for agent consumers.
+
+### Open implementation decisions
+
+- **Consumer error copy:** Exact Desktop/vscode strings for empty history vs exec/RBAC failure stay in peer interface contracts; operator BL only distinguishes outcome classes.

--- a/.ai/business_logic/error_state.md
+++ b/.ai/business_logic/error_state.md
@@ -25,6 +25,8 @@
 - **degraded** → reserved for future operator-side semantics
 - **unhealthy** → show error message, fall back to basic mode (kubectl-only)
 
+Empty events or assessments-history query results do **not** change operator health. Absence of matching retained rows is a consumer evidence gap, not an unhealthy signal (see `error_handling.md`).
+
 ## Stale Status
 - **Threshold**: `lastUpdate > 5 minutes` → treat as degraded regardless of reported health
 - **Rationale**: If status hasn't updated in 5+ minutes, operator may be down or unhealthy

--- a/.ai/business_logic/index.md
+++ b/.ai/business_logic/index.md
@@ -5,9 +5,10 @@ Core domain behavior and rules for the kube9-operator.
 - **Presence modes**: basic (no operator), operated (installed)
 - **Assessment**: WAF pillars, check lifecycle, run states
 - **Data collection**: Cluster metadata, resource inventory, config patterns (M8)
+- **Queryable history consumers**: Desktop/agent and vscode co-consume events list and assessments history; operator owns history semantics and retention outcomes (events 7/30 severity-split; assessments best-effort stored)
 
 ## Child Docs
-- [domain_model.md](domain_model.md) — Presence modes, assessment lifecycle, collection categories
-- [user_stories.md](user_stories.md) — Status, ArgoCD, events, collection scenarios
+- [domain_model.md](domain_model.md) — Presence modes, assessment lifecycle, collection categories, agent-consumer history outcomes
+- [user_stories.md](user_stories.md) — Status, ArgoCD, events, assessment history, collection scenarios
 - [error_state.md](error_state.md) — Health values, extension behavior
-- [error_handling.md](error_handling.md) — Graceful degradation, retries
+- [error_handling.md](error_handling.md) — Graceful degradation, retries, empty-history vs query failure

--- a/.ai/business_logic/user_stories.md
+++ b/.ai/business_logic/user_stories.md
@@ -83,7 +83,7 @@
 - **Metrics**: Events tracked with Prometheus metrics (events_stored_total, events_errors_total)
 
 ### Query Capabilities
-Events queryable via CLI (`kube9 events list`) with filters:
+Events queryable via CLI (`kube9 events list` / `kube9-operator query events list`) with filters:
 - **type**: Filter by event type (cluster, operator, insight, assessment, health, system)
 - **severity**: Filter by severity (info, warning, error, critical)
 - **since/until**: Filter by date range (ISO 8601 datetime)
@@ -92,7 +92,28 @@ Events queryable via CLI (`kube9 events list`) with filters:
 - **objectName**: Filter by Kubernetes object name
 - **limit/offset**: Pagination support (max 1000 per query)
 
+### Agent and Desktop co-consumers
+- Desktop Pro AI agent tools and vscode are **co-consumers** of the same events query surface. The operator does not own debug playbooks or diagnostic synthesis.
+- Agents read **already retained** events. This path does not expand cluster-event recording and does not add log capture.
+- **Retention outcome (user-visible):** info/warning events are retained for **7** days by default; error/critical for **30** days. Product copy that cites Operator history for agent/evidence must match this severity-split window (not a longer single-number promise).
+- **Empty history is success:** A successful query that returns zero matching rows is a valid outcome (for example nothing retained in range, or rows already pruned). It is not an operator unhealthy/error state. Clients may treat absence of history as an evidence gap.
+
 **Implementation**: Event types and severities defined in `src/types/event.ts`. Recording via `EventRecorder` (`src/events/event-recorder.ts`), queue processing via `EventQueueWorker` (`src/events/queue-worker.ts`), querying via `EventRepository` (`src/database/event-repository.ts`), CLI commands in `src/cli/commands/events.ts`.
+
+## Assessment History Query
+
+### Capabilities
+Assessment check history is queryable via CLI (`kube9-operator query assessments history`) with filters such as pillar, result, severity, since, and limit (see integration API contracts for the command surface).
+
+### Agent and Desktop co-consumers
+- Desktop Pro AI agent tools and vscode may consume assessments history as a **posture / historical check signal**, not as a live incident log stream. Diagnostic playbooks and root-cause synthesis remain Desktop-owned.
+- **Retention outcome (user-visible):** No new time-based TTL for assessment history. Rows remain until explicit remove or cascade with the parent assessment. Agents and contracts may rely only on whatever is still stored.
+- **Empty or partial history is success:** Zero matching rows after a successful query is a normal gap, not a retention SLA failure and not an operator unhealthy state.
+
+### Non-goals (this surface)
+- Operator log capture, log retention tables, or log query for agent consumers
+- Promising recovery of pruned live-API logs via operator history
+- Agent-driven cluster mutation through operator query paths
 
 ## Data Collection (M8)
 
@@ -120,3 +141,9 @@ Events queryable via CLI (`kube9 events list`) with filters:
 - **Statistics**: Collection success/failure tracked in `CollectionStatsTracker` and exposed in status ConfigMap
 
 **Implementation**: Collectors initialized in `src/operator.ts`, scheduled via `CollectionScheduler`, stored locally via `LocalStorage` (`src/collection/storage.ts`).
+
+## Open implementation decisions
+
+- **Assessment-history story acceptance:** Exact Given/When/Then wording that agent consumers treat assessments history as posture/history signal (not live incident log), and that empty rows are a valid success gap.
+- **Events retention copy coordination:** Desktop evidence-footer / Pro retention microcopy must state 7/30 severity-split; operator BL states the outcome, Desktop interface owns chip/footer strings.
+- **Agent filter subset:** Which events-list and assessments-history filters agents typically pass vs the full CLI filter set (coordinate with integration; not a new domain entity).

--- a/.ai/data/consistency.md
+++ b/.ai/data/consistency.md
@@ -63,11 +63,32 @@ Events are automatically cleaned up based on severity and age:
 - **Cleanup schedule**: Runs every 6 hours via `RetentionCleanup` service
 - **Immediate execution**: Cleanup runs immediately on service start, then on schedule
 
+### Agent and Desktop consumers of event history
+
+Desktop Pro debugging (and other agent tooling) that reads operator event history via the existing query CLI may treat the **severity-split defaults above (7 / 30 days)** as the **advertised consumer retention window**:
+
+- After prune, matching event rows are gone. Operator history cannot recover pruned events.
+- There is no single fixed “N days” in the data plane. Severity selects the band. Product surfaces that say “retained N days” must map to this split (or state both bands), not invent a third window.
+- Overrides via Helm/env change the effective store window. Consumers that need a hard bound should filter with `--since` / `--until` against still-stored rows, not assume a SLA beyond what remains after cleanup.
+- Empty or partial event history (prune, operator absent, persistence disabled / ephemeral volume) is a normal gap for history consumers. Live cluster reads remain the debugging baseline outside this store.
+
+### Assessment retention (no time-based TTL)
+
+`assessments` and `assessment_history` are **not** time-pruned by `RetentionCleanup` or any assessment TTL:
+
+- Rows persist until an explicit remove or parent cascade (`assessment_history` follows `assessments` via `ON DELETE CASCADE`).
+- Agent and Desktop consumers of `query assessments history` (and related assessment query paths) may rely **only on whatever is still stored**. Empty or partial assessment history is a normal gap, not a retention SLA.
+- This epic does **not** introduce an assessment TTL or a product retention window for assessment rows.
+
+### Log storage (out of scope)
+
+The operator SQLite model does **not** store pod or workload container logs. There is no log table, log retention policy, or pruned-log recovery path in this data plane. Log evidence for debugging agents comes from live Kubernetes API reads (Desktop Tier 1), not from operator history.
+
 ### Retention Cleanup Implementation
 
 - **Service**: `RetentionCleanup` class in `src/database/retention-cleanup.ts`
 - **Scheduled job**: Runs every 6 hours (`6 * 60 * 60 * 1000` milliseconds)
-- **Deletion queries**: Separate queries for info/warning vs error/critical events
+- **Deletion queries**: Separate queries for info/warning vs error/critical events (events table only)
 - **Logging**: Logs number of events deleted per cleanup run
 
 ### Configuration Sources
@@ -103,4 +124,9 @@ Retention days can be configured via:
 - **Privacy by default**: Raw data never leaves cluster
 - **ACID compliance**: SQLite provides transaction guarantees
 - **Referential integrity**: Foreign keys ensure data consistency
-- **Automatic cleanup**: Retention policies prevent unbounded growth
+- **Automatic cleanup**: Event retention policies prevent unbounded growth of the events table; assessments rely on explicit remove / cascade, not time prune
+
+## Open implementation decisions
+
+- **Assessment prune policy (if ever introduced):** days-by-severity or single window; whether prune targets `assessments` only (cascade history) vs both tables; cleanup schedule alignment with `RetentionCleanup`; Helm/env knobs and migration of consumer prose. Not product-committed now. Resolve via `/refine-issue` if a future epic adds TTL.
+- **Consumer-visible retention bounds on query results:** whether CLI/JSON should expose effective retention windows or “as of” bounds for agent tooling (field shapes). Contract intent today is filter-against-stored-rows only; no new result metadata required for current Desktop Tier 2 wrap.

--- a/.ai/data/data_model.md
+++ b/.ai/data/data_model.md
@@ -106,6 +106,8 @@ Nested under `OperatorStatus.aiConformance`. This is the client-facing readiness
 
 Framework assessment run records.
 
+**Retention (agent / Desktop consumers):** No time-based TTL. Rows persist until explicit remove or cascade. History consumers may rely only on whatever is still stored. See [consistency.md](consistency.md).
+
 | Column | Type | Constraints | Description |
 |--------|------|-------------|-------------|
 | run_id | TEXT | PRIMARY KEY | Unique assessment run identifier |
@@ -132,6 +134,8 @@ Framework assessment run records.
 ### assessment_history
 
 Individual check results from assessment runs.
+
+**Retention:** Follows parent `assessments` via `ON DELETE CASCADE`. No separate time-based prune. See [consistency.md](consistency.md).
 
 | Column | Type | Constraints | Description |
 |--------|------|-------------|-------------|
@@ -161,6 +165,8 @@ Individual check results from assessment runs.
 
 Event history for cluster, operator, assessment, health, and system events.
 
+**Retention (agent / Desktop consumers):** Severity-split defaults (info/warning **7** days, error/critical **30** days) are the advertised consumer window. Pruned rows are gone. See [consistency.md](consistency.md).
+
 | Column | Type | Constraints | Description |
 |--------|------|-------------|-------------|
 | id | TEXT | PRIMARY KEY | Event identifier (format: `evt_YYYYMMDD_HHMMSS_<random>`) |
@@ -179,6 +185,10 @@ Event history for cluster, operator, assessment, health, and system events.
 - `idx_events_severity` ON `events(severity)`
 - `idx_events_created_at` ON `events(created_at DESC)`
 - `idx_events_object_kind` ON `events(object_kind, object_namespace, object_name)`
+
+### Log entities
+
+None. Operator SQLite does not model pod/workload container logs. Debugging log evidence is out of band for this store (live Kubernetes API via Desktop). Do not add log tables under this epic.
 
 ### schema_version
 

--- a/.ai/data/index.md
+++ b/.ai/data/index.md
@@ -5,9 +5,10 @@ How data is modeled, persisted, serialized, and kept consistent.
 - **Status**: ConfigMap (kube9-operator-status)
 - **Rich data**: SQLite at /data/kube9.db (events, assessments; vulnerability scans; collections table specified in M8 — [issue #53](https://github.com/alto9/kube9-operator/issues/53); argocd_apps planned)
 - **Query**: CLI via kubectl exec
+- **Agent / Desktop history consumers**: Durable events and assessment rows stay in operator SQLite. Advertised event retention for those consumers is the severity-split window in [consistency.md](consistency.md) (7 days info/warning, 30 days error/critical). Assessments have no time-based TTL. Operator does not store pod/workload logs.
 
 ## Child Docs
-- [data_model.md](data_model.md) — Operator status, collection models, SQLite schema
-- [persistence_abstractions.md](persistence_abstractions.md) — Dual storage, PVC
-- [serialization.md](serialization.md) — CLI formats, JSON schema
-- [consistency.md](consistency.md) — Data lifecycle phases
+- [data_model.md](data_model.md) — Operator status, collection models, SQLite schema; agent-consumer retention pointers on events and assessments
+- [persistence_abstractions.md](persistence_abstractions.md) — Dual storage, PVC; durable history assumes PVC (emptyDir = ephemeral gap)
+- [serialization.md](serialization.md) — CLI formats, JSON schema; query surfaces for history consumers
+- [consistency.md](consistency.md) — Retention, agent-consumer reliability bounds, lifecycle phases

--- a/.ai/data/persistence_abstractions.md
+++ b/.ai/data/persistence_abstractions.md
@@ -52,6 +52,10 @@ Helm chart configuration:
 
 When persistence is disabled (`events.persistence.enabled = false`), uses `emptyDir` volume (ephemeral, lost on pod restart).
 
+### Durable history for agent / Desktop consumers
+
+Queryable event and assessment history for Desktop Tier 2 (and similar agents) assumes chart-default PVC-backed SQLite at `/data/kube9.db`. With `emptyDir` (persistence disabled) or a missing/unhealthy operator, treat history as degraded or absent: empty results are expected, not a store failure to invent. Desktop does not own a peer durable ledger of operator rows. Retention semantics for still-stored rows are in [consistency.md](consistency.md).
+
 ## Single Binary, Dual Modes
 
 ```

--- a/.ai/data/serialization.md
+++ b/.ai/data/serialization.md
@@ -29,6 +29,20 @@ kube9-operator query <subcommand>
 - `kube9-operator query events get <eventId>` - Get single event by ID
   - Options: `--format <json|yaml|table>` (default: json)
 
+Agent and Desktop history consumers use these existing event list/get shapes. Results reflect **currently stored** rows after event retention prune (see [consistency.md](consistency.md)). Output does not carry a separate retention-window field today.
+
+### Assessment query commands (history consumers)
+
+```
+kube9-operator query assessments <subcommand>
+```
+
+Normative query surface for co-consumers (Desktop, vscode, agents) is documented under integration `api_contracts.md`, including:
+
+- `query assessments list|get|summary|history` with the filter and `--format` options listed there
+
+Assessment history serialization is “rows still present,” not a time-bounded SLA. No assessment TTL metadata is required on responses.
+
 ### Assessment Commands
 
 ```
@@ -127,3 +141,8 @@ Extension reads `status` key from ConfigMap `kube9-operator-status` in operator 
 ## Collection Payloads
 
 M8 collectors store data as JSON blobs in `collections` table. Schema validated before storage. (Note: collections table not yet implemented in current schema)
+
+## Open implementation decisions
+
+- **Retention / “as of” bounds on serialized query results:** whether event (or assessment) list/get JSON should expose effective retention windows or query “as of” bounds for agent tooling. Not required for current Desktop wrap of existing CLI. Field-level shapes deferred to `/refine-issue` if product chooses to surface them.
+- **`--since` value forms for agent filters:** relative durations vs ISO-datetime validation on the operator CLI (peer Desktop may pass relative forms). Serialization contract stays ISO-oriented until a refine-issue lands an explicit dual form.

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -63,10 +63,22 @@ Clients must tolerate an absent `aiConformance` block until operator versions th
 
 **Command Format**: `kubectl exec -n <namespace> deploy/kube9-operator -- kube9-operator query <command>`
 
+**Consumers** (same wire path, same RBAC model):
+- **kube9-vscode**: extension host historical queries and dashboards
+- **kube9-desktop**: Pro historical context assembly and Desktop Pro AI agent Tier 2 tools that wrap `query events list` and `query assessments history` (no Desktop→operator HTTP; no new query subcommands for agent debugging)
+
+**Non-breaking stance**: Command names, JSON default format, and existing filter flags for `events list` and `assessments history` are a stable peer contract for Desktop Tier 2. Prefer additive changes. Intentional breaking CLI/JSON changes belong to a separate operator initiative, not agent wrapping.
+
+**Explicit non-goal (log query)**: This surface does **not** include `query logs*` (or equivalent). The operator does not expose a log query / failure-log capture CLI for agent or extension consumers here. Live pod logs remain a client Kubernetes API concern (Desktop Tier 1). Pruned-log recovery via operator is a future epic, not promised by this contract.
+
+**Consumer-facing event retention** (for evidence and agent copy; authoritative knobs in data/runtime):
+- Default severity-split event retention: **7** days info/warning, **30** days error/critical (Helm `events.retention.*` / env; cleanup every 6h). See [`.ai/data/consistency.md`](../data/consistency.md) and [`.ai/runtime/configuration.md`](../runtime/configuration.md).
+- Assessment history: no time-based prune in current product stance; rows persist until explicit remove/cascade. Empty or partial history is a normal query outcome, not a retention SLA.
+
 **Pod Resolution**:
-- Extension uses deployment name `kube9-operator` (or full name from Helm chart)
+- Consumers use deployment name `kube9-operator` (or full name from Helm chart)
 - Kubernetes resolves `deploy/kube9-operator` to the active pod automatically
-- Extension requires `get` permission on deployments in operator namespace for pod discovery
+- Consumers require `get` permission on deployments in operator namespace for pod discovery
 
 **Available Query Commands**:
 
@@ -81,6 +93,8 @@ kube9-operator query events list [--type=<type>] [--severity=<severity>] [--sinc
 kube9-operator query events get <eventId> [--format=json|yaml|table]
 ```
 
+**JSON shape (events list, programmatic default)**: Object with `events` (array) and `pagination` (`total`, `limit`, `offset`, `returned`). Field-level redaction beyond existing storage rules is not introduced for agent consumers.
+
 **Assessments Query**:
 ```bash
 kube9-operator query assessments list [--state=<state>] [--limit=<number>] [--since=<ISO8601>] [--format=json|yaml|table|compact]
@@ -88,6 +102,8 @@ kube9-operator query assessments get <assessmentId> [--format=json|yaml|table|co
 kube9-operator query assessments summary [--since=<ISO8601>] [--limit=<number>] [--format=json|yaml|table|compact]
 kube9-operator query assessments history [--pillar=<pillar>] [--result=<result>] [--severity=<severity>] [--limit=<number>] [--since=<ISO8601>] [--format=json|yaml|table|compact]
 ```
+
+**JSON shape (assessments history, programmatic default)**: Object with `history` (array) and `pagination` (`total`, `limit`, `offset`, `returned`). Agents may rely only on rows still stored.
 
 **Output Formats**:
 - `json` (default): JSON output for programmatic consumption
@@ -227,3 +243,11 @@ kube9-operator query argocd apps get <appNamespace>/<appName> [--format=json|yam
 ```
 
 Reads SQLite `argocd_apps` snapshots (M9 application status collection). Independent of resource-tree on-demand fetch.
+
+## Open implementation decisions
+
+**Desktop AI agent / CLI query alignment (tier TW, refine-issue):**
+
+- **`--since` relative vs ISO**: Operator CLI validates `--since` / `--until` with ISO-8601 datetime (`z.string().datetime()` on events list and assessment history). Desktop `kube9OperatorQueryClient` defaults `--since=24h` for `events-list`. Decide whether the operator adds relative-duration acceptance (additive) or Desktop always converts relative windows to absolute ISO before exec; document the agent tool parameter mapping either way.
+- **Agent tool filter subset vs full CLI**: Which `events list` / `assessments history` flags Desktop agent tools expose (object filters, severity, pillar, limit/offset caps, defaults) vs pass-through of the full CLI surface.
+- **Timeouts / exec failure mapping**: Numeric kubectl-exec timeouts and structured stderr/`code` conventions for agent tool results remain refine-issue detail (Desktop already has operator query failure codes). Operator-side notes only if CLI error envelopes need agent-facing stabilization beyond current events/assessments JSON errors.

--- a/.ai/integration/authorization.md
+++ b/.ai/integration/authorization.md
@@ -45,7 +45,9 @@
 
 **Binding**: `RoleBinding` binds ServiceAccount to Role in operator namespace
 
-### Extension User RBAC
+### Extension / Desktop User RBAC
+
+**Applies to**: kube9-vscode extension users and kube9-desktop (including Desktop Pro AI agent Tier 2 operator queries). Same permission set; no separate agent auth model.
 
 **Required Permissions**:
 
@@ -61,8 +63,9 @@
 - `create` on `pods/exec` subresource in operator namespace
 - Required for executing `kubectl exec` commands into operator pod
 - Format: `kubectl exec -n <namespace> deploy/kube9-operator -- kube9-operator query <command>`
+- Agent-facing history uses the same exec path (`query events list`, `query assessments history`); auth is unchanged for agent debugging tools
 
-**Example RoleBinding** (for extension users):
+**Example RoleBinding** (for extension / Desktop users):
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -115,10 +118,11 @@ rules:
 - Argo CD: Detection uses the Kubernetes API (`src/argocd/detection.ts`). **M9** adds read-only HTTP to in-cluster `argocd-server` for Application list/status into SQLite. **M17** adds on-demand `GET /api/v1/applications/{name}/resource-tree` at CLI query time. All Argo CD HTTP is **zero ingress** (cluster-internal egress).
 - **M17 resource-tree auth:** Dedicated Argo CD API bearer only (`ARGOCD_API_BEARER_TOKEN` or `ARGOCD_API_TOKEN_FILE`). The resource-tree path **must not** fall back to the operator Kubernetes ServiceAccount token. Platform admin creates a Secret out-of-band and sets Helm `argocd.api.token.existingSecret` / `existingSecretKey` (default key `token`); the chart mounts the key at `/var/run/secrets/kube9/argocd-api-token` and sets `ARGOCD_API_TOKEN_FILE`. Unset `existingSecret` is default-off. Platform admin grants Argo CD RBAC `get` on Applications (resource-tree) for the token identity; the kube9-operator chart does not mutate Argo CD roles.
 
-**Extension → Operator** (via kubectl):
+**Extension / Desktop → Operator** (via kubectl):
 - ConfigMap read: Direct Kubernetes API access (no ingress)
-- CLI exec: Direct `kubectl exec` into pod (no ingress)
+- CLI exec: Direct `kubectl exec` into pod (no ingress), including Desktop AI agent Tier 2 history queries
 - All communication uses standard Kubernetes mechanisms
+- No agent-specific ingress, token exchange, or hosted SaaS path for operator history
 
 **Outbound connections (operator core)**:
 - Kubernetes API (in-cluster or via kubeconfig)
@@ -130,3 +134,7 @@ rules:
 - No external IPs or load balancers needed
 - Works in air-gapped environments (open-source operator path)
 - Simplified network security (egress-only)
+
+## Open implementation decisions
+
+- **Agent auth model**: Closed for this epic. Desktop AI agent Tier 2 uses the same Extension / Desktop User RBAC and kubectl-exec path; no new Role, ClusterRole, or token type.

--- a/.ai/integration/external_systems.md
+++ b/.ai/integration/external_systems.md
@@ -111,16 +111,16 @@ Exposed in ConfigMap `kube9-operator-status` under `status.argocd`:
 - Provides `/healthz` (liveness), `/readyz` (readiness), and `/metrics` endpoints
 - Started early during operator initialization for probe availability
 
-## kube9-vscode
+## In-cluster clients (kube9-vscode and kube9-desktop)
 
-**Primary Consumer**: VS Code extension that integrates with kube9-operator
+**Consumers**: kube9-vscode and kube9-desktop share the same zero-ingress integration path (ConfigMap read + `kubectl exec` CLI query). Desktop Pro AI agent Tier 2 tools are a co-consumer of `query events list` and `query assessments history` on that path; they do not introduce a separate HTTP or SaaS hop.
 
 **Integration Points**:
 
 1. **Operator detection**:
    - Reads `kube9-operator-status` ConfigMap to determine whether the operator is installed and healthy
    - `basic`: No operator / no status ConfigMap
-   - `operated`: Operator installed; extension uses status JSON for dashboards and workflows
+   - `operated`: Operator installed; clients use status JSON for dashboards, workflows, and (Desktop) capability gating for Tier 2 agent tools
 
 2. **Status monitoring**:
    - Reads ConfigMap for operator health status
@@ -129,17 +129,22 @@ Exposed in ConfigMap `kube9-operator-status` under `status.argocd`:
 
 3. **Rich Data Queries**:
    - Executes CLI commands via `kubectl exec` for:
-     - Event history (`query events list`)
-     - Assessment results (`query assessments summary`, `query assessments history`)
+     - Event history (`query events list`): vscode, Desktop historical context, and Desktop AI agent Tier 2
+     - Assessment results (`query assessments summary`, `query assessments history`): same consumer set for history; agent wraps history for debugging turns
      - Detailed status (`query status`)
+   - **Non-goal**: No operator log query surface for these clients. Live logs stay on the Kubernetes API path in the client (Desktop Tier 1).
 
-4. **RBAC Requirements**:
+4. **RBAC Requirements** (unchanged; see [authorization.md](authorization.md)):
    - `get` permission on `configmaps` named `kube9-operator-status` in operator namespace
    - `get` permission on `deployments` in operator namespace (for pod discovery)
    - `create` permission on `pods/exec` in operator namespace (for CLI queries)
 
+5. **Retention narrative for consumers**:
+   - Event history available to query is bounded by default severity-split retention (**7** days info/warning, **30** days error/critical). See [api_contracts.md](api_contracts.md) CLI Exec Contract and [`.ai/data/consistency.md`](../data/consistency.md).
+   - Assessment history has no time-based prune commitment for agent consumers; empty/partial results are normal.
+
 **Discovery Flow**:
-1. Extension checks default namespace (`kube9-system`) for ConfigMap
+1. Client checks default namespace (`kube9-system`) for ConfigMap
 2. If found, reads `status.namespace` field
 3. Uses discovered namespace for all subsequent operations
 4. Resolves operator pod via deployment name `kube9-operator`

--- a/.ai/integration/index.md
+++ b/.ai/integration/index.md
@@ -5,10 +5,10 @@ How the operator connects to external APIs and systems.
 - **Kubernetes**: Cluster resources, ConfigMap, in-cluster config
 - **ArgoCD**: Detection (CRD check, namespace check, deployment verification), periodic refresh (6h default), configuration via environment variables; Application status (M9)
 - **Prometheus**: Metrics endpoint (`/metrics`), auto-detection; Endpoint override (M1 planned)
-- **kube9-vscode**: Primary consumer via ConfigMap read and CLI exec
+- **In-cluster consumers**: kube9-vscode and kube9-desktop (including the Desktop Pro AI agent) via ConfigMap read and CLI exec (`kubectl exec` → `kube9-operator query …`)
 
 ## Child Docs
-- [api_contracts.md](api_contracts.md) — Extension↔operator contracts (ConfigMap read, CLI exec, Assessment API)
-- [external_systems.md](external_systems.md) — Kubernetes API, ArgoCD detection/configuration, Prometheus metrics, kube9-vscode integration
-- [authorization.md](authorization.md) — RBAC (operator ClusterRole/Role, extension user permissions), zero ingress architecture
-- [messaging_async.md](messaging_async.md) — Event queue (EventRecorder, EventQueueWorker, non-blocking recording)
+- [api_contracts.md](api_contracts.md): Extension/Desktop↔operator contracts (ConfigMap read, CLI exec, Assessment API); agent co-consumer of events list and assessments history
+- [external_systems.md](external_systems.md): Kubernetes API, ArgoCD detection/configuration, Prometheus metrics, kube9-vscode and kube9-desktop integration
+- [authorization.md](authorization.md): RBAC (operator ClusterRole/Role, extension/Desktop user permissions), zero ingress architecture
+- [messaging_async.md](messaging_async.md): Event queue (EventRecorder, EventQueueWorker, non-blocking recording)

--- a/.ai/operations/build_packaging.md
+++ b/.ai/operations/build_packaging.md
@@ -65,9 +65,19 @@ The Helm chart supports comprehensive configuration through `values.yaml`:
 - `events.retention.infoWarning`: Retention period for info/warning events in days (default: `7`)
 - `events.retention.errorCritical`: Retention period for error/critical events in days (default: `30`)
 
+**Advertised retention for agent / Desktop history consumers:** Chart defaults above are the product-visible event windows (info/warning **7** days, error/critical **30** days). Peer clients that cite Operator history must match this severity-split pair. There is no single unified day count in packaging. Overrides via Helm/env remain supported; changing defaults is out of scope for agent-debugging packaging.
+
+**Packaging non-goals (agent-consumer path):**
+- No Helm values, PVC sizing, or image packaging for operator **log** capture or failure-log retention
+- No assessment-history TTL / prune knobs in the chart (assessments persist until explicit remove or cascade; data owns lifecycle)
+
 #### Namespace
 - **Default Namespace**: `kube9-system`
 - Configurable via `--namespace` flag during Helm install
+
+### Open implementation decisions
+
+- **Footer vs dual retention:** Desktop evidence-footer microcopy for “retained N days” should not invent a packaging single-N default; refine-issue may add a short chart README note that consumers should state both bands (7 and 30) when paraphrasing policy.
 
 ## Docker Image
 

--- a/.ai/operations/deployment_environments.md
+++ b/.ai/operations/deployment_environments.md
@@ -81,3 +81,18 @@ Shared local cluster for **kube9-vscode** and **kube9-operator** development: [k
 
 - Host-run dev: `LOG_LEVEL`, `DB_PATH` (defaults to `./.kube9-data` when unset in `npm run dev` / `dev:watch`), `POD_NAMESPACE`, `HEALTH_PORT` (default `8080`); see `.env.example`.
 - In-cluster: override via Helm values (e.g. `logLevel: debug`) on install/upgrade.
+
+## Agent / Desktop history consumers (availability)
+
+Desktop and other clients may query retained events and assessments history via the existing in-pod CLI (`kubectl exec`). Delivery posture for that path:
+
+- **Optional for Pro debugging:** Product acceptance for debugging does not require operator install. Operator absence or unreadiness is a Tier 2 gap, not a failed delivery environment.
+- **Best-effort when ready + PVC:** Queryable history is available when the operator Deployment is ready and SQLite is on the chart-default PersistentVolumeClaim (`events.persistence.enabled = true`). No HA, multi-replica, or external query SLA for agent consumers.
+- **Persistence disabled:** With `events.persistence.enabled = false` (`emptyDir`), history is ephemeral across pod restarts. Consumers treat that as operator-history degraded or absent, not as a separate environment tier.
+- **No log-capture ops:** Operations contracts do not add log retention, log PVC sizing, failure-log capture runbooks, or pruned-log recovery. That remains a separate epic.
+- **Assessment history:** No ops-owned time-based TTL or cleanup schedule for assessment rows. Storage growth under frequent assessments is a data-domain concern unless a later epic adds policy.
+
+### Open implementation decisions
+
+- **Local dogfood paths:** Whether minikube / kind checklists should call out an explicit operator-present vs operator-absent history query smoke step (Desktop owns acceptance scoring; operator side only needs confirmable query + chart defaults).
+- **emptyDir wording in install docs:** Exact operator install-doc phrasing that persistence-off means ephemeral history for agent/evidence consumers (packaging already documents the volume switch).

--- a/.ai/operations/index.md
+++ b/.ai/operations/index.md
@@ -5,9 +5,10 @@ How the operator is built, deployed, observed, and secured.
 - **Install**: Helm chart, GHCR image
 - **Distribution**: charts.kube9.io, GitHub Actions
 - **Observability**: Prometheus metrics, health checks, logging
+- **Agent / Desktop history consumers**: Best-effort queryable history when the operator is ready and persistence uses the chart default PVC. Advertised event retention stays severity-split **7** / **30** days. No log-capture ops, assessment TTL knobs, or Pro-debugging gate on operator install.
 
 ## Child Docs
-- [build_packaging.md](build_packaging.md) — Helm chart, Docker image
-- [deployment_environments.md](deployment_environments.md) — Chart hosting, image publishing, **local testing** (Minikube via kube9-minikube, kind in test-helm-chart)
+- [build_packaging.md](build_packaging.md) — Helm chart, Docker image; advertised event retention defaults; packaging non-goals for log capture
+- [deployment_environments.md](deployment_environments.md) — Chart hosting, image publishing, **local testing** (Minikube via kube9-minikube, kind in test-helm-chart); agent-consumer availability posture
 - [observability.md](observability.md) — Metrics, health, logging
 - [security.md](security.md) — Zero ingress, minimal RBAC

--- a/.ai/operations/observability.md
+++ b/.ai/operations/observability.md
@@ -250,3 +250,11 @@ Exact metric names and label sets are defined at implementation time and registe
 - Include relevant context in log messages
 - Structured data aids troubleshooting
 - Logs are collected by Kubernetes and can be forwarded to external systems
+
+## Agent / Desktop query consumers
+
+Agent or Desktop wrapping of `query events list` / `query assessments history` does **not** add a new metric taxonomy, scrape contract, or regulated observability band. Existing event and assessment Prometheus series plus `/healthz` / `/readyz` remain the ops surface. Operator process logs (Winston stdout) are unrelated to capturing workload pod logs for agent evidence.
+
+### Open implementation decisions
+
+- **Alert thresholds under query load:** Exact alert thresholds on `kube9_operator_events_dropped_total` / queue depth when clients issue more frequent history queries remain refine-issue backlog, not a packaging or deployment-band change.


### PR DESCRIPTION
Contract-only PR from ideation (`/ideate`).

- **Initiative:** kube9-desktop-ai-debugging-agent-tools-v2
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and cross-repo coherence before merge

Merge before `/plan-roadmap` when downstream work should read merged contracts on `main`.