### PR TITLE
docs(ai): advertise 7/30 event retention for agent and Desktop consumers (#159)

### DIFF
--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -73,6 +73,7 @@ Clients must tolerate an absent `aiConformance` block until operator versions th
 
 **Consumer-facing event retention** (for evidence and agent copy; authoritative knobs in data/runtime):
 - Default severity-split event retention: **7** days info/warning, **30** days error/critical (Helm `events.retention.*` / env; cleanup every 6h). See [`.ai/data/consistency.md`](../data/consistency.md) and [`.ai/runtime/configuration.md`](../runtime/configuration.md).
+- Filter against stored rows: bound event history with `--since` / `--until` (ISO-8601 on the operator CLI) against rows still present after `RetentionCleanup`. Query JSON does not expose configured retention days or prune "as of" metadata (see [`.ai/data/serialization.md`](../data/serialization.md)).
 - Assessment history: no time-based prune in current product stance; rows persist until explicit remove/cascade. Empty or partial history is a normal query outcome, not a retention SLA.
 
 **Pod Resolution**:


### PR DESCRIPTION
## Description

Advertises severity-split event retention (**7** days info/warning, **30** days error/critical) for kube9-desktop Pro AI agent and kube9-vscode evidence consumers. Most contract prose landed on `main` via refine PR #162 and sibling #158; this PR completes the integration contract with explicit filter-against-stored-rows guidance.

Fixes #159

## Motivation and Context

Desktop and vscode co-consumers need honest store bounds when citing operator event history. Consumers must filter with `--since` / `--until` against still-stored rows after `RetentionCleanup` (every 6h), not assume a single unified retention window.

## Type of Change

- [x] Documentation update

## How Has This Been Tested?

- [x] `npm run lint` passes
- [x] `npm run test` passes
- Manual contract verification against issue acceptance criteria (consistency, api_contracts, domain_model, user_stories, serialization, runtime/configuration, build_packaging, chart README)

## How to Test this Work

```bash
cd kube9-operator
npm install
npm run lint
npm run test
```

Then verify `.ai/integration/api_contracts.md` **Consumer-facing event retention** documents 7/30 split, cleanup cadence, `--since`/`--until` filter guidance, and cross-references to data/runtime/serialization contracts.

## How to Validate this Work

1. Read `.ai/data/consistency.md` **Agent and Desktop consumers of event history** — confirm 7/30, 6-hour cleanup, Helm/env overrides, filter guidance.
2. Read `.ai/integration/api_contracts.md` **Consumer-facing event retention** — confirm severity-split defaults and filter-against-stored-rows bullet.
3. Read `charts/kube9-operator/README.md` **Event Storage and Retention** — confirm agent/Desktop consumer paragraph states 7/30 split and ISO filter bounds.
4. Grep operator `.ai` for unified 90-day agent/history retention claims — none should remain.

## Additional Notes

- Assessment TTL and log capture remain explicitly out of scope (sibling #160).
- No operator application code changes in this PR.