### PR TITLE
docs(ai): finish-m8-collector-set contract updates

### DIFF
--- a/.ai/business_logic/domain_model.md
+++ b/.ai/business_logic/domain_model.md
@@ -83,10 +83,21 @@ The evaluator must prefer `not-evaluated` or `needs-evidence` over inference whe
    - Limits/requests, replica counts, image pull policies, security contexts, probes, volume types, service types
    - Collector: `ResourceConfigurationPatternsCollector` (`src/collection/collectors/resource-configuration-patterns.ts`)
 
-4. Performance metrics (future, 15min)
-5. Security posture (future, 24h)
+4. **Performance metrics** (15m default, enforced minimum)
+   - Bounded aggregate utilization/ratio rollups from optional in-cluster Prometheus (outbound scrape/query)
+   - Graceful degrade when Prometheus is absent or unreachable; no metrics-server / Kubernetes metrics API fallback
+   - Distinct from operator `/metrics` exposition (inbound scrape of the operator itself)
+   - Collector: Performance metrics collector on `CollectionScheduler` (SQLite `collections`; existing collections query CLI)
 
-**Implementation**: Intervals configured via Helm values (`charts/kube9-operator/values.yaml`) and enforced with minimums. Collections scheduled with random offsets (0-1 hour) to distribute load. Default intervals: 86400s (24h), 21600s (6h), 43200s (12h).
+5. **Security posture** (24h default, enforced minimum)
+   - Cluster API aggregates only: privileged/hostPath/hostNetwork-style counts, NetworkPolicy coverage, and basic NSA/CIS-oriented rollups from Kubernetes objects
+   - Distinct from resource-configuration-patterns (including its security-context-style pattern counts) and from Trivy image/CVE scanning
+   - Non-goals for this category: Trivy CVE duplication, RBAC risk rollups, broader CIS/NSA families beyond the basic rollups above
+   - Collector: Security posture collector on `CollectionScheduler` (SQLite `collections`; existing collections query CLI)
+
+**Scheduler and storage**: Intervals configured via Helm values and enforced with minimums. Collections scheduled with random offsets (0-1 hour) matching existing collectors. Persistence stays on the SQLite `collections` path; no CRDs for these payloads; no phone-home / registration / kube9-api sync. Default intervals for the five categories: 86400s (24h metadata), 21600s (6h inventory), 43200s (12h config patterns), ~900s (15m performance), 86400s (24h security posture). Exact second values and minima for the two newer collectors are listed under Open implementation decisions.
+
+**Milestone consumer scope**: Operator-owned schedule, status `collectionStats`, and collections query are the user-visible outcomes for these collectors. vscode and Desktop remain progressive-enhancement co-consumers later; this surface does not add presence modes or AssessmentRunState/CheckStatus values.
 
 ## Queryable history for agent and client consumers
 
@@ -98,6 +109,7 @@ Paid Desktop products and vscode extensions may **co-consume** the same operator
 |---------|----------------------|-------|
 | Events | Severity-split defaults: **7** days for info/warning, **30** days for error/critical | Honest advertised window for agent/evidence outcomes that cite Operator history. Knobs and cleanup schedule live in data/runtime contracts. |
 | Assessments history | **No** time-based retention SLA in this product surface | **Posture / historical check signal** for agent and vscode consumers (not a live incident log stream). Rows persist until explicit remove or cascade delete of the parent assessment. Consumers may rely only on whatever is still stored. Empty or partial assessment history is a normal gap. |
+| Collections | **No** time-based retention SLA (assessments-class) | Snapshot rows for all collection categories, including performance metrics and security posture, persist until explicit remove or operational cleanup. No count-based cap. Consumers may rely only on whatever is still stored. Empty collections query results are a normal gap. |
 
 ### Non-goals (agent-consumer path)
 
@@ -108,3 +120,9 @@ Paid Desktop products and vscode extensions may **co-consume** the same operator
 ### Consumer documentation
 
 User-facing operator docs (`charts/kube9-operator/README.md`) list **kube9-vscode** and **kube9-desktop** (including Pro AI agent Tier 2 operator query tools) as first-class co-consumers on the ConfigMap read + `kubectl exec` query path. Integration contracts own CLI semantics; README owns operator-facing consumer naming.
+
+## Open implementation decisions
+
+- **Collection type tokens:** Exact kebab-case type strings for performance metrics and security posture (family candidates such as `performance-metrics` and `security-posture`) are locked with data and interface contracts; business logic treats them as additive members of the existing collections type set.
+- **Interval seconds and minima:** Exact default seconds and enforced minima for the ~15m performance and ~24h security-posture collectors are locked with runtime and operations (Helm/env keys); product defaults remain ~15m and ~24h with random offset matching peer collectors.
+- **Performance collector registration gate:** Whether the performance collector always registers on `CollectionScheduler` or registers only when a Prometheus endpoint is configured/enabled is locked with runtime and integration; either choice must preserve graceful degrade when Prometheus is absent or unreachable and must not block ready or other collectors.

--- a/.ai/business_logic/error_handling.md
+++ b/.ai/business_logic/error_handling.md
@@ -22,11 +22,17 @@
 - **Retry behavior**: Collections retry on next scheduled interval (no immediate retry)
 
 ### External Endpoint Failures
-- **Prometheus unreachable**: Log warning, skip optional checks that depend on Prometheus
+- **Prometheus unreachable (optional assessment checks)**: Log warning, skip optional checks that depend on Prometheus
+- **Prometheus unreachable (performance metrics collector)**: Log warning; that collector tick degrades gracefully (no metrics-server / Kubernetes metrics API fallback). Operator continues; other collectors keep their schedules. Prometheus miss alone does **not** set operator `health` to `unhealthy`, and does **not** promote reserved `degraded` health. Exact tick classification (failed vs skipped vs success-with-unavailable) is under Open implementation decisions.
 - **ArgoCD endpoint unreachable**: Detection returns not detected, operator continues
 - **Trivy server unreachable**: Detection returns not detected; workload scans are skipped until a server is configured
 
 **Implementation**: All external dependencies wrapped with try-catch, errors logged but never thrown to operator main loop.
+
+### Security posture collection partial failures
+- **Partial cluster API reads**: When some reads for security-posture signals fail mid-tick while others succeed, classify per Open implementation decisions (partial snapshot vs failed tick). Log and record collection metrics; retry on the next scheduled interval; do not crash the operator.
+- **Health**: Security-posture partial or failed ticks alone do **not** set `health: unhealthy` and do not promote reserved `degraded` health.
+- **Non-overlap**: Trivy unreachable remains the vulnerability-scan path only; it is not a security-posture collector failure mode.
 
 ## Per-Check (Assessments)
 
@@ -71,6 +77,7 @@
 
 ### Empty history vs failure
 - **Success with zero rows**: Valid outcome when filters match nothing or retained rows have aged out / been removed. Does not change operator `health`. Clients report an evidence gap, not an operator failure.
+- **Empty collections query**: Successful `query collections` with zero rows (including a new type filter with no snapshots yet) is the same class as empty history: normal evidence gap, not unhealthy.
 - **Operator unhealthy or absent**: Consumers fall back per presence/`error_state.md` (toward basic). Tiered agent tooling that depends on history is gated off; live Kubernetes debugging paths remain independent of operator history.
 - **Query / exec / RBAC transport failure**: Distinct from empty history. Surface as consumer-side query failure (integration CLI/exec contracts); do not conflate with "no matching retained rows."
 - **Assessment history gaps**: Empty or partial assessment history after a successful query is a normal gap (no time-based retention SLA). Same success-vs-failure distinction as events.
@@ -82,3 +89,5 @@
 ### Open implementation decisions
 
 - **Consumer error copy:** Exact Desktop/vscode strings for empty history vs exec/RBAC failure stay in peer interface contracts; operator BL only distinguishes outcome classes.
+- **Performance collector tick classification:** When Prometheus is absent or unreachable, lock whether the tick is recorded as failed, skipped, or success-with-unavailable (coordinate with runtime and data). Must not invent a new operator `health` value.
+- **Security posture partial-failure classification:** When some cluster API reads fail mid-tick, lock whether the outcome is a failed tick, a partial persisted snapshot, or skipped (coordinate with runtime and data). Same health constraint as Prometheus miss.

--- a/.ai/business_logic/error_state.md
+++ b/.ai/business_logic/error_state.md
@@ -25,7 +25,9 @@
 - **degraded** → reserved for future operator-side semantics
 - **unhealthy** → show error message, fall back to basic mode (kubectl-only)
 
-Empty events or assessments-history query results do **not** change operator health. Absence of matching retained rows is a consumer evidence gap, not an unhealthy signal (see `error_handling.md`).
+Empty events, assessments-history, or collections query results do **not** change operator health. Absence of matching retained rows is a consumer evidence gap, not an unhealthy signal (see `error_handling.md`).
+
+Optional performance-metrics Prometheus miss and security-posture collection partial or failed ticks do **not** alone set `health` to `unhealthy`, and do **not** promote reserved `degraded`. Those outcomes stay collection/integration degrade classes (see `error_handling.md`).
 
 ## Stale Status
 - **Threshold**: `lastUpdate > 5 minutes` → treat as degraded regardless of reported health

--- a/.ai/business_logic/index.md
+++ b/.ai/business_logic/index.md
@@ -4,7 +4,7 @@ Core domain behavior and rules for the kube9-operator.
 
 - **Presence modes**: basic (no operator), operated (installed)
 - **Assessment**: WAF pillars, check lifecycle, run states
-- **Data collection**: Cluster metadata, resource inventory, config patterns (M8)
+- **Data collection**: Cluster metadata, resource inventory, config patterns, performance metrics, security posture
 - **Queryable history consumers**: Desktop/agent and vscode co-consume events list and assessments history; operator owns history semantics and retention outcomes (events 7/30 severity-split; assessments best-effort stored)
 
 ## Child Docs

--- a/.ai/business_logic/user_stories.md
+++ b/.ai/business_logic/user_stories.md
@@ -150,12 +150,54 @@ Assessment check history is queryable via CLI (`kube9-operator query assessments
    - Interval: 12h default (43200s), 3600s minimum
    - Random offset: 0-1 hour
 
+4. **Performance metrics collector**
+   - Collects: Bounded aggregate utilization/ratio rollups from optional in-cluster Prometheus (outbound scrape/query)
+   - Interval: ~15m default, enforced minimum; random offset 0-1 hour
+   - Degrade: When Prometheus is absent or unreachable, that collector tick degrades gracefully; the operator continues and other collectors stay on schedule. No metrics-server / Kubernetes metrics API fallback.
+
+5. **Security posture collector**
+   - Collects: Cluster API aggregates only (privileged/hostPath/hostNetwork-style counts, NetworkPolicy coverage, basic NSA/CIS-oriented rollups)
+   - Interval: ~24h default, enforced minimum; random offset 0-1 hour
+   - Distinct from resource-configuration-patterns and from Trivy vulnerability scanning
+
 ### Collection Behavior
 - **Scheduled**: Collections registered with `CollectionScheduler` (`src/collection/scheduler.ts`)
 - **Random offset**: Each collection scheduled with 0-1 hour random offset to distribute load
+- **Persistence**: SQLite `collections` path; append-only snapshot rows; no CRDs; no phone-home
+- **Retention**: No time-based TTL (assessments-class); rows persist until explicit remove or operational cleanup; no count-based cap
+- **Query**: Existing `query collections` CLI/types extended with additive `--type` values for the new collectors
 - **Error handling**: Collection errors logged, metrics recorded, but don't crash operator
 - **Retry**: Failed collections retry on next scheduled interval (no immediate retry)
-- **Statistics**: Collection success/failure tracked in `CollectionStatsTracker` and exposed in status ConfigMap
+- **Statistics**: Collection success/failure tracked in `CollectionStatsTracker` and exposed in status ConfigMap for all five types without changing the aggregate `collectionStats` field set
+- **Consumer scope**: Operator schedule, status, and query are the outcomes of this surface; vscode/Desktop progressive enhancement of new types ships later
+
+**Acceptance (schedule success):**
+- **Given** the operator is running with collectors registered,
+- **When** a performance-metrics or security-posture interval elapses,
+- **Then** a successful tick persists a collections snapshot and participates in status `collectionStats` like the three peer collectors.
+
+**Acceptance (Prometheus absent degrade):**
+- **Given** in-cluster Prometheus is not configured, absent, or unreachable,
+- **When** the performance-metrics collector would tick,
+- **Then** the operator continues serving; health does not become unhealthy for that reason alone; other collectors keep their schedules; there is no metrics-server fallback.
+
+**Acceptance (security posture queryable):**
+- **Given** at least one successful security-posture snapshot is stored,
+- **When** an operator issues `query collections` filtered to that type,
+- **Then** the snapshot is returned on the existing collections list/get surface (no parallel query API).
+
+**Acceptance (empty list for new type):**
+- **Given** no rows yet exist for a new collections `--type`,
+- **When** `query collections list` succeeds with an empty result for that filter,
+- **Then** the outcome is a normal success / evidence gap, not an operator unhealthy state.
+
+### Non-goals (this surface)
+- vscode/Desktop consumer UX in the same milestone (progressive enhancement later)
+- New Well-Architected assessment checks that consume these collections
+- Trivy CVE duplication in security posture; RBAC risk rollups; broader CIS/NSA families beyond basic rollups
+- metrics-server / Kubernetes metrics API as a performance source
+- Phone-home, registration, or kube9-api sync of collection payloads
+- CRDs or a parallel query API for these collectors
 
 **Implementation**: Collectors initialized in `src/operator.ts`, scheduled via `CollectionScheduler`, stored locally via `LocalStorage` (`src/collection/storage.ts`).
 
@@ -164,3 +206,8 @@ Assessment check history is queryable via CLI (`kube9-operator query assessments
 ### Resolved (events retention copy coordination)
 
 Operator business-logic and integration contracts state the user-visible outcome: info/warning **7** days, error/critical **30** days by default, with cleanup every **6 hours** and Helm/env overrides of the effective store window. kube9-desktop interface contracts own evidence-footer and Pro retention microcopy; those surfaces must cite the severity-split pair (or both bands), not a single longer “N days” promise. No 90-day (or other unified) agent/history retention claim belongs in operator consumer prose.
+
+### Performance metrics and security posture (collections)
+
+- **CLI `--type` presentation:** Exact enum strings, help text, and table column widths for the two new types are locked with interface contracts; behavior stays on the existing collections list/get archetype (filters, formats, pagination, stderr errors).
+- **Empty-list and degrade copy:** User-facing wording for empty successful lists vs Prometheus-degrade tick outcomes stays coordinated with interface and error_handling; business logic only fixes the outcome classes above.

--- a/.ai/data/consistency.md
+++ b/.ai/data/consistency.md
@@ -80,6 +80,16 @@ Desktop Pro debugging (and other agent tooling) that reads operator event histor
 - Agent and Desktop consumers of `query assessments history` (and related assessment query paths) may rely **only on whatever is still stored**. Empty or partial assessment history is a normal gap, not a retention SLA.
 - This epic does **not** introduce an assessment TTL or a product retention window for assessment rows.
 
+### Collections retention (no time-based TTL, no count-based cap)
+
+`collections` rows are **not** time-pruned by `RetentionCleanup` and have **no** count-based eviction in this product surface:
+
+- Rows persist until explicit remove or operational cleanup (same class as assessments).
+- Append-only collectors (including ~15m `performance-metrics`) may grow the table; growth is an operational concern, not a product TTL or max-row SLA.
+- Agent and Desktop consumers of `query collections list|get` may rely **only on whatever is still stored**. Empty or partial collection history is a normal gap, not a retention window.
+- This initiative does **not** introduce per-type or global TTL windows, nor a durable max-row cap analogous to the historical in-memory `LocalStorage` buffer.
+- Query JSON does not expose retention metadata (same stance as events/assessments).
+
 ### Log storage (out of scope)
 
 The operator SQLite model does **not** store pod or workload container logs. There is no log table, log retention policy, or pruned-log recovery path in this data plane. Log evidence for debugging agents comes from live Kubernetes API reads (Desktop Tier 1), not from operator history.
@@ -124,12 +134,17 @@ Retention days can be configured via:
 - **Privacy by default**: Raw data never leaves cluster
 - **ACID compliance**: SQLite provides transaction guarantees
 - **Referential integrity**: Foreign keys ensure data consistency
-- **Automatic cleanup**: Event retention policies prevent unbounded growth of the events table; assessments rely on explicit remove / cascade, not time prune
+- **Automatic cleanup**: Event retention policies prevent unbounded growth of the events table; assessments and collections rely on explicit remove / cascade (or operational cleanup), not time prune or count-based eviction
 
 ## Open implementation decisions
 
 - **Assessment prune policy (if ever introduced):** days-by-severity or single window; whether prune targets `assessments` only (cascade history) vs both tables; cleanup schedule alignment with `RetentionCleanup`; Helm/env knobs and migration of consumer prose. Not product-committed now. Resolve via `/refine-issue` if a future epic adds TTL.
+- **Collections prune / cap policy (if ever introduced):** time window (global or per-type), count-based eviction, Helm/env knobs, indexes used for delete, and whether `collectionsStoredCount` reflects post-prune totals. Not product-committed now; current contract is no TTL and no count cap. Resolve via `/refine-issue` if a future epic adds either.
 
 ### Resolved (event retention consumer bounds)
 
 Event and assessment query JSON **does not** expose effective retention windows, configured day counts, or query “as of” prune bounds. Agent and Desktop consumers filter with `--since` / `--until` (ISO-8601 on the operator CLI) against **still-stored** rows after `RetentionCleanup`. Helm/env overrides change the effective store window but are not echoed as result metadata in this product surface. A future additive operator epic may introduce optional metadata; that is not committed here.
+
+### Resolved (collections retention)
+
+Collections use assessments-class retention: **no time-based TTL** and **no count-based cap** in this initiative. Consumers read still-stored rows only. Retention metadata is not added to collections list/get JSON.

--- a/.ai/data/data_model.md
+++ b/.ai/data/data_model.md
@@ -94,11 +94,17 @@ Nested under `OperatorStatus.aiConformance`. This is the client-facing readiness
 
 ## Collection Models (M8)
 
-**Cluster Metadata** (24h interval): Kubernetes version, cluster identifier, node count, provider, region/zone.
+Five scheduled collectors persist append-only snapshot rows in SQLite `collections` as `CollectionPayload` documents (discriminated on `type`). No CRDs. Operator owns producer shapes; peer Desktop foreshadows (flat `metrics` / `security` sketches, CRD notes) are non-normative.
 
-**Resource Inventory** (6h interval): Namespace counts (hashed IDs), pod/deployment/statefulset/replicaset/service counts.
+**Cluster Metadata** (`cluster-metadata`, ~24h): Kubernetes version, cluster identifier, node count, provider, region/zone.
 
-**Resource Configuration Patterns** (12h interval): Limits/requests, replica counts, image pull policies, security contexts, probes, volume types, service types.
+**Resource Inventory** (`resource-inventory`, ~6h): Namespace counts (hashed IDs), pod/deployment/statefulset/replicaset/service counts.
+
+**Resource Configuration Patterns** (`resource-configuration-patterns`, ~12h): Limits/requests, replica counts, image pull policies, security contexts, probes, volume types, service types.
+
+**Performance Metrics** (`performance-metrics`, ~15m): Bounded aggregate snapshot from optional in-cluster Prometheus (utilization / ratio style rollups). Not a raw time-series warehouse. When Prometheus is absent or unreachable, the collector degrades gracefully and does not invent metrics-server / Kubernetes metrics API data. Field-level `data` keys remain open implementation decisions below.
+
+**Security Posture** (`security-posture`, ~24h): Bounded cluster-API aggregate counts and coverage rollups (privileged / hostPath / hostNetwork-style counts, NetworkPolicy coverage, basic NSA/CIS-oriented rollups from Kubernetes objects). Distinct from resource-configuration-patterns security-context counts and from Trivy image scanning (no CVE bodies). RBAC risk rollups and broader CIS/NSA families are out of scope for this payload. Field-level `data` keys remain open implementation decisions below.
 
 ## SQLite Tables (at /data/kube9.db)
 
@@ -239,19 +245,28 @@ Normalized vulnerability findings linked to a scan (and optionally to originatin
 
 ### collections (M8)
 
-Stores serialized periodic collection payloads (`ClusterMetadata`, `ResourceInventory`, `ResourceConfigurationPatternsData`) wrapped as `CollectionPayload` in `src/collection/types.ts`. Persisted JSON must match `CollectionPayload` at write time.
+Stores serialized periodic collection payloads wrapped as `CollectionPayload` (`version`, `type`, `data`, `sanitization` plus identity/timestamp fields). Persisted JSON must match `CollectionPayload` at write time. Row model is **append-only**: each successful tick inserts a new `collection_id`, not a latest-only upsert.
+
+**Retention (agent / Desktop consumers):** No time-based TTL (same class as assessments). No count-based cap. Rows persist until explicit remove or operational cleanup. Consumers rely only on whatever is still stored. See [consistency.md](consistency.md).
 
 | Column | Type | Constraints | Description |
 |--------|------|-------------|-------------|
 | collection_id | TEXT | PRIMARY KEY | Matches payload `collectionId` (e.g. `coll_*`) |
 | cluster_id | TEXT | NOT NULL | Cluster identifier `cls_*` |
-| type | TEXT | NOT NULL | `cluster-metadata` \| `resource-inventory` \| `resource-configuration-patterns` |
+| type | TEXT | NOT NULL | `cluster-metadata` \| `resource-inventory` \| `resource-configuration-patterns` \| `performance-metrics` \| `security-posture` |
 | collected_at | TEXT | NOT NULL | ISO 8601 (payload `timestamp`) |
 | payload_json | TEXT | NOT NULL | Full `CollectionPayload` document as JSON |
 
-**Indexes (suggested):** `cluster_id`, `type`, `collected_at` (DESC).
+**Indexes:** `idx_collections_cluster_id`, `idx_collections_type`, `idx_collections_collected_at` (DESC). Queried via `CollectionRepository` / `query collections` CLI.
 
-**Status:** Target schema and CLI read path captured in [issue #53](https://github.com/alto9/kube9-operator/issues/53); implement before or with collector tickets (#50–#54, #51).
+**Type set:** Closed in application validation (Zod / TypeScript literals). SQLite `type` remains free TEXT (no DB CHECK). Additive kebab-case tokens only; do not rename existing type strings.
+
+**Payload classes:**
+- `performance-metrics`: bounded Prometheus aggregate snapshot (optional outbound source)
+- `security-posture`: bounded cluster-API aggregate / coverage rollups (no Trivy CVE bodies, no RBAC risk rollups in this payload)
+- Existing three types keep their current envelope roles unchanged
+
+**Producer ownership:** Operator defines normative `CollectionPayload` shapes. Desktop foreshadowed flat `metrics` / `security` documents and CRD storage notes are non-normative for these rows.
 
 ### argocd_apps (M9)
 
@@ -319,3 +334,29 @@ Stores per-requirement results for each conformance run.
 | evaluated_at | TEXT | NOT NULL | ISO 8601 timestamp for this result |
 
 **Indexes:** `idx_ai_conformance_requirement_results_run_id`, `idx_ai_conformance_requirement_results_category`, `idx_ai_conformance_requirement_results_status`, and unique `(run_id, requirement_id)`.
+
+## Open implementation decisions
+
+### Collection payload field catalogs (`performance-metrics`, `security-posture`)
+
+- Exact `data` object keys and nested shapes for `performance-metrics` (which utilization / ratio rollups; whether an explicit `prometheusAvailable` or source-status marker is required; max payload size / key count bounds).
+- Exact `data` object keys for `security-posture` (privileged / hostPath / hostNetwork-style counters; NetworkPolicy coverage representation; which basic NSA/CIS rollup keys). Must exclude Trivy CVE bodies and deferred RBAC risk fields.
+- Sanitization wrapping details for hashed / namespaced aggregates, aligned with peer collectors.
+- Resolve via `/refine-issue` into full field tables under Collection Models / serialization once implementation picks concrete keys.
+
+### Zod / TypeScript type literals
+
+- Extend `CollectionPayload` discriminated union, `CollectionRowType`, CLI `--type` enum, and `CollectionPayloadSchema` with `performance-metrics` and `security-posture`.
+- Write-time rejection rules when `type` and `data` shape mismatch.
+- Keep SQLite `type` as unconstrained TEXT; closed set stays in app validation only.
+
+### Degrade-row persistence (Prometheus unavailable)
+
+- Whether a Prometheus-absent/unreachable tick **omits** a `collections` row, stores a **success** payload with empty/unavailable metrics (and optional source-status marker), or counts as a **collection failure** with no durable row.
+- Coordinate with runtime / integration / error_handling for tick classification; data owns which documents are valid to persist.
+- Security posture (cluster API only) is not gated on Prometheus; degrade semantics above apply to performance-metrics only unless a shared pattern is chosen.
+
+### Durable write path vs in-memory
+
+- Wire both new collectors (and ideally existing ones) through durable `CollectionRepository.insertCollection` so `query collections` and status `collectionsStoredCount` reflect SQLite truth.
+- Document whether in-memory `LocalStorage` (historical max-100 buffer) remains a cache, is removed from the write path, or is transitional only. Single durable write path is the product contract for queryable history.

--- a/.ai/data/index.md
+++ b/.ai/data/index.md
@@ -3,12 +3,13 @@
 How data is modeled, persisted, serialized, and kept consistent.
 
 - **Status**: ConfigMap (kube9-operator-status)
-- **Rich data**: SQLite at /data/kube9.db (events, assessments; vulnerability scans; collections table specified in M8 — [issue #53](https://github.com/alto9/kube9-operator/issues/53); argocd_apps planned)
-- **Query**: CLI via kubectl exec
-- **Agent / Desktop history consumers**: Durable events and assessment rows stay in operator SQLite. Advertised event retention for those consumers is the severity-split window in [consistency.md](consistency.md) (7 days info/warning, 30 days error/critical). Assessments have no time-based TTL. Operator does not store pod/workload logs.
+- **Rich data**: SQLite at `/data/kube9.db` (events, assessments, vulnerability scans, collections, argocd_apps, AI conformance runs)
+- **Collections**: Five `CollectionPayload` types on the SQLite `collections` table (no CRDs). Includes `performance-metrics` and `security-posture` alongside the three earlier collectors.
+- **Query**: CLI via kubectl exec (`query collections list|get` for collection snapshots)
+- **Agent / Desktop history consumers**: Durable events, assessment, and collection rows stay in operator SQLite. Advertised event retention is the severity-split window in [consistency.md](consistency.md) (7 days info/warning, 30 days error/critical). Assessments and collections have no time-based TTL and no count-based cap. Operator does not store pod/workload logs.
 
 ## Child Docs
-- [data_model.md](data_model.md) — Operator status, collection models, SQLite schema; agent-consumer retention pointers on events and assessments
+- [data_model.md](data_model.md) — Operator status, collection models, SQLite schema; retention pointers on events, assessments, and collections
 - [persistence_abstractions.md](persistence_abstractions.md) — Dual storage, PVC; durable history assumes PVC (emptyDir = ephemeral gap)
-- [serialization.md](serialization.md) — CLI formats, JSON schema; query surfaces for history consumers
+- [serialization.md](serialization.md) — CLI formats, JSON schema; collection payload envelopes; query surfaces for history consumers
 - [consistency.md](consistency.md) — Retention, agent-consumer reliability bounds, lifecycle phases

--- a/.ai/data/persistence_abstractions.md
+++ b/.ai/data/persistence_abstractions.md
@@ -4,7 +4,7 @@
 
 **Dual storage**:
 - **ConfigMap**: Status only. Simple, cacheable, backward compatible.
-- **SQLite**: Events, assessments, ArgoCD data (M9), and Kubernetes AI Conformance readiness runs (M10). Rich queries via CLI.
+- **SQLite**: Events, assessments, collections (five `CollectionPayload` types, no CRDs), ArgoCD data (M9), and Kubernetes AI Conformance readiness runs (M10). Rich queries via CLI.
 
 ## Kubernetes AI Conformance Persistence
 
@@ -54,7 +54,20 @@ When persistence is disabled (`events.persistence.enabled = false`), uses `empty
 
 ### Durable history for agent / Desktop consumers
 
-Queryable event and assessment history for Desktop Tier 2 (and similar agents) assumes chart-default PVC-backed SQLite at `/data/kube9.db`. With `emptyDir` (persistence disabled) or a missing/unhealthy operator, treat history as degraded or absent: empty results are expected, not a store failure to invent. Desktop does not own a peer durable ledger of operator rows. Retention semantics for still-stored rows are in [consistency.md](consistency.md): events are severity-split time-pruned; **assessments and `assessment_history` have no time-based TTL** (cascade on parent delete only). Operator SQLite does not store pod/workload logs.
+Queryable event, assessment, and collection history for Desktop Tier 2 (and similar agents) assumes chart-default PVC-backed SQLite at `/data/kube9.db`. With `emptyDir` (persistence disabled) or a missing/unhealthy operator, treat history as degraded or absent: empty results are expected, not a store failure to invent. Desktop does not own a peer durable ledger of operator rows. Retention semantics for still-stored rows are in [consistency.md](consistency.md): events are severity-split time-pruned; **assessments**, **`assessment_history`**, and **`collections`** have no time-based TTL and collections have no count-based cap (explicit remove / operational cleanup only). Operator SQLite does not store pod/workload logs.
+
+### Collections persistence boundary
+
+- **Store:** Existing SQLite `collections` table via `CollectionRepository` (append-only inserts). No CRDs, no phone-home / kube9-api sync, no second persistence engine.
+- **Queryable truth:** `query collections list|get` and status `collectionsStoredCount` reflect durable SQLite rows.
+- **Types:** `cluster-metadata`, `resource-inventory`, `resource-configuration-patterns`, `performance-metrics`, `security-posture`.
+- **Producer ownership:** Operator owns normative write shapes. Peer Desktop foreshadows are non-normative.
+
+## Open implementation decisions
+
+- **Single durable write path:** Wire collectors through `CollectionRepository.insertCollection` so CLI and `collectionsStoredCount` match SQLite. Decide fate of in-memory `LocalStorage` (cache vs removed vs transitional). See [data_model.md](data_model.md).
+- **Degrade persistence:** Whether Prometheus-unavailable performance ticks omit rows, persist unavailable success payloads, or fail without a row. Coordinate with runtime / integration.
+- **Optional future prune/cap:** Not in contract now; if introduced later, align Helm/env, `RetentionCleanup` (or peer service), and consumer prose via `/refine-issue`.
 
 ## Single Binary, Dual Modes
 

--- a/.ai/data/serialization.md
+++ b/.ai/data/serialization.md
@@ -140,13 +140,54 @@ Extension reads `status` key from ConfigMap `kube9-operator-status` in operator 
 
 ## Collection Payloads
 
-M8 collectors store data as JSON blobs in `collections` table. Schema validated before storage. (Note: collections table not yet implemented in current schema)
+Collectors store data as JSON documents in the SQLite `collections` table. Schema validated before storage (`CollectionPayload` / `CollectionPayloadSchema`). Query surface: `kube9-operator query collections list|get` (additive `--type` values; same list/get pagination envelope as today).
+
+### Envelope
+
+Each stored document is a `CollectionPayload`:
+
+| Field | Role |
+|-------|------|
+| `version` | Payload schema version |
+| `type` | Discriminant: `cluster-metadata` \| `resource-inventory` \| `resource-configuration-patterns` \| `performance-metrics` \| `security-posture` |
+| `data` | Type-specific bounded aggregate object (not a raw dump) |
+| `sanitization` | Sanitization metadata / wrapping consistent with peer collectors |
+| identity / time fields | `collectionId`, `clusterId`, `timestamp` (and peers as already defined for existing types) |
+
+Persisted `payload_json` must match this envelope at write time. Operator owns the normative producer shape. Desktop foreshadowed flat `metrics` / `security` sketches and CRD notes are non-normative.
+
+### Type semantics (serialization class)
+
+| `type` | `data` class | Source class |
+|--------|--------------|--------------|
+| `cluster-metadata` | Cluster identity / topology aggregates | Kubernetes API |
+| `resource-inventory` | Hashed namespace and workload counts | Kubernetes API |
+| `resource-configuration-patterns` | Config-pattern rollups (limits, probes, security contexts, …) | Kubernetes API |
+| `performance-metrics` | Bounded utilization / ratio aggregates | Optional in-cluster Prometheus (outbound); degrade when absent |
+| `security-posture` | Bounded privileged/host* counts, NetworkPolicy coverage, basic NSA/CIS-oriented rollups | Kubernetes API only (no Trivy CVE bodies; no RBAC risk rollups in this type) |
+
+Empty successful `query collections list` (including `--type` with no rows) remains normal success serialization. No retention-window fields on list/get JSON (see [consistency.md](consistency.md)).
+
+### Status surface
+
+`collectionStats` stays aggregate counters (`totalSuccessCount`, `totalFailureCount`, `collectionsStoredCount`, `lastSuccessTime`). New types participate in those counters without changing the CollectionStats field set.
 
 ## Open implementation decisions
+
+### Collection payload field-level serialization
+
+- Concrete `data` property catalogs and nested JSON shapes for `performance-metrics` and `security-posture` (including optional Prometheus source-status marker and size bounds).
+- Exact Zod / TypeScript literal updates for the two new discriminants and write-time mismatch rejection.
+- Whether degrade ticks serialize a durable unavailable payload vs omit the row (see [data_model.md](data_model.md) open decisions).
+- Resolve via `/refine-issue` into field tables once implementation picks keys.
 
 ### Resolved (retention metadata on query JSON)
 
 Event list/get and assessments history JSON keep existing shapes (`events` / `history` plus `pagination`). No retention-window, configured-day, or prune “as of” fields are added for agent or Desktop consumers in this epic. Consumers bound queries with `--since` / `--until` against rows still present after severity-split retention (see [consistency.md](consistency.md)).
+
+### Resolved (collections query JSON)
+
+Collections list/get keep the generic envelope and pagination. New types appear as additive `type` / `--type` values only. No retention metadata, TTL, or count-cap fields are added to collections query JSON. Consumers read still-stored rows (assessments-class retention; see [consistency.md](consistency.md)).
 
 ### Out of scope (operator `--since` value forms)
 

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -16,11 +16,13 @@
 - `lastUpdate`: string - ISO 8601 timestamp
 - `error`: string | null - Error message if unhealthy
 - `namespace`: string - Operator deployment namespace (used for subsequent operations)
-- `collectionStats`: object - Collection activity statistics
+- `collectionStats`: object - Aggregate collection activity statistics (new collection types participate without changing this field set)
 - `argocd`: object - ArgoCD detection status (`detected`, `namespace`, `version`, `lastChecked`, optional `resourceTreeCapable`, optional `resourceTreeLastError`)
 - `trivy`: object - Trivy detection status (`detected`, `serverUrl`, `version`, `lastChecked`)
 - `assessment`: object - Bounded Well-Architected assessment status summary
 - `aiConformance`: object - Bounded Kubernetes AI Conformance readiness status summary
+
+Clients must tolerate unknown top-level status keys and unknown collection `type` values (progressive enhancement). An optional bounded Prometheus detection block (if introduced for outbound client capability) follows the same omit-when-absent pattern as `trivy` / `argocd` capability fields.
 
 **Discovery Flow**:
 1. Extension checks default namespace (`kube9-system`) for ConfigMap
@@ -122,6 +124,49 @@ kube9-operator query assessments history [--pillar=<pillar>] [--result=<result>]
 - `yaml`: YAML output for human-readable structured data
 - `table`: Human-readable tabular output
 - `compact`: Compact format for assessments (assessment-specific)
+
+### Collections Query Contract
+
+**Command surface** (existing; additive types only):
+```bash
+kube9-operator query collections list [--type=<type>] [--cluster-id=<id>] [--since=<ISO8601>] [--until=<ISO8601>] [--limit=<number>] [--offset=<number>] [--format=json|yaml|table|compact]
+kube9-operator query collections get <collectionId> [--format=json|yaml|table|compact]
+```
+
+**Producer ownership**: kube9-operator owns collection type tokens, SQLite `collections` persistence, payload schemas, and this CLI. This initiative ships **performance-metrics** and **security-posture** as additive `--type` / payload `type` values alongside the shipped set:
+- `cluster-metadata`
+- `resource-inventory`
+- `resource-configuration-patterns`
+- `performance-metrics` (optional Prometheus-backed aggregate snapshot)
+- `security-posture` (Kubernetes API aggregate snapshot; no Trivy CVE bodies)
+
+**Naming note**: Assessment pillar name `performance` is unrelated to the collection type token `performance-metrics`. Do not collapse the two strings in filters or docs.
+
+**Non-breaking stance**:
+- Prefer additive `--type` enum values and additive JSON fields inside typed payloads.
+- Do not rename or remove shipped type strings.
+- Empty successful list (including a valid `--type` with zero stored rows) remains normal success / evidence gap, not an error.
+- `collectionStats` on the status ConfigMap stays an **aggregate** counter object (`totalSuccessCount`, `totalFailureCount`, `collectionsStoredCount`, `lastSuccessTime`). New types participate in those aggregates without changing the CollectionStats field set. Clients must tolerate unknown collection types when present (progressive enhancement).
+
+**JSON shape (collections list, programmatic default)**: Object with `collections` (summary array) and `pagination` (`total`, `limit`, `offset`, `returned`). `get` returns the full sanitization-wrapped `CollectionPayload` for one `collection_id`.
+
+**Wire path / consumers**:
+- Same kubectl-exec + Extension/Desktop User RBAC as other query commands.
+- **This initiative**: operator-only producer (schedule, persist, status participation, CLI). kube9-vscode and kube9-desktop do not ship consumer UX in the same milestone; they remain read-only progressive-enhancement peers.
+- Desktop foreshadowed flat `metrics` / `security` sketches, CRD `SecurityScan` notes, and any api.kube9.io metrics posting paths are **non-normative** for operator v1 collection payloads. Operator contracts win for in-cluster query JSON.
+
+**Failure / degrade (consumer-facing)**:
+- CLI validation and not-found follow existing collections stderr JSON + non-zero exit patterns.
+- Prometheus absence affects whether new `performance-metrics` rows appear over time; it does not invent a separate query error family for list/get of stored rows. Exact collector tick failure codes are open implementation decisions (see [external_systems.md](external_systems.md)).
+
+**Retention (consumer narrative)**: No time-based TTL and no count-based cap for `collections` rows in this initiative (assessments-class: rows persist until explicit remove / operational cleanup). Consumers rely only on rows still stored. Authoritative persistence wording lives in `.ai/data/consistency.md`.
+
+### Open implementation decisions (collections query / status wire)
+
+- Exact CLI help text / `--type` enum listing once both new tokens ship; table/compact column widths for new summary fields (coordinate with interface).
+- Whether status ConfigMap gains an optional bounded `prometheus` (or equivalent) detection block analogous to `trivy` / `argocd` (coordinate with external_systems + data serialization).
+- Payload field catalogs for `performance-metrics` and `security-posture` (owned by data; integration requires only that wire types stay additive and peer-tolerant).
+- Confirm peers that ignore unknown `type` values need no same-milestone `.ai` edits (default: yes).
 
 ### Assessment API Contract
 

--- a/.ai/integration/authorization.md
+++ b/.ai/integration/authorization.md
@@ -6,30 +6,45 @@
 
 **Resource**: `ClusterRole` (created when `rbac.create: true` in Helm values)
 
-**Permissions Required**:
+**Permissions Required** (read-only cluster access; chart `ClusterRole` is authoritative when `rbac.create: true`):
 
 **Cluster Metadata**:
 - `get` on non-resource URL `/version` (cluster version)
 
 **Core Resources** (read-only):
 - `get`, `list`, `watch` on:
-  - `nodes` - For cluster metadata collection
-  - `namespaces` - For resource inventory and ArgoCD detection
-  - `pods` - For resource inventory
-  - `events` - For Kubernetes event watching and recording
-  - `services` - For resource inventory
+  - `nodes` - Cluster metadata collection
+  - `namespaces` - Resource inventory, ArgoCD detection, posture coverage denominators
+  - `pods` - Resource inventory and security-posture aggregates (privileged / hostPath / hostNetwork-style signals)
+  - `events` - Kubernetes event watching and recording
+  - `services` - Resource inventory
+  - `configmaps` - Cluster-scoped reads used by collectors/assessments (status ConfigMap writes remain Role-scoped)
+  - `resourcequotas`, `limitranges` - Assessment / governance signals
 
 **Apps Resources** (read-only):
 - `get`, `list`, `watch` on:
-  - `deployments` - For resource inventory and ArgoCD detection
-  - `replicasets` - For resource inventory
-  - `statefulsets` - For resource inventory
+  - `deployments`, `replicasets`, `statefulsets`, `daemonsets` - Inventory, ArgoCD detection, assessment
+
+**Networking / policy** (read-only):
+- `get`, `list`, `watch` on:
+  - `networkpolicies` (networking.k8s.io) - Security-posture NetworkPolicy coverage and related conformance/assessment checks
+  - `poddisruptionbudgets` (policy) - Assessment
+  - `horizontalpodautoscalers` (autoscaling) - Assessment
+  - `verticalpodautoscalers` (autoscaling.k8s.io) - Optional when CRD present
+
+**RBAC resources** (read-only; assessment analysis today):
+- `get`, `list` on `clusterroles`, `roles`, `clusterrolebindings`, `rolebindings` (rbac.authorization.k8s.io)
+- **Note:** Security-posture **v1** does **not** publish RBAC-risk rollups. These reads remain for assessment checks; posture v1 must not expand into RBAC-risk product scope via this initiative.
 
 **ArgoCD Detection**:
 - `get`, `list` on:
   - `customresourcedefinitions` (apiextensions.k8s.io) - To check for `applications.argoproj.io` CRD
   - `namespaces` - To verify ArgoCD namespace exists
   - `deployments` (apps) - To find ArgoCD server deployment
+
+**Security-posture collector**: Uses the same read-only Kubernetes API surface (pods, namespaces, networkpolicies, and related object fields already readable). No Secrets API, no `pods/exec`, no cluster-admin. Any additional API-group reads required for agreed NSA/CIS-oriented rollups are additive ClusterRole deltas coordinated with operations (open implementation decision below).
+
+**Prometheus outbound client**: Optional HTTP egress to a configured in-cluster Prometheus. Does **not** require new Kubernetes RBAC verbs for Prometheus itself. Credential mounts (if any) follow optional Secret patterns; do not imply SA token as Prometheus credential by default (see [external_systems.md](external_systems.md)).
 
 **Binding**: `ClusterRoleBinding` binds ServiceAccount to ClusterRole
 
@@ -113,8 +128,9 @@ rules:
 **Communication Patterns**:
 
 **Operator → In-Cluster Services** (outbound only):
-- Kubernetes API: Operator-initiated API calls
-- Prometheus: Metrics endpoint exposed, scraped by Prometheus (no ingress needed)
+- Kubernetes API: Operator-initiated API calls (includes security-posture aggregates; sole posture source)
+- Prometheus **exposition**: Operator `/metrics` exposed on the health server; scraped by in-cluster Prometheus / agents (no ingress needed). kube9 does not require owning the scraper.
+- Prometheus **outbound client** (optional, performance-metrics collector): Operator-initiated HTTP to a configured in-cluster Prometheus endpoint (query and/or scrape). Trivy-style opt-in; graceful degrade when absent/unreachable. No metrics-server / Metrics API path. No phone-home.
 - Argo CD: Detection uses the Kubernetes API (`src/argocd/detection.ts`). **M9** adds read-only HTTP to in-cluster `argocd-server` for Application list/status into SQLite. **M17** adds on-demand `GET /api/v1/applications/{name}/resource-tree` at CLI query time. All Argo CD HTTP is **zero ingress** (cluster-internal egress).
 - **M17 resource-tree auth:** Dedicated Argo CD API bearer only (`ARGOCD_API_BEARER_TOKEN` or `ARGOCD_API_TOKEN_FILE`). The resource-tree path **must not** fall back to the operator Kubernetes ServiceAccount token. Platform admin creates a Secret out-of-band and sets Helm `argocd.api.token.existingSecret` / `existingSecretKey` (default key `token`); the chart mounts the key at `/var/run/secrets/kube9/argocd-api-token` and sets `ARGOCD_API_TOKEN_FILE`. Unset `existingSecret` is default-off. Platform admin grants Argo CD RBAC `get` on Applications (resource-tree) for the token identity; the kube9-operator chart does not mutate Argo CD roles.
 
@@ -127,6 +143,7 @@ rules:
 **Outbound connections (operator core)**:
 - Kubernetes API (in-cluster or via kubeconfig)
 - Optional Trivy HTTP health/version probes when `TRIVY_SERVER_URL` / chart `trivy.serverUrl` is set
+- Optional Prometheus HTTP client when performance-metrics outbound is configured (base URL / enable knobs; see [external_systems.md](external_systems.md))
 - The operator does not register with or upload collections to `kube9-api`
 
 **Benefits**:
@@ -138,3 +155,6 @@ rules:
 ## Open implementation decisions
 
 - **Agent auth model**: Closed for this epic. Desktop AI agent Tier 2 uses the same Extension / Desktop User RBAC and kubectl-exec path; no new Role, ClusterRole, or token type.
+- **Security-posture RBAC delta vs live ClusterRole**: Chart already grants read on pods, namespaces, networkpolicies, and related assessment resources. Coordinate with operations any **additional** API-group/resource verbs required for agreed NSA/CIS-oriented rollups. Keep read-only; no Secrets, no pod exec, no cluster-admin. Document the final delta in Helm ClusterRole + this file together.
+- **Prometheus outbound auth knobs**: Exact none / bearer / basic / Secret-mount defaults and TLS verify vs insecure. Confirm operator SA token is never an implicit Prometheus credential. Align Secret mount patterns with chart precedents if dedicated credentials are supported.
+- **Degrade vs global health**: Prometheus miss and posture API list failures follow existing collector failure practice (log/metric/retry next interval). Do not widen `health: degraded` / `unhealthy` solely for optional Prometheus absence (coordinate wording with runtime/error_handling).

--- a/.ai/integration/external_systems.md
+++ b/.ai/integration/external_systems.md
@@ -88,7 +88,13 @@ Exposed in ConfigMap `kube9-operator-status` under `status.argocd`:
 
 **Consumption**: Scan results feed SQLite persistence, security assessment checks, operator CLI query commands, and Prometheus metrics (see `.ai/data/data_model.md` and `.ai/operations/observability.md` as those contracts are extended for M3).
 
+**Boundary vs security-posture collection**: Security-posture collection uses **Kubernetes API aggregates only** (privileged/hostPath/hostNetwork-style counts, NetworkPolicy coverage, basic NSA/CIS-oriented object rollups). It must **not** call Trivy HTTP/CLI, store CVE bodies, or treat Trivy detection as a prerequisite. Trivy remains the vulnerability path; configuration-pattern security-context counts remain a separate collection type.
+
 ## Prometheus
+
+Prometheus has two distinct roles for kube9-operator. They must not be conflated in contracts or Helm docs.
+
+### Role A: Operator metrics exposition (inbound scrape)
 
 **Metrics Endpoint**:
 - **Path**: `/metrics` on health server (port 8080)
@@ -100,16 +106,45 @@ Exposed in ConfigMap `kube9-operator-status` under `status.argocd`:
 - Event metrics (queue size, storage size, errors)
 - Assessment metrics (run counts, durations, results)
 
-**Configuration**:
-- **Endpoint override**: Planned for M1 milestone (not yet implemented)
-- **Auto-detection**: Default behavior (scrapes from `/metrics` endpoint)
-- **Service discovery**: Uses standard Kubernetes service discovery
-- **Scraping**: Configured via Prometheus ServiceMonitor or annotations (`prometheus.io/scrape: "true"`, `prometheus.io/port: "8080"`)
+**Inbound scrape configuration** (cluster / Prometheus Operator side):
+- **Service discovery**: Standard Kubernetes service discovery
+- **Scraping**: Configured via Prometheus ServiceMonitor / PodMonitor or annotations (`prometheus.io/scrape: "true"`, `prometheus.io/port: "8080"`)
+- kube9-operator does **not** require owning a ServiceMonitor for its own `/metrics` scrape to function
 
 **Health Server**:
 - Runs on port 8080 (configurable)
 - Provides `/healthz` (liveness), `/readyz` (readiness), and `/metrics` endpoints
 - Started early during operator initialization for probe availability
+
+### Role B: Optional outbound client (performance-metrics collector)
+
+**Scope boundary**: The performance-metrics collector may call an **in-cluster Prometheus** HTTP API (and/or scrape selected in-cluster targets) to build a **bounded aggregate snapshot** for SQLite `collections`. This path is **optional** and **additive** to Role A. The kube9-operator chart does **not** install Prometheus or Prometheus Operator. Absence or unreachability must not block other collectors, readiness, or serve startup.
+
+**Opt-in posture** (align with Trivy optional outbound):
+- No performance-metrics pull until an in-cluster Prometheus endpoint is configured (or explicitly enabled via chart/env).
+- Do **not** silently auto-query arbitrary discovered scrapers without configuration.
+- Default install stays zero-ingress: cluster-internal egress only when configured.
+- **Non-goals**: metrics-server / Kubernetes Metrics API fallback; multi-cluster federation; phone-home or upload of collections/metrics to kube9-api; replacing Prometheus Operator as a metrics stack.
+
+**Behavior**:
+- **Detection / readiness of the integration**: When configured, the operator may probe the configured Prometheus endpoint (timeouts and periodic refresh are implementation-defined, Trivy/Argo CD-adjacent). Exact Helm/env key names and whether a bounded `status.prometheus` (or equivalent) block is published are open implementation decisions below.
+- **Collection**: On CollectionScheduler ticks for the performance-metrics type, fetch a bounded utilization/ratio rollup snapshot. Persist as an append-only SQLite `collections` row when successful (see `.ai/data/`).
+- **Resilience**: Unreachable, auth-failed, timed-out, or empty Prometheus responses degrade **this collection type only** (log + metric + retry next interval). Operator global `health` does not become `unhealthy` solely because Prometheus is missing. Exact tick classification (failed vs skipped vs success-with-unavailable) is coordinated with runtime/data/error_handling.
+
+**Auth family** (shape):
+- Stay inside existing optional in-cluster HTTP patterns (base URL, timeout, TLS verify / insecure).
+- Prefer **not** sending the operator Kubernetes ServiceAccount token to Prometheus by default.
+- Dedicated optional credentials only when a platform admin configures them (Secret mount pattern may follow Argo CD / chart precedents). Exact schemes and defaults are open implementation decisions below.
+
+**Consumption**: Snapshots feed SQLite `collections`, `query collections`, status `collectionStats` participation, and observability `type` labels. kube9-vscode / kube9-desktop are progressive-enhancement consumers later; this initiative is operator-producer only.
+
+### Open implementation decisions (Prometheus outbound)
+
+- Discovery / URL keys: exact Helm values and env names for base URL, enable flag, namespace/service defaults, timeouts; whether any presence probe populates a bounded `status.prometheus` (or equivalent) analogous to `status.trivy`.
+- Call shape: PromQL HTTP API vs direct scrape of selected targets (or both); requirements-level query set / series allowlist; body/size bounds; retries.
+- Auth knobs: none vs bearer vs basic (and Secret mount if any); TLS verify / insecure default; confirm SA token is never used as an implicit Prometheus credential.
+- Degrade signals: failure codes for unreachable / auth failed / timeout / empty result, and how they surface in collectionStats / CLI without changing global health semantics beyond existing collector failure practice.
+- Registration gate consistency with runtime: Trivy-style opt-in until configured (integration default). Exact always-register-with-skip vs gated-register wiring must match `.ai/runtime/` after Phase D open-impl lock.
 
 ## In-cluster clients (kube9-vscode and kube9-desktop)
 
@@ -131,6 +166,7 @@ Exposed in ConfigMap `kube9-operator-status` under `status.argocd`:
    - Executes CLI commands via `kubectl exec` for:
      - Event history (`query events list`): vscode, Desktop historical context, and Desktop AI agent Tier 2
      - Assessment results (`query assessments summary`, `query assessments history`): same consumer set for history; agent wraps history for debugging turns
+     - Collections (`query collections list|get`): operator-owned; additive types include performance-metrics and security-posture. vscode/desktop consumer UX is progressive enhancement (not same-milestone)
      - Detailed status (`query status`)
    - **Non-goal**: No operator log query surface for these clients. Live logs stay on the Kubernetes API path in the client (Desktop Tier 1).
 

--- a/.ai/integration/index.md
+++ b/.ai/integration/index.md
@@ -2,13 +2,14 @@
 
 How the operator connects to external APIs and systems.
 
-- **Kubernetes**: Cluster resources, ConfigMap, in-cluster config
+- **Kubernetes**: Cluster resources, ConfigMap, in-cluster config; sole source for security-posture collection aggregates
 - **ArgoCD**: Detection (CRD check, namespace check, deployment verification), periodic refresh (6h default), configuration via environment variables; Application status (M9)
-- **Prometheus**: Metrics endpoint (`/metrics`), auto-detection; Endpoint override (M1 planned)
-- **In-cluster consumers**: kube9-vscode and kube9-desktop (including the Desktop Pro AI agent) via ConfigMap read and CLI exec (`kubectl exec` → `kube9-operator query …`)
+- **Prometheus (dual role)**: (1) Operator exposes `/metrics` for inbound scrape; (2) optional outbound HTTP client for performance-metrics collection (Trivy-style opt-in, graceful degrade, no metrics-server fallback)
+- **Trivy**: Optional vulnerability path only; not used for security-posture collection
+- **In-cluster consumers**: kube9-vscode and kube9-desktop (including the Desktop Pro AI agent) via ConfigMap read and CLI exec (`kubectl exec` → `kube9-operator query …`); progressive enhancement for new collection types (operator owns producer this initiative)
 
 ## Child Docs
-- [api_contracts.md](api_contracts.md): Extension/Desktop↔operator contracts (ConfigMap read, CLI exec, Assessment API); agent co-consumer of events list and assessments history
-- [external_systems.md](external_systems.md): Kubernetes API, ArgoCD detection/configuration, Prometheus metrics, kube9-vscode and kube9-desktop integration
-- [authorization.md](authorization.md): RBAC (operator ClusterRole/Role, extension/Desktop user permissions), zero ingress architecture
+- [api_contracts.md](api_contracts.md): Extension/Desktop↔operator contracts (ConfigMap read, CLI exec, Assessment API, collections query); agent co-consumer of events list and assessments history
+- [external_systems.md](external_systems.md): Kubernetes API, ArgoCD detection/configuration, Prometheus exposition + optional outbound client, Trivy boundary, kube9-vscode and kube9-desktop integration
+- [authorization.md](authorization.md): RBAC (operator ClusterRole/Role, extension/Desktop user permissions), zero ingress architecture, optional outbound auth posture
 - [messaging_async.md](messaging_async.md): Event queue (EventRecorder, EventQueueWorker, non-blocking recording)

--- a/.ai/interface/input_handling.md
+++ b/.ai/interface/input_handling.md
@@ -74,11 +74,36 @@ kube9-operator assess history [options]
 - `--since`: Filter since date (ISO 8601)
 - `--format`: Output format (json|yaml|table|compact), default: json
 
+### Collections Commands
+```
+kube9-operator query collections list [options]
+kube9-operator query collections get <collectionId> [--format=<format>]
+```
+
+Persisted M8 collection snapshots (SQLite). Extends the existing `query collections` family; no parallel subcommands for new collector types.
+
+**Collections List Options:**
+- `--type`: Filter by collection type (`cluster-metadata` | `resource-inventory` | `resource-configuration-patterns` | `performance-metrics` | `security-posture`)
+- `--cluster-id`: Filter by cluster id
+- `--since`: Collected on/after date (ISO 8601)
+- `--until`: Collected before date (ISO 8601)
+- `--limit`: Limit number of results (default: 50, max: 1000)
+- `--offset`: Skip number of results (default: 0)
+- `--format`: Output format (json|yaml|table|compact), default: json
+
+**Collections Get Options:**
+- `--format`: Output format (json|yaml|table|compact), default: json
+
+**Collections input rules:**
+- New collector types are additive `--type` enum values only (same kebab-case family as the three shipped types).
+- Filtering to a type with no stored rows is a valid list input; empty success is presentation, not an error (see [presentation.md](presentation.md)).
+- Invalid `--type` values fail option validation (Zod/Commander) with the existing JSON-on-stderr error pattern.
+
 ## Output Formats
 - `json` (default): Pretty-printed JSON with 2-space indentation
 - `yaml`: YAML format with 2-space indentation
 - `table`: Human-readable table format
-- `compact`: Compact table format (assessment commands only)
+- `compact`: Compact table format (assessments, collections, and other query surfaces that advertise it)
 
 ## Invocation
 Extensions use `kubectl exec` into operator pod:
@@ -90,3 +115,8 @@ kubectl exec -n <namespace> deploy/kube9-operator -- kube9-operator <command> [o
 - Uses Commander.js for command-line argument parsing
 - Uses Zod for option validation and type safety
 - All date filters accept ISO 8601 format strings
+
+## Open implementation decisions
+
+- **Exact `--type` tokens:** Lock final kebab-case strings for the two new collectors with data / business_logic (`performance-metrics` and `security-posture` are the working candidates already listed above). CLI Zod enum, Commander help text, and payload discriminants must match.
+- **Help / description copy:** Exact Commander descriptions for `query collections` and the `--type` option once the enum is final (today help lists only the three shipped types).

--- a/.ai/interface/interaction_flow.md
+++ b/.ai/interface/interaction_flow.md
@@ -58,3 +58,18 @@
 3. Extension processes results:
    - Parses JSON/YAML output based on `--format` option
    - Handles pagination metadata for list queries
+
+## Collections Query Flow
+Operator CLI / kubectl-exec consumers only for this milestone (no vscode/desktop UX flow). Same pod resolution and stderr error pattern as [CLI Query Flow](#cli-query-flow).
+
+1. Operator or peer lists collections:
+   - `kube9-operator query collections list [--type=] [--cluster-id=] [--since=] [--until=] [--limit=] [--offset=] [--format=]`
+   - `--type` accepts the shipped types plus additive performance-metrics and security-posture values (exact tokens in [input_handling.md](input_handling.md))
+   - Pagination envelope matches other list queries (`total`, `limit`, `offset`, `returned`)
+2. Operator or peer retrieves one collection:
+   - `kube9-operator query collections get <collectionId> [--format=]`
+   - Returns full `CollectionPayload` (generic json/yaml/table/compact rendering; no type-specific get layout in v1)
+3. Consumer processes results:
+   - Empty list (including filter to a new type with no rows yet) is success; treat as evidence gap, not failure
+   - Parse stdout by `--format`; validation/not-found failures remain JSON on stderr with non-zero exit
+   - Prometheus degrade for performance collection does not add a separate interactive recovery branch on this surface

--- a/.ai/interface/presentation.md
+++ b/.ai/interface/presentation.md
@@ -60,3 +60,35 @@ The `status` key contains a JSON string with the following `OperatorStatus` stru
 - Client copy must not claim official CNCF conformance or certification from this status payload alone.
 - `not-evaluated` and `needs-evidence` rows are first-class outcomes. They should be shown as unresolved readiness evidence, not as passing or failing cluster checks.
 - Rows should group by checklist category and distinguish MUST from SHOULD counts.
+
+## Collections Query Presentation
+
+Operator CLI only this milestone (no vscode/desktop consumer UX contracts). Surface: `kube9-operator query collections list|get` via `kubectl exec`.
+
+### List
+
+- **Envelope (json/yaml):** `{ collections: [...summaries], pagination: { total, limit, offset, returned } }`.
+- **Table / compact columns:** `COLLECTION_ID`, `CLUSTER_ID`, `TYPE`, `COLLECTED_AT` (unchanged for the two new types).
+- **Empty success:** Zero matching rows (including `--type` for a new collector with no snapshots yet) is a normal success outcome. Table/compact print an empty-results line (today: `No results found`); json/yaml return an empty `collections` array with pagination totals of zero. Do not present empty list as unhealthy or as a transport failure.
+- **TYPE values:** Additive kebab-case strings for performance metrics and security posture participate in the same `TYPE` column as the three shipped types. No per-type list layouts.
+
+### Get
+
+- Returns the full `CollectionPayload` for `<collectionId>`.
+- Formats use the shared formatter: json/yaml for structured consumers; table/compact as generic key-value rendering of the payload object.
+- No type-specific get table layouts for performance metrics or security posture in v1.
+
+### Degrade and errors
+
+- Prometheus absence / performance degrade is not a distinct CLI presentation mode. Operators see missing or failed persisted rows (or empty type filters), not a special “Prometheus unavailable” list/get cue, unless a later data contract stores an explicit payload marker that json/yaml already surface.
+- Not-found get and validation/runtime failures keep the existing JSON-on-stderr pattern and non-zero exit; they are distinct from empty successful list.
+
+### Status ConfigMap
+
+- New collection types participate in aggregate `collectionStats` counters only. No new status fields or per-type presentation schema for this milestone. Peer extensions continue progressive enhancement on the existing status shape.
+
+## Open implementation decisions
+
+- **TYPE column truncation:** Confirm whether current table/compact TYPE truncation (24 compact / 36 table) remains sufficient for the final type tokens, or widen only the TYPE column.
+- **Get formatting:** Keep generic `formatOutput` for new payload bodies in v1 (no type-specific table columns). Any human-oriented summary view is deferred.
+- **Empty-list copy:** Keep existing empty-results language consistent with events/assessments; do not invent a type-specific “no collections of this type yet” string unless product copy requires it at implement time.

--- a/.ai/knowledge_map.json
+++ b/.ai/knowledge_map.json
@@ -72,6 +72,25 @@
             ".ai/operations/observability.md",
             ".ai/operations/security.md"
           ]
+        },
+        {
+          "name": "schemas",
+          "primary_doc": ".ai/schemas/vision.schema.json",
+          "description": "JSON Schema validators for structured .ai product documents (vision, project).",
+          "children": [
+            ".ai/schemas/vision.schema.json",
+            ".ai/schemas/project.schema.json"
+          ]
+        },
+        {
+          "name": "specs",
+          "primary_doc": ".ai/specs/index.md",
+          "description": "Durable capability-level architecture and behavior specifications.",
+          "children": [
+            ".ai/specs/data-collection-pipeline.spec.md",
+            ".ai/specs/performance-metrics-collector.spec.md",
+            ".ai/specs/security-posture-collector.spec.md"
+          ]
         }
       ]
     }

--- a/.ai/operations/build_packaging.md
+++ b/.ai/operations/build_packaging.md
@@ -56,6 +56,19 @@ The Helm chart supports comprehensive configuration through `values.yaml`:
 - `metrics.intervals.clusterMetadata`: Cluster metadata collection interval in seconds (default: `86400` = 24 hours, minimum: `3600`)
 - `metrics.intervals.resourceInventory`: Resource inventory collection interval in seconds (default: `21600` = 6 hours, minimum: `1800`)
 - `metrics.intervals.resourceConfigurationPatterns`: Resource configuration patterns collection interval in seconds (default: `43200` = 12 hours, minimum: `3600`)
+- `metrics.intervals.performanceMetrics`: Performance metrics collection interval in seconds (default: `900` = 15 minutes; enforced minimum locked with runtime)
+- `metrics.intervals.securityPosture`: Security posture collection interval in seconds (default: `86400` = 24 hours; enforced minimum locked with runtime)
+
+Chart `values.yaml` also carries intervals for Argo CD Application status and workload image scan under the same `metrics.intervals` map; those stay documented in the chart README.
+
+#### Optional Prometheus (performance collector, outbound)
+
+Performance metrics use an optional in-cluster Prometheus HTTP client (query and/or scrape). Packaging posture mirrors Trivy / Argo CD optional integrations:
+
+- Default install stays **zero-ingress**. Prometheus integration is **outbound** cluster-internal traffic when configured or discovered.
+- Chart must not install Prometheus, create a ServiceMonitor for kube9 ownership of Prometheus, or invent an inbound scrape surface for this collector.
+- Chart must not create Secrets from plaintext credentials. If bearer/auth is ever required, use an existingSecret mount pattern (same class as `argocd.api.token.existingSecret`).
+- Exact values-tree keys (`prometheus.*` vs `performanceMetrics.*`), discovery defaults, timeout/TLS knobs, and enable vs always-register wiring are open implementation decisions below (coordinate with runtime + integration).
 
 #### Event Storage
 - `events.persistence.enabled`: Enable persistent storage (default: `true`)
@@ -70,6 +83,7 @@ The Helm chart supports comprehensive configuration through `values.yaml`:
 **Packaging non-goals (agent-consumer path):**
 - No Helm values, PVC sizing, or image packaging for operator **log** capture or failure-log retention
 - No assessment-history TTL / prune knobs in the chart (assessments persist until explicit remove or cascade; data owns lifecycle)
+- No collections TTL or count-cap knobs in the chart (SQLite `collections` rows persist until explicit remove / operational cleanup; same class as assessments). Operators should expect PVC growth under frequent append-only collectors (notably ~15m performance ticks); sizing stays an operational concern, not a product retention SLA.
 
 #### Namespace
 - **Default Namespace**: `kube9-system`
@@ -123,3 +137,9 @@ The Helm chart supports comprehensive configuration through `values.yaml`:
 - Chart version follows SemVer
 - App version matches chart version
 - Chart versioning independent of operator binary version
+
+## Open implementation decisions
+
+- **Exact Helm interval keys and env mapping:** Lock camelCase under `metrics.intervals` (candidates above: `performanceMetrics`, `securityPosture`) and Deployment env names (candidates: `PERFORMANCE_METRICS_INTERVAL_SECONDS`, `SECURITY_POSTURE_INTERVAL_SECONDS`). Defaults stay in the ~900s / ~86400s class; enforced minima and random-offset seconds align with runtime config loader.
+- **Prometheus values block shape:** Whether outbound client knobs live under `prometheus.*` (mirror `trivy.*` sibling) or nested under `performanceMetrics.*`; which of base URL, autoDetect/discovery, timeoutMs, tlsInsecure, and existingSecret auth are chart-first vs env-only; default-off until configured vs always-register collector with graceful degrade (must match runtime + integration).
+- **Chart harness / README tables:** `test-helm-chart.sh` Phase 5 assertions and README value tables for new interval env keys, optional Prometheus knobs, and any status fields; consumer wording that performance needs optional Prometheus and security posture is cluster-API only.

--- a/.ai/operations/deployment_environments.md
+++ b/.ai/operations/deployment_environments.md
@@ -91,8 +91,11 @@ Desktop and other clients may query retained events and assessments history via 
 - **Persistence disabled:** With `events.persistence.enabled = false` (`emptyDir`), history is ephemeral across pod restarts. Consumers treat that as operator-history degraded or absent, not as a separate environment tier.
 - **No log-capture ops:** Operations contracts do not add log retention, log PVC sizing, failure-log capture runbooks, or pruned-log recovery. That remains a separate epic.
 - **Assessment history:** No ops-owned time-based TTL or cleanup schedule for assessment rows. Storage growth under frequent assessments is a data-domain concern unless a later epic adds policy.
+- **Collections (append-only, no TTL):** SQLite `collections` has no time-based TTL or count-based cap in this product lane (same class as assessments). Finishing performance (~15m) and security-posture (~24h) collectors increases append volume on the chart-default PVC. That is an operational disk-growth concern for platform admins, not a new environment tier, retention SLA, or chart prune knob. No phone-home / kube9-api export path is introduced.
+- **No new delivery tier:** Performance Prometheus outbound and security-posture cluster-API reads stay on the existing Helm / GHCR / kind / minikube path. Zero-ingress default and optional-integration degrade posture are unchanged. Agent / Desktop remain read-only progressive-enhancement peers for this collector milestone.
 
 ### Open implementation decisions
 
 - **Local dogfood paths:** Whether minikube / kind checklists should call out an explicit operator-present vs operator-absent history query smoke step (Desktop owns acceptance scoring; operator side only needs confirmable query + chart defaults).
 - **emptyDir wording in install docs:** Exact operator install-doc phrasing that persistence-off means ephemeral history for agent/evidence consumers (packaging already documents the volume switch).
+- **Collector smoke in Helm Phase 5 / minikube:** Whether `test-helm-chart.sh` Phase 5 or deploy:minikube docs assert new interval env keys and (when Prometheus is absent) graceful performance-collector degrade without failing readiness; exact assertions stay refine-issue / harness work.

--- a/.ai/operations/index.md
+++ b/.ai/operations/index.md
@@ -4,11 +4,12 @@ How the operator is built, deployed, observed, and secured.
 
 - **Install**: Helm chart, GHCR image
 - **Distribution**: charts.kube9.io, GitHub Actions
-- **Observability**: Prometheus metrics, health checks, logging
+- **Observability**: Prometheus metrics (operator `/metrics` exposition plus optional outbound Prometheus for performance collection), health checks, logging
+- **Collectors packaging**: Interval keys under `metrics.intervals` for core collectors including performance metrics (~15m) and security posture (~24h); no collections TTL / count-cap knobs; PVC growth is operational
 - **Agent / Desktop history consumers**: Best-effort queryable history when the operator is ready and persistence uses the chart default PVC. Advertised event retention stays severity-split **7** / **30** days. No log-capture ops, assessment TTL knobs, or Pro-debugging gate on operator install.
 
 ## Child Docs
-- [build_packaging.md](build_packaging.md) — Helm chart, Docker image; advertised event retention defaults; packaging non-goals for log capture
-- [deployment_environments.md](deployment_environments.md) — Chart hosting, image publishing, **local testing** (Minikube via kube9-minikube, kind in test-helm-chart); agent-consumer availability posture
-- [observability.md](observability.md) — Metrics, health, logging
-- [security.md](security.md) — Zero ingress, minimal RBAC
+- [build_packaging.md](build_packaging.md) — Helm chart, Docker image; collection intervals; optional Prometheus values posture; advertised event retention defaults; packaging non-goals for log capture and collections TTL
+- [deployment_environments.md](deployment_environments.md) — Chart hosting, image publishing, **local testing** (Minikube via kube9-minikube, kind in test-helm-chart); agent-consumer availability posture; collections disk-growth note
+- [observability.md](observability.md) — Metrics, health, logging; collection `type` labels and aggregate `collectionStats`
+- [security.md](security.md) — Zero ingress, minimal RBAC (chart-synced ClusterRole); optional Trivy / Prometheus outbound degrade

--- a/.ai/operations/observability.md
+++ b/.ai/operations/observability.md
@@ -96,11 +96,13 @@ All metrics are exposed at `/metrics` endpoint and follow Prometheus naming conv
 
 ### Collection Metrics
 
+Collection metrics use a bounded `type` label family shared with collection payload / CLI type ids (data + interface own the strings; operations documents Prometheus alignment). Existing type strings stay stable. Additive types for the finished collector set are `performance-metrics` and `security-posture` (exact lock with data/runtime if candidates change before implementation).
+
 #### `kube9_operator_collection_total`
 - **Type**: Counter
 - **Description**: Total number of collection attempts by type and status
 - **Labels**:
-  - `type`: Collection type (e.g., "cluster-metadata", "resource-inventory", "resource-configuration-patterns")
+  - `type`: Collection type (e.g., "cluster-metadata", "resource-inventory", "resource-configuration-patterns", "performance-metrics", "security-posture")
   - `status`: Collection status ("success" or "failed")
 
 #### `kube9_operator_collection_duration_seconds`
@@ -115,6 +117,12 @@ All metrics are exposed at `/metrics` endpoint and follow Prometheus naming conv
 - **Description**: Unix timestamp of last successful collection by type
 - **Labels**:
   - `type`: Collection type
+
+#### Status ConfigMap `collectionStats`
+
+Status ConfigMap `collectionStats` remains an **aggregate** counter set (`totalSuccessCount`, `totalFailureCount`, `collectionsStoredCount`, `lastSuccessTime`). New collectors participate in those totals without renaming or removing required aggregate fields. Optional per-type progressive enhancement is allowed only if peers that read aggregates stay compatible; do not replace the aggregate shape with a closed per-type enum.
+
+Prometheus-absent or unreachable ticks for performance metrics must not fail scrapes of the operator `/metrics` endpoint and must not mark the Deployment unready. Mapping of those ticks onto the `status` label (`success` / `failed` / skip-without-increment) is coordinated with runtime degrade semantics (open decision below).
 
 ### Assessment metrics
 
@@ -258,3 +266,8 @@ Agent or Desktop wrapping of `query events list` / `query assessments history` d
 ### Open implementation decisions
 
 - **Alert thresholds under query load:** Exact alert thresholds on `kube9_operator_events_dropped_total` / queue depth when clients issue more frequent history queries remain refine-issue backlog, not a packaging or deployment-band change.
+- **Canonical collection `type` label strings:** Confirm Prometheus `type` values match payload / CLI ids (`performance-metrics`, `security-posture` candidates). Do not rename or remove existing type strings; keep cardinality bounded to the known collection-type set.
+- **Prometheus-absent tick → `status` label:** How absent/unreachable Prometheus maps to `kube9_operator_collection_total` `status` (`success` / `failed` / skip-without-increment) so existing dashboards that filter known types keep working; coordinate with runtime degrade classification.
+- **`collectionStats` progressive enhancement:** Whether status ConfigMap stays aggregate-only for this initiative, or gains optional per-type fields under progressive enhancement without breaking required aggregate fields.
+- **Histogram buckets for ~15m performance ticks:** Confirm shared collection duration buckets remain adequate; any bucket tweak is refine-issue backlog, not a product packaging change.
+- **Collection-series alert thresholds:** Exact alert thresholds on the new type labels stay `/refine-issue` backlog like other collection metrics.

--- a/.ai/operations/security.md
+++ b/.ai/operations/security.md
@@ -22,20 +22,21 @@
 
 ### ClusterRole Permissions
 
-The operator requires minimal cluster-wide permissions via ClusterRole:
+The operator requires minimal cluster-wide permissions via ClusterRole. Live chart truth is `charts/kube9-operator/templates/clusterrole.yaml`; this section tracks that read-only grant set (verbs `get` / `list` / `watch` unless noted).
 
 #### Read-Only Cluster Resources
-- **`/version`** (non-resource URL): `get` - Read cluster version for metadata collection
-- **`nodes`**: `get`, `list`, `watch` - Cluster metadata collection
-- **`namespaces`**: `get`, `list`, `watch` - Cluster metadata and ArgoCD detection
-- **`pods`**: `get`, `list`, `watch` - Cluster metadata collection
-- **`events`**: `get`, `list`, `watch` - Event monitoring and recording
+- **`/version`** (non-resource URL): `get` - Cluster version for metadata collection
+- **`nodes`**, **`namespaces`**, **`pods`**, **`configmaps`** (core): `get`, `list`, `watch` - Metadata, inventory, assessments, conformance
+- **`events`** (core): `get`, `list`, `watch` - Event monitoring and recording
+- **`services`**, **`resourcequotas`**, **`limitranges`** (core): `get`, `list`, `watch` - Inventory and assessment checks
 
-#### Read-Only Workload Resources
-- **`deployments`** (apps): `get`, `list`, `watch` - Resource inventory and ArgoCD detection
-- **`replicasets`** (apps): `get`, `list`, `watch` - Resource inventory
-- **`statefulsets`** (apps): `get`, `list`, `watch` - Resource inventory
-- **`services`**: `get`, `list`, `watch` - Resource inventory
+#### Read-Only Workload and Policy Resources
+- **`deployments`**, **`replicasets`**, **`statefulsets`**, **`daemonsets`** (apps): `get`, `list`, `watch` - Inventory, Argo CD detection, assessment / posture signals (privileged, hostPath, hostNetwork-style counts from pod/workload specs)
+- **`horizontalpodautoscalers`** (autoscaling): `get`, `list`, `watch` - Assessment checks
+- **`poddisruptionbudgets`** (policy): `get`, `list`, `watch` - Assessment checks
+- **`networkpolicies`** (networking.k8s.io): `get`, `list`, `watch` - AI conformance network-policy checks and security-posture NetworkPolicy coverage rollups
+- **`verticalpodautoscalers`** (autoscaling.k8s.io): `get`, `list`, `watch` - Optional VPA assessment checks when CRDs exist
+- **`clusterroles`**, **`roles`**, **`clusterrolebindings`**, **`rolebindings`** (rbac.authorization.k8s.io): `get`, `list` - Assessment RBAC analysis (not security-posture v1 RBAC-risk rollups; those remain deferred)
 
 #### ArgoCD Detection Permissions
 - **`customresourcedefinitions`** (apiextensions.k8s.io): `get`, `list` - ArgoCD CRD detection
@@ -137,13 +138,34 @@ securityContext:
 - **No Trivy lifecycle in-chart**: Installing, upgrading, or operating the Trivy Operator or Trivy server is out of scope for this repository; platform or cluster admins own that lifecycle.
 - **Safe degradation**: When Trivy is absent or fails, the operator continues running; vulnerability features report unavailable or degraded state rather than blocking core operation.
 
+## Optional Prometheus (performance collector, outbound)
+
+- **Prometheus is optional**: The performance-metrics collector may query or scrape an in-cluster Prometheus HTTP endpoint when configured or discovered. There is **no** requirement to install Prometheus via the kube9-operator Helm chart, and kube9 does not own Prometheus Operator / ServiceMonitor lifecycle.
+- **Zero-ingress unchanged**: Traffic is operator → Prometheus (cluster-internal egress). Operator `/metrics` exposition for scrapers of the operator itself remains a separate inbound path on the existing Service/port model.
+- **Safe degradation**: When Prometheus is absent or unreachable, the operator Deployment stays ready; only that collection type degrades. Absence must not become a readiness failure and must not imply phone-home or kube9-api sync.
+- **Auth hygiene**: Prefer not sending the operator ServiceAccount token to Prometheus by default. If a dedicated credential is ever required, use an out-of-band Secret + existingSecret mount (same class as Argo CD API token); chart does not create Secrets from plaintext. Tokens must not appear in status ConfigMap or CLI success stdout.
+
+## Security posture collector (RBAC class)
+
+- Security posture v1 signals are cluster-API aggregates only (privileged / hostPath / hostNetwork-style counts, NetworkPolicy coverage, basic NSA/CIS-oriented rollups from Kubernetes objects). No Trivy overlap; no Secrets API; no pod exec; no cluster-admin.
+- Prefer deriving signals from already-granted pod/workload and NetworkPolicy reads. Chart grants already cover NetworkPolicy and broad workload reads used by assessments / ai-conformance; expand ClusterRole only for resources still missing for the agreed signal set.
+- Deferred RBAC-risk rollups and broader CIS/NSA families must not expand ClusterRole in this initiative.
+
 ## Security Best Practices Summary
 
 1. **Zero Ingress**: No external attack surface
 2. **Minimal RBAC**: Read-only cluster access, write only to namespace ConfigMaps
 3. **Non-Root Execution**: Runs as UID 1000, no privilege escalation
 4. **Capability Dropping**: All Linux capabilities dropped
-5. **No Secrets Access**: Never requests or accesses secrets
+5. **No Secrets Access**: Never requests or accesses secrets via the Kubernetes Secrets API
 6. **Isolated Data**: Database isolated to operator's namespace
 7. **Structured Logging**: No sensitive data in logs
 8. **Minimal Image**: Alpine-based, minimal dependencies
+9. **Optional outbound only**: Trivy and Prometheus integrations are opt-in / degrade-safe; no phone-home
+
+## Open implementation decisions
+
+- **RBAC delta vs live chart:** Diff agreed security-posture v1 reads against `charts/kube9-operator/templates/clusterrole.yaml`. Add only missing resources/verbs; keep read-only. Confirm privileged / hostPath / hostNetwork signals need no new API groups beyond current pod/workload grants.
+- **NetworkPolicy purpose comment:** Chart comment today cites ai-conformance; update template comment (and this doc) so NetworkPolicy reads also cover security-posture coverage rollups (same verbs).
+- **Additional API groups for basic NSA/CIS rollups:** If implementation needs resources not already listed (for example namespaces already granted, or other policy objects), list them explicitly here and in the ClusterRole before merge; do not silently widen to Secrets, pods/exec, or deferred RBAC-risk analysis.
+- **Prometheus credential mount:** Whether v1 ships URL/timeout/TLS only (no Secret mount) or includes an optional existingSecret path in the same release; coordinate with packaging and integration.

--- a/.ai/runtime/configuration.md
+++ b/.ai/runtime/configuration.md
@@ -41,6 +41,31 @@
   - Minimum enforced: `3600` (1 hour)
   - Random offset range: 0-1 hour
 
+- **PERFORMANCE_METRICS_INTERVAL_SECONDS**: Performance metrics collection interval (Prometheus-backed)
+  - Default target: `900` (15 minutes); exact default/min/offset candidates under Open implementation decisions
+  - Enforced minimum and random offset required (same family as other `*_INTERVAL_SECONDS` collectors)
+  - Invalid or below-minimum values fail config load (match existing interval fail-fast), not silent clamp after ready
+
+- **SECURITY_POSTURE_INTERVAL_SECONDS**: Security posture collection interval (cluster API aggregates)
+  - Default target: `86400` (24 hours); exact default/min/offset candidates under Open implementation decisions
+  - Enforced minimum and random offset required
+  - Invalid or below-minimum values fail config load
+
+### Performance metrics / Prometheus outbound (optional)
+
+Optional **operator → in-cluster Prometheus** client used only by the performance metrics collector. Distinct from the operator’s own `/metrics` exposition on `HEALTH_PORT`. Same optional-outbound family as Trivy / Argo CD HTTP (not a new trust boundary and not a readiness gate).
+
+- **Registration (recommended default):** Register the performance collector on `CollectionScheduler` only when a Prometheus base URL (or equivalent enable+URL pair) is configured. When unset, do not schedule performance ticks and do not treat absence as config failure. See Open implementation decisions for exact env names and the alternate always-register path.
+- **When configured but unreachable:** Degrade that collection type on the tick only; do not fail `/readyz`, do not stop other collectors, and do not require metrics-server / Kubernetes metrics API fallback.
+- **Secrets vs config:** Endpoint, timeout, and TLS flags are configuration. Optional auth (if any) follows existing chart secret-mount precedents (Argo CD API token style). Prefer not sending the operator ServiceAccount token to Prometheus by default. Auth must not become a bootstrap readiness dependency.
+- Exact Prometheus env/Helm keys (URL, timeout, TLS, auth) are Open implementation decisions; Helm chart wiring for those keys is owned with operations (`deployment_environments.md` / chart values), with runtime as the env contract home.
+
+### Security posture collector
+
+- Always runnable from cluster API reads alone (no Prometheus, no Trivy dependency).
+- **Registration:** Always register on `CollectionScheduler` during serve bootstrap (core-collector pattern), unless an explicit enable flag is added for symmetry (Open implementation decisions; default remains always-on).
+- Uses `SECURITY_POSTURE_INTERVAL_SECONDS` and SQLite `collections` like peer collectors. No phone-home / kube9-api registration path.
+
 ### Kubernetes AI Conformance Environment Variables
 - **AI_CONFORMANCE_ENABLED**: Enable scheduled Kubernetes AI Conformance readiness evaluation
   - Default: `true` once the M10 feature is shipped
@@ -200,9 +225,12 @@ metrics:
     clusterMetadata: 86400                    # 24 hours (default), minimum 3600 (1h)
     resourceInventory: 21600                  # 6 hours (default), minimum 1800 (30m)
     resourceConfigurationPatterns: 43200     # 12 hours (default), minimum 3600 (1h)
+    performanceMetrics: 900                   # 15 minutes (target default); min/offset under Open implementation decisions
+    securityPosture: 86400                    # 24 hours (target default); min/offset under Open implementation decisions
 ```
 - Maps to `*_INTERVAL_SECONDS` environment variables
 - Operator enforces minimum intervals to prevent abuse
+- Performance metrics also need optional Prometheus client values (URL / timeout / TLS); exact keys under Open implementation decisions. Chart RBAC and ServiceMonitor ownership stay in operations; runtime only loads the env contract and must not treat Prometheus as required for ready.
 
 ### Kubernetes AI Conformance Configuration
 ```yaml
@@ -246,3 +274,17 @@ events:
   - Watching Kubernetes events
   - Updating status ConfigMap
   - Detecting ArgoCD installations
+  - Security posture cluster API aggregates (read-only)
+
+## Open implementation decisions
+
+- **Interval env / Helm keys:** Lock exact names. Recommended: `PERFORMANCE_METRICS_INTERVAL_SECONDS` ↔ `metrics.intervals.performanceMetrics`; `SECURITY_POSTURE_INTERVAL_SECONDS` ↔ `metrics.intervals.securityPosture`. Wire through `loadConfig()` and chart env like peer collectors.
+- **Numeric defaults, minima, offsets (candidates):**
+  - Performance: default `900` (15m), minimum `300` (5m), random offset `0–300` (0–5m). Shorter floor than inventory because the product default is already ~15m.
+  - Security posture: default `86400` (24h), minimum `3600` (1h), random offset `0–3600` (0–1h). Align with cluster-metadata long-interval peers.
+  - Config-load rejection for non-numeric / below-minimum values (fail-fast), matching existing `*_INTERVAL_SECONDS` behavior.
+- **Performance registration policy (recommended default):** **Config-gated registration** — register on `CollectionScheduler` only when an in-cluster Prometheus base URL is configured (optional explicit enable flag may AND with URL). Rationale: there is no useful performance tick without Prometheus (unlike workload-image-scan, which still collects image refs); matches integration’s Trivy-style “no pull until configured” and Argo CD API `collectionEnabled` family; avoids empty ~15m ticks and collectionStats noise when Prometheus was never intended. Alternate (not recommended): always-register and degrade/skip every tick when URL unset. Either choice must not invent a new readiness or secrets-before-traffic trust boundary.
+- **Enable flags:** Prefer URL-nonempty as the gate for performance (no separate `*_ENABLED` required in v1). Security posture: no enable flag (always-on) unless implementation adds one for chart symmetry (default on).
+- **Prometheus connection env / Helm keys (candidates):** `PROMETHEUS_BASE_URL` (or `PERFORMANCE_METRICS_PROMETHEUS_URL`), `PROMETHEUS_TIMEOUT_MS` (default class `30000`, minimum class `1000`), `PROMETHEUS_TLS_INSECURE` (default `false`). Optional auth only if needed: bearer env and/or token file + chart `existingSecret` mount patterned after Argo CD API token (do not default to SA token). Unset URL → soft miss (no register / no fail load). Invalid timeout or malformed URL when set → fail config load.
+- **Degrade tick semantics (runtime boundary):** When registered and Prometheus is missing/unreachable: log warn, do not throw out of the scheduler, retry next interval, do not flip `/readyz` or whole-operator `health` to unhealthy, and do not use reserved `health: degraded` for this miss. Exact tick classification in `collectionStats` / metrics (`failed` vs skipped vs success-with-unavailable) is locked with business_logic error_handling and data. When not registered (URL unset): no performance ticks at all.
+- **Ops vs runtime home:** Env semantics and load/validation live here. Helm value schema, RBAC for posture reads, and any ServiceMonitor for operator `/metrics` exposition stay in operations with a one-line pointer back to this doc for interval/Prometheus client env names.

--- a/.ai/runtime/execution_model.md
+++ b/.ai/runtime/execution_model.md
@@ -16,9 +16,10 @@ The kube9-operator binary supports multiple execution modes via Commander.js CLI
   - Starts ArgoCD detection manager
   - Starts status writer (periodic ConfigMap updates)
   - Initializes collection scheduler
-  - Registers collectors (cluster metadata, resource inventory, configuration patterns)
+  - Registers collectors (cluster metadata, resource inventory, configuration patterns; security posture always-on; performance metrics when Prometheus client config is present per recommended gate; plus existing optional scheduler tasks)
   - Registers signal handlers (SIGTERM, SIGINT)
   - Runs indefinitely until shutdown signal
+  - Optional Prometheus outbound for performance metrics never gates readiness
 - **Use Case**: Primary operator deployment mode
 
 ### query (CLI Mode)
@@ -28,6 +29,7 @@ The kube9-operator binary supports multiple execution modes via Commander.js CLI
   - `query status` - Operator status and health from the status ConfigMap
   - `query events list` - List events with filters (type, severity, since)
   - `query events get <id>` - Get specific event by ID
+  - `query collections list|get` - Stored collection snapshots (additive types include performance metrics and security posture when present)
 - **Behavior**:
   - Reads from SQLite database
   - Outputs JSON/YAML/table format
@@ -126,8 +128,21 @@ The kube9-operator binary supports multiple execution modes via Commander.js CLI
      - Minimum: 3600s (1h)
      - Random offset: 0-1 hour
      - Collector: `ResourceConfigurationPatternsCollector`
+
+  4. **Performance Metrics Collection**
+     - Interval: ~15m class (exact default/min/offset in configuration Open implementation decisions)
+     - Collector: performance metrics collector (optional in-cluster Prometheus HTTP client)
+     - **Recommended registration:** Config-gated until Prometheus base URL configured; when registered, tick degrades on unreachable Prometheus without stopping the scheduler or failing ready
+     - Storage: existing SQLite `collections` path; no CRDs; no phone-home
+
+  5. **Security Posture Collection**
+     - Interval: ~24h class (exact default/min/offset in configuration Open implementation decisions)
+     - Collector: security posture collector (Kubernetes API aggregates only)
+     - **Registration:** Always register (core-collector pattern); independent of Prometheus and Trivy
+     - Storage: existing SQLite `collections` path; no CRDs; no phone-home
 - **Randomization**: Random offsets prevent thundering herd when multiple operators run
-- **Error Handling**: Collection failures are logged and metrics recorded, but don't stop scheduler
+- **Error Handling**: Collection failures are logged and metrics recorded, but don't stop scheduler. Prometheus miss for performance is collection/integration degrade for that type only; operator `health: degraded` remains reserved/narrow and is not flipped solely for optional Prometheus absence.
+- **Process model**: Single process; no worker threads or child processes for these collectors
 
 ### Kubernetes AI Conformance Scheduler
 - **Purpose**: Periodically evaluate bundled Kubernetes AI Conformance checklist requirements
@@ -193,4 +208,10 @@ The kube9-operator binary supports multiple execution modes via Commander.js CLI
 - **Memory**: 1Gi request/limit (Guaranteed QoS)
 - **CPU**: 500m request/limit
 - **Storage**: 5Gi PersistentVolume (when persistence enabled)
-- **Network**: HTTP health server (port 8080), Kubernetes API client
+- **Network**: HTTP health server (port 8080), Kubernetes API client, optional cluster-internal egress to Prometheus when performance metrics client is configured
+
+## Open implementation decisions
+
+- **Registration policy lock:** Confirm recommended config-gated performance registration vs always-register-with-degrade with integration contracts; security posture stays always-register. See configuration.md Open implementation decisions for the recommendation rationale.
+- **Degrade tick → stats/metrics:** How a Prometheus miss maps to `collectionStats` counters and `kube9_operator_collection_*` labels (`failed` vs skipped vs success-with-unavailable) is coordinated with business_logic and data; execution model only requires that the scheduler keeps running and ready stays up.
+- **Query mode process boundary unchanged:** `query collections` for the new types remains a separate CLI process via `kubectl exec`, same as today. No in-serve query API.

--- a/.ai/runtime/index.md
+++ b/.ai/runtime/index.md
@@ -4,7 +4,8 @@ How the kube9-operator starts, runs, and shuts down.
 
 - **Platform**: Node.js 22
 - **Modes**: Dual-mode binary—serve (operator loop) and query (CLI)
-- **Key loops**: Status update (60s), assessment scheduler (24h/6h/12h), event watcher
+- **Key loops**: Status update (60s), `CollectionScheduler` (cluster metadata, resource inventory, configuration patterns, performance metrics, security posture, plus gated optional tasks), assessment / AI conformance schedules, event watcher
+- **Optional outbound**: Prometheus client for performance metrics must not block config load (when unset), `/readyz`, or other collectors
 
 ## Child Docs
 - [configuration.md](configuration.md) — Config loading, env, Helm values

--- a/.ai/runtime/lifecycle_shutdown.md
+++ b/.ai/runtime/lifecycle_shutdown.md
@@ -103,8 +103,11 @@ Both signals are handled identically and call `gracefulShutdown()` with all comp
   - Resource configuration patterns: Every `resourceConfigurationPatternsIntervalSeconds` (default: 43200s = 12h)
     - Minimum interval: 3600s (1h)
     - Random offset: 0-1 hour
+  - Performance metrics: Every ~15m class interval when registered (Prometheus optional outbound; exact seconds under configuration Open implementation decisions)
+  - Security posture: Every ~24h class interval (always registered; exact seconds under configuration Open implementation decisions)
+  - Existing optional scheduler tasks (workload-image-scan, assessment, AI conformance, Argo CD application status) when their gates allow
 - **Component**: `CollectionScheduler`
-- **Stopped during shutdown**: Yes (clears all timers)
+- **Stopped during shutdown**: Yes (clears all timers, including the two new collectors). No separate shutdown path for performance or security posture.
 
 ### ArgoCD Detection
 - **Interval**: Every `ARGOCD_DETECTION_INTERVAL` hours (default: 6 hours)

--- a/.ai/runtime/startup_bootstrap.md
+++ b/.ai/runtime/startup_bootstrap.md
@@ -12,7 +12,8 @@ The operator follows a strict initialization sequence defined in `src/operator.t
 
 **Configuration loaded:**
 - `logLevel`, `statusUpdateIntervalSeconds`
-- Collection intervals (`clusterMetadataIntervalSeconds`, `resourceInventoryIntervalSeconds`, `resourceConfigurationPatternsIntervalSeconds`, `workloadImageScanIntervalSeconds`)
+- Collection intervals (`clusterMetadataIntervalSeconds`, `resourceInventoryIntervalSeconds`, `resourceConfigurationPatternsIntervalSeconds`, `workloadImageScanIntervalSeconds`, plus performance metrics and security posture intervals when wired)
+- Optional Prometheus outbound client settings for performance metrics (URL / timeout / TLS / auth). Unset Prometheus URL must not fail config load; invalid set values fail load like other typed env.
 - Event retention policies (`eventRetentionInfoWarningDays`, `eventRetentionErrorCriticalDays`)
 
 ### 2. Start Health Server
@@ -74,7 +75,7 @@ The operator follows a strict initialization sequence defined in `src/operator.t
 ### 9. Initialize Collection Scheduler
 - Creates `CollectionScheduler` instance
 - Creates `LocalStorage` instance for local data storage
-- Initializes collectors:
+- Initializes collectors (same in-process scheduler; no new serve mode or worker):
   - **ClusterMetadataCollector**: Collects cluster metadata
     - Interval: `clusterMetadataIntervalSeconds` (default: 86400 = 24h)
     - Minimum interval: 3600s (1 hour)
@@ -87,10 +88,18 @@ The operator follows a strict initialization sequence defined in `src/operator.t
     - Interval: `resourceConfigurationPatternsIntervalSeconds` (default: 43200 = 12h)
     - Minimum interval: 3600s (1 hour)
     - Random offset: 0-1 hour
-- Registers each collector with scheduler
+  - **Performance metrics collector**: Bounded Prometheus aggregate snapshots into SQLite `collections`
+    - Interval: ~15m class (`performanceMetricsIntervalSeconds`; exact default/min/offset in configuration Open implementation decisions)
+    - **Recommended registration:** Register only when Prometheus base URL (or enable+URL) is configured. Do not probe Prometheus as a hard dependency before ready. When registered and Prometheus is unreachable, degrade that tick only (log/metric/retry next interval).
+    - Persistence remains `{DB_PATH}/kube9.db` collections store. No metrics-server fallback. No phone-home.
+  - **Security posture collector**: Cluster API aggregate rollups into SQLite `collections`
+    - Interval: ~24h class (`securityPostureIntervalSeconds`; exact default/min/offset in configuration Open implementation decisions)
+    - **Registration:** Always register (core-collector pattern). Independent of Prometheus and Trivy.
+- Also registers existing gated / always-on optional tasks on the same scheduler as today (workload-image-scan, assessment, AI conformance, Argo CD application status) without changing their enable semantics.
 - Starts scheduler (begins periodic collection tasks)
-- Collection failures are logged but don't stop operator
+- Per-collector init or tick failures are logged; operator continues (same “log and continue” family as ArgoCD/K8s client tests)
 - Collection metrics are recorded for monitoring
+- Prometheus absence must not block this step from completing or from reaching step 11 (`/readyz`)
 
 ### 10. Register Signal Handlers
 - Registers `SIGTERM` handler for graceful shutdown
@@ -135,4 +144,12 @@ Each step logs its progress:
 - Event system starts before main reconcile loop
 - Initial ArgoCD detection has timeout to prevent blocking
 - Collection scheduler starts after all other systems
+- Optional Prometheus client for performance metrics is not probed as a gate before ready
 - Total startup time typically < 5 seconds
+
+## Open implementation decisions
+
+- **Bootstrap registration order:** Register performance (when gated condition met) and security posture after the three core collectors and before or alongside existing optional scheduler tasks; exact order among optional tasks is TW as long as failures for one collector still “log and continue.”
+- **Performance gate check at bootstrap:** Whether the gate is “non-empty Prometheus URL”, “explicit enable + URL”, or “enable with default-off until URL set” is locked with configuration Open implementation decisions. Recommended: non-empty URL (no separate enable required).
+- **First-tick vs scheduled-tick when Prometheus miss:** Prefer the same degrade path for first tick and later ticks (no special bootstrap scrape). Do not delay `setInitialized(true)` waiting on a Prometheus probe.
+- **Init failure isolation:** Constructing or registering either new collector must follow today’s collection-init catch: log error, continue serve without that collector if needed, still mark ready when the rest of bootstrap succeeds.

--- a/.ai/schemas/vision.schema.json
+++ b/.ai/schemas/vision.schema.json
@@ -33,6 +33,11 @@
                 "key_architecture": {
                     "type": "string"
                 },
+                "last_validated": {
+                    "type": "string",
+                    "description": "Optional stewardship date (YYYY-MM-DD) when vision content was last reviewed.",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                },
                 "long_term_vision": {
                     "type": "object",
                     "additionalProperties": false,
@@ -44,18 +49,18 @@
                             "type": "object",
                             "additionalProperties": false,
                             "required": [
-                                "short_term",
-                                "medium_term",
-                                "long_term"
+                                "now",
+                                "next",
+                                "later"
                             ],
                             "properties": {
-                                "short_term": {
+                                "now": {
                                     "type": "string"
                                 },
-                                "medium_term": {
+                                "next": {
                                     "type": "string"
                                 },
-                                "long_term": {
+                                "later": {
                                     "type": "string"
                                 }
                             }
@@ -66,20 +71,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "required": [
-                            "priority",
-                            "text"
-                        ],
-                        "properties": {
-                            "priority": {
-                                "type": "integer"
-                            },
-                            "text": {
-                                "type": "string"
-                            }
-                        }
+                        "type": "string"
                     }
                 },
                 "market_strategy": {
@@ -90,44 +82,47 @@
                         "differentiation_from_competitors"
                     ],
                     "properties": {
+                        "primary_competitor": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "why_primary",
+                                "their_strengths",
+                                "last_reviewed"
+                            ],
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "why_primary": {
+                                    "type": "string"
+                                },
+                                "their_strengths": {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "last_reviewed": {
+                                    "type": "string",
+                                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                                }
+                            }
+                        },
                         "competitive_advantages": {
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "required": [
-                                    "priority",
-                                    "text"
-                                ],
-                                "properties": {
-                                    "priority": {
-                                        "type": "integer"
-                                    },
-                                    "text": {
-                                        "type": "string"
-                                    }
-                                }
+                                "type": "string"
                             }
                         },
                         "differentiation_from_competitors": {
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "required": [
-                                    "priority",
-                                    "text"
-                                ],
-                                "properties": {
-                                    "priority": {
-                                        "type": "integer"
-                                    },
-                                    "text": {
-                                        "type": "string"
-                                    }
-                                }
+                                "type": "string"
                             }
                         }
                     }

--- a/.ai/specs/data-collection-pipeline.spec.md
+++ b/.ai/specs/data-collection-pipeline.spec.md
@@ -1,0 +1,48 @@
+# Data collection pipeline
+
+## Introduction
+
+The kube9-operator data collection pipeline schedules periodic in-cluster collectors, persists append-only snapshots in SQLite `collections`, exposes aggregate `collectionStats` on the operator status ConfigMap, and serves `kube9-operator query collections list|get` for progressive consumers (VS Code / Desktop later). This capability covers the shared pipeline for all collection types, including the completed set: cluster-metadata, resource-inventory, resource-configuration-patterns, performance-metrics, and security-posture.
+
+Related capabilities: `performance-metrics-collector` and `security-posture-collector` specialize the two newest collectors; Trivy image scan and assessment runs are separate optional paths.
+
+## Functional Specification
+
+- Collectors register on the in-process CollectionScheduler with type-specific intervals, enforced minima, and random offsets.
+- Successful ticks append a new `collections` row (`collection_id` per snapshot) with a versioned `CollectionPayload` (`version`, `type`, `data`, `sanitization`).
+- Operators query history via existing collections CLI filters (`--type`, time window, pagination) and formats (`json|yaml|table|compact`). Empty successful lists are normal (evidence gap), not operator unhealthy.
+- Status `collectionStats` remains aggregate counters over stored collections; new types participate without breaking the aggregate field set for progressive peers.
+- **Retention:** assessments-class — no time-based TTL and no count-based cap; rows persist until explicit remove or operational cleanup. Consumers rely only on still-stored rows. Disk growth from high-frequency appends is an operational concern.
+- **Non-goals for this capability boundary:** phone-home / kube9-api sync; CRDs for collection payloads; multi-cluster federation; same-milestone vscode/desktop consumer UX; metrics-server fallback for performance.
+
+## Technical Specification
+
+- **Runtime:** Node.js `>=22` (package engines); TypeScript operator process; better-sqlite3 for durable store at `{DB_PATH}/kube9.db`.
+- **Components:** CollectionScheduler; per-type collectors; CollectionRepository / SQLite `collections` table; Zod `CollectionPayload` validation; status publisher; CLI query path via `kubectl exec`.
+- **Type tokens (closed set for this pipeline):** `cluster-metadata`, `resource-inventory`, `resource-configuration-patterns`, `performance-metrics`, `security-posture`.
+- **Config:** Helm `metrics.intervals.*` and matching env interval seconds; optional Prometheus client config for performance only.
+- **Trust / deploy:** Zero-ingress default; cluster-internal egress only for optional Prometheus; read-only ClusterRole for Kubernetes API collectors.
+- Field catalogs, exact env key names, registration gate details, and degrade-row persistence shapes remain open implementation decisions in domain child docs until `/refine-issue`.
+
+## Testing Strategy
+
+- Unit: payload schema accept/reject per type; interval min enforcement; empty query success envelope.
+- Integration: scheduler registers expected collectors; SQLite insert + `query collections` round-trip; status aggregates include new types without dropping required fields.
+- Contract / chart: Helm values expose interval keys; ClusterRole remains read-only for posture reads; collection Prometheus metric `type` labels stay within the closed set.
+- Manual / smoke (kind/minikube): install without Prometheus → operator ready, security-posture rows appear over time, performance absent or gated without failing ready; with Prometheus configured → performance rows appear.
+
+## References
+
+- `.ai/business_logic/domain_model.md`
+- `.ai/business_logic/user_stories.md`
+- `.ai/business_logic/error_handling.md`
+- `.ai/data/data_model.md`
+- `.ai/data/consistency.md`
+- `.ai/data/serialization.md`
+- `.ai/runtime/configuration.md`
+- `.ai/runtime/startup_bootstrap.md`
+- `.ai/integration/api_contracts.md`
+- `.ai/interface/input_handling.md`
+- `.ai/operations/observability.md`
+- `.ai/specs/performance-metrics-collector.spec.md`
+- `.ai/specs/security-posture-collector.spec.md`

--- a/.ai/specs/index.md
+++ b/.ai/specs/index.md
@@ -1,0 +1,9 @@
+# Capability specs (kube9-operator)
+
+Durable capability-level architecture and behavior specifications. Specs integrate domain contracts; they do not replace `.ai/<domain>/` docs.
+
+| Slug | Title | Purpose | Status |
+|------|-------|---------|--------|
+| `data-collection-pipeline` | Data collection pipeline | Scheduled in-cluster collectors: persist to SQLite `collections`, expose status `collectionStats`, and serve `query collections` | draft |
+| `performance-metrics-collector` | Performance metrics collector | Optional Prometheus-backed aggregate snapshots on the shared collection pipeline | draft |
+| `security-posture-collector` | Security posture collector | Kubernetes API aggregate security-posture snapshots on the shared collection pipeline | draft |

--- a/.ai/specs/performance-metrics-collector.spec.md
+++ b/.ai/specs/performance-metrics-collector.spec.md
@@ -1,0 +1,41 @@
+# Performance metrics collector
+
+## Introduction
+
+Optional in-cluster collector that builds bounded performance aggregate snapshots from Prometheus and stores them on the shared data collection pipeline as type `performance-metrics`. Differentiates kube9-operator from Prometheus Operator by consuming metrics for Well-Architected / cluster insights rather than operating a metrics stack.
+
+Depends on `data-collection-pipeline`. Does not replace operator `/metrics` exposition (inbound scrape by Prometheus remains separate).
+
+## Functional Specification
+
+- Default schedule target ~15 minutes with enforced minimum and random offset (exact seconds in runtime open-impl).
+- Data source v1: in-cluster Prometheus only (optional outbound HTTP query and/or scrape). No metrics-server / Kubernetes metrics API fallback.
+- Opt-in / degrade: no performance pull until Prometheus endpoint is configured (recommended: config-gated registration). When Prometheus is absent or unreachable, other collectors and readiness continue; operator health does not become unhealthy solely for that reason.
+- Persisted payload class: bounded utilization / ratio style aggregates inside `CollectionPayload`, not a raw time-series warehouse.
+- Queryable via `query collections` with `--type performance-metrics`; empty list before first success is normal.
+- **Non-goals:** installing Prometheus/Prometheus Operator; phone-home; peer UX this milestone; storing unsanitized high-cardinality series dumps.
+
+## Technical Specification
+
+- **Runtime:** Node.js `>=22`; same CollectionScheduler and SQLite path as peer collectors.
+- **Integration:** Trivy-style optional outbound client; cluster-internal egress; prefer not using the operator ServiceAccount token as an implicit Prometheus credential.
+- **Recommended registration:** register performance ticks only when a Prometheus base URL (or equivalent enable+URL) is set; unset is soft miss, not config failure.
+- Exact PromQL vs scrape shape, auth/TLS knobs, timeouts, and whether unavailable ticks omit rows vs store an unavailable marker are open implementation decisions (integration / data / runtime).
+
+## Testing Strategy
+
+- Unit: payload validation for `performance-metrics`; config reject for invalid Prometheus URL when set.
+- Integration: with Prometheus unset → collector not registered or no failing ticks; `/readyz` stays ready; with mock Prometheus → successful append + query by type.
+- Chart / ops: optional Prometheus values documented; zero-ingress unchanged; metric `type=performance-metrics` appears only on collection series when ticks run.
+- Manual: kind/minikube without Prometheus proves graceful degrade; with in-cluster Prometheus proves snapshot queryability.
+
+## References
+
+- `.ai/specs/data-collection-pipeline.spec.md`
+- `.ai/integration/external_systems.md`
+- `.ai/runtime/configuration.md`
+- `.ai/runtime/startup_bootstrap.md`
+- `.ai/data/serialization.md`
+- `.ai/business_logic/error_handling.md`
+- `.ai/operations/build_packaging.md`
+- `.ai/vision.json` (primary competitor: Prometheus Operator)

--- a/.ai/specs/security-posture-collector.spec.md
+++ b/.ai/specs/security-posture-collector.spec.md
@@ -1,0 +1,40 @@
+# Security posture collector
+
+## Introduction
+
+Always-on in-cluster collector that builds bounded security-posture aggregate snapshots from the Kubernetes API and stores them on the shared data collection pipeline as type `security-posture`. Complements optional Trivy vulnerability scanning and resource-configuration-patterns without duplicating either.
+
+Depends on `data-collection-pipeline`.
+
+## Functional Specification
+
+- Default schedule target ~24 hours with enforced minimum and random offset (exact seconds in runtime open-impl).
+- Signal classes v1 (cluster API aggregates only): privileged / hostPath / hostNetwork-style counts; NetworkPolicy coverage; basic NSA/CIS-oriented rollups from Kubernetes objects.
+- Distinct from Trivy (CVE / image vulnerability path unchanged) and from configuration-patterns security-context counts (separate collection type).
+- **Deferred / non-goals for v1:** RBAC risk rollups; broader CIS/NSA families beyond the basic rollups named above; Trivy HTTP/CLI reuse; CRDs; phone-home; same-milestone vscode/desktop UX.
+- Always registered on CollectionScheduler (core-collector pattern) unless an explicit enable flag is later added for symmetry; does not depend on Prometheus.
+- Queryable via `query collections` with `--type security-posture`; partial API failures warn and retry next interval without flipping whole-operator unhealthy solely for that reason.
+
+## Technical Specification
+
+- **Runtime:** Node.js `>=22`; CollectionScheduler + SQLite `collections` + `CollectionPayload`.
+- **Integration / RBAC:** read-only ClusterRole expansion only for resources still missing for the agreed signal set; chart already grants many workload and NetworkPolicy reads. No Secrets API, no pod exec, no cluster-admin for this collector.
+- Field-level counter keys, NSA/CIS rollup catalog, and exact ClusterRole delta vs live chart are open implementation decisions (data / operations / integration).
+
+## Testing Strategy
+
+- Unit: payload validation for `security-posture`; reject Trivy CVE bodies or RBAC-risk blobs if presented as this type.
+- Integration: successful append from fake/minimal API fixtures; query by type; scheduler always registers security posture when core collectors start.
+- Chart: ClusterRole remains read-only; NetworkPolicy (and any added resources) documented for posture purpose.
+- Manual: kind/minikube shows posture rows after first successful tick without Prometheus or Trivy installed.
+
+## References
+
+- `.ai/specs/data-collection-pipeline.spec.md`
+- `.ai/business_logic/domain_model.md`
+- `.ai/business_logic/user_stories.md`
+- `.ai/data/serialization.md`
+- `.ai/integration/external_systems.md`
+- `.ai/integration/authorization.md`
+- `.ai/operations/security.md`
+- `.ai/runtime/startup_bootstrap.md`

--- a/.ai/vision.json
+++ b/.ai/vision.json
@@ -8,7 +8,7 @@
     "long_term_vision": {
       "strategic_goals": {
         "now": "Complete Well-Architected Framework validation across all 6 pillars (M2-M6); establish operator as standard for kube9 cluster integration; transparent security model; chart repository for easy installation (M7).",
-        "next": "Complete data collectors (cluster metadata, resource inventory, config patterns) per M8; ArgoCD Application sync and drift detection per M9; 1,000+ installations.",
+        "next": "Complete data collectors (cluster metadata, resource inventory, config patterns, performance metrics, security posture); ArgoCD Application sync and drift detection; 1,000+ installations.",
         "later": "Standard operator for Kubernetes observability; cross-cluster analytics; edge clusters and air-gapped environments; operator marketplace for extensibility."
       }
     },
@@ -20,6 +20,15 @@
       "Privacy & Compliance: RBAC-controlled access; no secrets or credentials collected; audit trail for operations."
     ],
     "market_strategy": {
+      "primary_competitor": {
+        "name": "Prometheus Operator",
+        "why_primary": "Purpose-built kube9 Well-Architected / cluster-insights operator vs general metrics collection; finishing performance and security-posture collectors deepens that wedge without becoming a generic metrics stack.",
+        "their_strengths": [
+          "Mature Prometheus-in-Kubernetes metrics collection and scraping ecosystem",
+          "Broad community adoption as the standard in-cluster Prometheus operator stack"
+        ],
+        "last_reviewed": "2026-08-02"
+      },
       "competitive_advantages": [
         "Zero Ingress Architecture: No ingress required—all communication is outbound to in-cluster services (Prometheus, ArgoCD, Kubernetes API).",
         "Operator status signals: Progressive enhancement in VS Code based on operator presence, health, and optional integrations.",


### PR DESCRIPTION
Contract-only PR from ideation (`/ideate`).

- **Initiative:** finish-m8-collector-set
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and cross-repo coherence before merge

Completes foreshadowed M8 collectors (performance-metrics + security-posture) on the existing SQLite collections / query CLI / CollectionScheduler path. Adds capability specs, vision schema catch-up, and knowledge_map specs/schemas nodes.

Merge before `/plan-roadmap` when downstream work should read merged contracts on `main`.