### PR TITLE
docs(ai): refine issue #159 contract updates

### DIFF
--- a/.ai/business_logic/user_stories.md
+++ b/.ai/business_logic/user_stories.md
@@ -161,4 +161,6 @@ Assessment check history is queryable via CLI (`kube9-operator query assessments
 
 ## Open implementation decisions
 
-- **Events retention copy coordination:** Desktop evidence-footer / Pro retention microcopy must state 7/30 severity-split; operator BL states the outcome, Desktop interface owns chip/footer strings (sibling issue #159).
+### Resolved (events retention copy coordination)
+
+Operator business-logic and integration contracts state the user-visible outcome: info/warning **7** days, error/critical **30** days by default, with cleanup every **6 hours** and Helm/env overrides of the effective store window. kube9-desktop interface contracts own evidence-footer and Pro retention microcopy; those surfaces must cite the severity-split pair (or both bands), not a single longer “N days” promise. No 90-day (or other unified) agent/history retention claim belongs in operator consumer prose.

--- a/.ai/data/consistency.md
+++ b/.ai/data/consistency.md
@@ -129,4 +129,7 @@ Retention days can be configured via:
 ## Open implementation decisions
 
 - **Assessment prune policy (if ever introduced):** days-by-severity or single window; whether prune targets `assessments` only (cascade history) vs both tables; cleanup schedule alignment with `RetentionCleanup`; Helm/env knobs and migration of consumer prose. Not product-committed now. Resolve via `/refine-issue` if a future epic adds TTL.
-- **Consumer-visible retention bounds on query results:** whether CLI/JSON should expose effective retention windows or “as of” bounds for agent tooling (field shapes). Contract intent today is filter-against-stored-rows only; no new result metadata required for current Desktop Tier 2 wrap.
+
+### Resolved (event retention consumer bounds)
+
+Event and assessment query JSON **does not** expose effective retention windows, configured day counts, or query “as of” prune bounds. Agent and Desktop consumers filter with `--since` / `--until` (ISO-8601 on the operator CLI) against **still-stored** rows after `RetentionCleanup`. Helm/env overrides change the effective store window but are not echoed as result metadata in this product surface. A future additive operator epic may introduce optional metadata; that is not committed here.

--- a/.ai/data/serialization.md
+++ b/.ai/data/serialization.md
@@ -144,5 +144,10 @@ M8 collectors store data as JSON blobs in `collections` table. Schema validated 
 
 ## Open implementation decisions
 
-- **Retention / “as of” bounds on serialized query results:** whether event (or assessment) list/get JSON should expose effective retention windows or query “as of” bounds for agent tooling. Not required for current Desktop wrap of existing CLI. Field-level shapes deferred to `/refine-issue` if product chooses to surface them.
-- **`--since` value forms for agent filters:** relative durations vs ISO-datetime validation on the operator CLI (peer Desktop may pass relative forms). Serialization contract stays ISO-oriented until a refine-issue lands an explicit dual form.
+### Resolved (retention metadata on query JSON)
+
+Event list/get and assessments history JSON keep existing shapes (`events` / `history` plus `pagination`). No retention-window, configured-day, or prune “as of” fields are added for agent or Desktop consumers in this epic. Consumers bound queries with `--since` / `--until` against rows still present after severity-split retention (see [consistency.md](consistency.md)).
+
+### Out of scope (operator `--since` value forms)
+
+The operator CLI validates `--since` / `--until` as **ISO-8601 datetimes** only. kube9-desktop converts relative windows (for example `24h`) before exec. Relative-duration aliases on the operator CLI are not part of this serialization contract; see integration [api_contracts.md](../integration/api_contracts.md).

--- a/.ai/operations/build_packaging.md
+++ b/.ai/operations/build_packaging.md
@@ -75,9 +75,9 @@ The Helm chart supports comprehensive configuration through `values.yaml`:
 - **Default Namespace**: `kube9-system`
 - Configurable via `--namespace` flag during Helm install
 
-### Open implementation decisions
+### Consumer retention narrative (chart README)
 
-- **Footer vs dual retention:** Desktop evidence-footer microcopy for “retained N days” should not invent a packaging single-N default; refine-issue may add a short chart README note that consumers should state both bands (7 and 30) when paraphrasing policy.
+`charts/kube9-operator/README.md` under **Event Storage and Retention** documents the agent/Desktop consumer stance: severity-split defaults (**7** / **30** days), cleanup every **6 hours** via `RetentionCleanup`, Helm/env overrides of the effective store window, and that peers must not paraphrase a single “N days” default for evidence copy. kube9-desktop owns evidence-footer chip strings against this peer truth.
 
 ## Docker Image
 

--- a/.ai/runtime/configuration.md
+++ b/.ai/runtime/configuration.md
@@ -64,6 +64,8 @@
   - Default: `30` days
   - Events with error or critical severity are retained for this period
 
+**Agent and Desktop consumers:** These env vars (and Helm `events.retention.*`) define the **effective store window** for `query events list` / `get` after `RetentionCleanup` runs every **6 hours** (plus immediate run on service start). Consumers filter with `--since` / `--until` against still-stored rows; query JSON does not echo configured retention days. See [`.ai/data/consistency.md`](../data/consistency.md).
+
 ### ArgoCD Configuration Environment Variables
 - **ARGOCD_AUTO_DETECT**: Enable automatic ArgoCD detection
   - Default: `true` (unless set to `"false"`)

--- a/charts/kube9-operator/README.md
+++ b/charts/kube9-operator/README.md
@@ -209,6 +209,9 @@ The operator stores Kubernetes events in a SQLite database for insights and dash
 
 - **infoWarning** (default: `7`): Days to retain info and warning events.
 - **errorCritical** (default: `30`): Days to retain error and critical events.
+- **Cleanup:** `RetentionCleanup` prunes expired event rows every **6 hours** and once on operator start. Helm/env overrides above change the effective store window that in-cluster query consumers may filter against.
+
+**Agent and Desktop query consumers:** [kube9-desktop](https://github.com/alto9/kube9-desktop) Pro AI agent Tier 2 tools and [kube9-vscode](https://github.com/alto9/kube9-vscode) read event history via `kubectl exec` → `kube9-operator query events list`. When citing Operator-stored history, product copy must reflect the **severity-split** defaults (**7** days info/warning, **30** days error/critical), not a single unified day count. Bound queries with `--since` / `--until` (ISO-8601 on the operator CLI) against still-stored rows; pruned, absent, or ephemeral-store gaps are normal. Assessment history retention is separate (no time-based TTL on assessment rows).
 
 **PVC vs emptyDir behavior:**
 


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #159
- **Scope:** `.ai` contract updates and chart README consumer retention narrative; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

Merge before `/build-from-github` when implementation should read merged contracts on `main`.