### PR TITLE
docs(ai): refine issue #160 contract updates

### DIFF
--- a/.ai/business_logic/domain_model.md
+++ b/.ai/business_logic/domain_model.md
@@ -97,7 +97,7 @@ Paid Desktop products and vscode extensions may **co-consume** the same operator
 | History | User-visible promise | Notes |
 |---------|----------------------|-------|
 | Events | Severity-split defaults: **7** days for info/warning, **30** days for error/critical | Honest advertised window for agent/evidence outcomes that cite Operator history. Knobs and cleanup schedule live in data/runtime contracts. |
-| Assessments history | **No** time-based retention SLA in this product surface | Rows persist until explicit remove or cascade delete of the parent assessment. Consumers may rely only on whatever is still stored. Empty or partial assessment history is a normal gap. |
+| Assessments history | **No** time-based retention SLA in this product surface | **Posture / historical check signal** for agent and vscode consumers (not a live incident log stream). Rows persist until explicit remove or cascade delete of the parent assessment. Consumers may rely only on whatever is still stored. Empty or partial assessment history is a normal gap. |
 
 ### Non-goals (agent-consumer path)
 

--- a/.ai/data/persistence_abstractions.md
+++ b/.ai/data/persistence_abstractions.md
@@ -54,7 +54,7 @@ When persistence is disabled (`events.persistence.enabled = false`), uses `empty
 
 ### Durable history for agent / Desktop consumers
 
-Queryable event and assessment history for Desktop Tier 2 (and similar agents) assumes chart-default PVC-backed SQLite at `/data/kube9.db`. With `emptyDir` (persistence disabled) or a missing/unhealthy operator, treat history as degraded or absent: empty results are expected, not a store failure to invent. Desktop does not own a peer durable ledger of operator rows. Retention semantics for still-stored rows are in [consistency.md](consistency.md).
+Queryable event and assessment history for Desktop Tier 2 (and similar agents) assumes chart-default PVC-backed SQLite at `/data/kube9.db`. With `emptyDir` (persistence disabled) or a missing/unhealthy operator, treat history as degraded or absent: empty results are expected, not a store failure to invent. Desktop does not own a peer durable ledger of operator rows. Retention semantics for still-stored rows are in [consistency.md](consistency.md): events are severity-split time-pruned; **assessments and `assessment_history` have no time-based TTL** (cascade on parent delete only). Operator SQLite does not store pod/workload logs.
 
 ## Single Binary, Dual Modes
 

--- a/charts/kube9-operator/README.md
+++ b/charts/kube9-operator/README.md
@@ -211,7 +211,11 @@ The operator stores Kubernetes events in a SQLite database for insights and dash
 - **errorCritical** (default: `30`): Days to retain error and critical events.
 - **Cleanup:** `RetentionCleanup` prunes expired event rows every **6 hours** and once on operator start. Helm/env overrides above change the effective store window that in-cluster query consumers may filter against.
 
-**Agent and Desktop query consumers:** [kube9-desktop](https://github.com/alto9/kube9-desktop) Pro AI agent Tier 2 tools and [kube9-vscode](https://github.com/alto9/kube9-vscode) read event history via `kubectl exec` → `kube9-operator query events list`. When citing Operator-stored history, product copy must reflect the **severity-split** defaults (**7** days info/warning, **30** days error/critical), not a single unified day count. Bound queries with `--since` / `--until` (ISO-8601 on the operator CLI) against still-stored rows; pruned, absent, or ephemeral-store gaps are normal. Assessment history retention is separate (no time-based TTL on assessment rows).
+**Agent and Desktop query consumers:** [kube9-desktop](https://github.com/alto9/kube9-desktop) Pro AI agent Tier 2 tools and [kube9-vscode](https://github.com/alto9/kube9-vscode) read event history via `kubectl exec` → `kube9-operator query events list`. When citing Operator-stored history, product copy must reflect the **severity-split** defaults (**7** days info/warning, **30** days error/critical), not a single unified day count. Bound queries with `--since` / `--until` (ISO-8601 on the operator CLI) against still-stored rows; pruned, absent, or ephemeral-store gaps are normal.
+
+**Assessment history (agent/Desktop consumers):** Well-Architected check history is available via `kube9-operator query assessments history`. It is a **posture / historical check signal**, not a live incident log stream. Assessment rows are **not** time-pruned by `RetentionCleanup`; they persist until explicit remove or cascade delete of the parent assessment run. A successful query that returns an empty `history` array is a normal evidence gap, not an operator error.
+
+**Log evidence (explicit non-goal):** This operator does **not** expose `query logs*` (or equivalent) for agent or extension consumers. Pod and workload container logs for debugging agents come from live Kubernetes API reads in the client (Desktop Tier 1), not from operator SQLite history.
 
 **PVC vs emptyDir behavior:**
 


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #160
- **Scope:** `.ai` contract updates and chart README consumer copy; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

Merge before `/build-from-github` when implementation should read merged contracts on `main`.