### PR TITLE
docs(ai): refine issue #168 contract updates

### DIFF
--- a/.ai/business_logic/domain_model.md
+++ b/.ai/business_logic/domain_model.md
@@ -95,7 +95,7 @@ The evaluator must prefer `not-evaluated` or `needs-evidence` over inference whe
    - Non-goals for this category: Trivy CVE duplication, RBAC risk rollups, broader CIS/NSA families beyond the basic rollups above
    - Collector: Security posture collector on `CollectionScheduler` (SQLite `collections`; existing collections query CLI)
 
-**Scheduler and storage**: Intervals configured via Helm values and enforced with minimums. Collections scheduled with random offsets (0-1 hour) matching existing collectors. Persistence stays on the SQLite `collections` path; no CRDs for these payloads; no phone-home / registration / kube9-api sync. Default intervals for the five categories: 86400s (24h metadata), 21600s (6h inventory), 43200s (12h config patterns), ~900s (15m performance), 86400s (24h security posture). Exact second values and minima for the two newer collectors are listed under Open implementation decisions.
+**Scheduler and storage**: Intervals configured via Helm values and enforced with minimums. Collections scheduled with random offsets (0-1 hour) matching existing collectors. Persistence stays on the SQLite `collections` path via `CollectionRepository.insertCollection` (sole durable write); no CRDs for these payloads; no phone-home / registration / kube9-api sync. Default intervals for the five categories: 86400s (24h metadata), 21600s (6h inventory), 43200s (12h config patterns), ~900s (15m performance), 86400s (24h security posture). Exact second values and minima for the two newer collectors remain packaging/runtime peer scope under Open implementation decisions.
 
 **Milestone consumer scope**: Operator-owned schedule, status `collectionStats`, and collections query are the user-visible outcomes for these collectors. vscode and Desktop remain progressive-enhancement co-consumers later; this surface does not add presence modes or AssessmentRunState/CheckStatus values.
 
@@ -123,6 +123,14 @@ User-facing operator docs (`charts/kube9-operator/README.md`) list **kube9-vscod
 
 ## Open implementation decisions
 
-- **Collection type tokens:** Exact kebab-case type strings for performance metrics and security posture (family candidates such as `performance-metrics` and `security-posture`) are locked with data and interface contracts; business logic treats them as additive members of the existing collections type set.
-- **Interval seconds and minima:** Exact default seconds and enforced minima for the ~15m performance and ~24h security-posture collectors are locked with runtime and operations (Helm/env keys); product defaults remain ~15m and ~24h with random offset matching peer collectors.
-- **Performance collector registration gate:** Whether the performance collector always registers on `CollectionScheduler` or registers only when a Prometheus endpoint is configured/enabled is locked with runtime and integration; either choice must preserve graceful degrade when Prometheus is absent or unreachable and must not block ready or other collectors.
+### Resolved (collection type tokens)
+
+Additive kebab-case tokens are `performance-metrics` and `security-posture`. Business logic, data Zod/TS literals, CLI `--type`, and observability `type` labels use the same strings. Do not rename or remove the three shipped type strings.
+
+### Interval seconds and minima — peer packaging / runtime scope
+
+Exact default seconds and enforced minima for the ~15m performance and ~24h security-posture collectors are locked with runtime and operations (Helm/env keys); product defaults remain ~15m and ~24h with random offset matching peer collectors.
+
+### Performance collector registration gate — peer collector / runtime scope
+
+Whether the performance collector always registers on `CollectionScheduler` or registers only when a Prometheus endpoint is configured/enabled is locked with runtime and integration; either choice must preserve graceful degrade when Prometheus is absent or unreachable and must not block ready or other collectors.

--- a/.ai/data/data_model.md
+++ b/.ai/data/data_model.md
@@ -24,7 +24,7 @@ Exposed via ConfigMap `kube9-operator-status` in operator namespace.
 |----------|------|-------------|
 | totalSuccessCount | number | Total number of successful collections across all types |
 | totalFailureCount | number | Total number of failed collections across all types |
-| collectionsStoredCount | number | Number of collections currently stored locally |
+| collectionsStoredCount | number | Number of rows in SQLite `collections` (durable truth via `CollectionRepository.countCollections`) |
 | lastSuccessTime | string \| null | ISO 8601 timestamp of most recent successful collection |
 
 ### ArgoCDStatus
@@ -102,9 +102,62 @@ Five scheduled collectors persist append-only snapshot rows in SQLite `collectio
 
 **Resource Configuration Patterns** (`resource-configuration-patterns`, ~12h): Limits/requests, replica counts, image pull policies, security contexts, probes, volume types, service types.
 
-**Performance Metrics** (`performance-metrics`, ~15m): Bounded aggregate snapshot from optional in-cluster Prometheus (utilization / ratio style rollups). Not a raw time-series warehouse. When Prometheus is absent or unreachable, the collector degrades gracefully and does not invent metrics-server / Kubernetes metrics API data. Field-level `data` keys remain open implementation decisions below.
+**Performance Metrics** (`performance-metrics`, ~15m): Bounded aggregate snapshot from optional in-cluster Prometheus (utilization / ratio style rollups). Not a raw time-series warehouse. When Prometheus is absent or unreachable, the collector degrades gracefully and does not invent metrics-server / Kubernetes metrics API data. Normative `data` catalog below; tick gather / degrade classification owned by the performance-metrics collector capability.
 
-**Security Posture** (`security-posture`, ~24h): Bounded cluster-API aggregate counts and coverage rollups (privileged / hostPath / hostNetwork-style counts, NetworkPolicy coverage, basic NSA/CIS-oriented rollups from Kubernetes objects). Distinct from resource-configuration-patterns security-context counts and from Trivy image scanning (no CVE bodies). RBAC risk rollups and broader CIS/NSA families are out of scope for this payload. Field-level `data` keys remain open implementation decisions below.
+**Security Posture** (`security-posture`, ~24h): Bounded cluster-API aggregate counts and coverage rollups (privileged / hostPath / hostNetwork-style counts, NetworkPolicy coverage, basic NSA/CIS-oriented rollups from Kubernetes objects). Distinct from resource-configuration-patterns security-context counts and from Trivy image scanning (no CVE bodies). RBAC risk rollups and broader CIS/NSA families are out of scope for this payload. Normative `data` catalog below; tick gather / partial-API classification owned by the security-posture collector capability.
+
+### CollectionPayload envelope
+
+| Field | Type | Notes |
+|-------|------|-------|
+| version | string | Payload schema version (e.g. `v1.0.0`) |
+| type | string enum | Closed: `cluster-metadata` \| `resource-inventory` \| `resource-configuration-patterns` \| `performance-metrics` \| `security-posture` |
+| data | object | Type-specific; must match discriminant (Zod discriminated union at write time) |
+| sanitization | object | `{ rulesApplied: string[], timestamp: string }` |
+
+Identity and time live on `data` for all types: `timestamp` (ISO 8601), `collectionId` (`coll_*`), `clusterId` (`cls_*`).
+
+### performance-metrics `data`
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| timestamp | string | yes | ISO 8601 |
+| collectionId | string | yes | `coll_*` |
+| clusterId | string | yes | `cls_*` |
+| source | object | yes | `{ available: boolean, reason?: string }`; `reason` max 200 chars when present |
+| utilization | object | no | Optional `cpu` / `memory` objects |
+| utilization.cpu.clusterAvgRatio | number | no | `[0, 1]` when present |
+| utilization.cpu.nodeHighWatermarkRatio | number | no | `[0, 1]` when present |
+| utilization.memory.clusterAvgRatio | number | no | `[0, 1]` when present |
+| utilization.memory.nodeHighWatermarkRatio | number | no | `[0, 1]` when present |
+| ratios | object | no | Map of named ratios in `[0, 1]`; max **16** keys; each key length ≤ 64 |
+
+**Reject:** raw Prometheus vector / series dumps, unbounded label cardinality maps, nested sample arrays, serialized `data` larger than **64 KiB**.
+
+### security-posture `data`
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| timestamp | string | yes | ISO 8601 |
+| collectionId | string | yes | `coll_*` |
+| clusterId | string | yes | `cls_*` |
+| privilegedHost | object | yes | Non-negative integer counts |
+| privilegedHost.privilegedContainers | number | yes | ≥ 0 |
+| privilegedHost.hostPathVolumes | number | yes | ≥ 0 |
+| privilegedHost.hostNetworkPods | number | yes | ≥ 0 |
+| privilegedHost.hostPIDPods | number | no | ≥ 0 when present |
+| privilegedHost.hostIPCPods | number | no | ≥ 0 when present |
+| networkPolicyCoverage | object | yes | Namespace coverage aggregates |
+| networkPolicyCoverage.namespacesTotal | number | yes | ≥ 0 |
+| networkPolicyCoverage.namespacesWithNetworkPolicy | number | yes | ≥ 0 |
+| networkPolicyCoverage.coverageRatio | number | no | `[0, 1]` when present |
+| nsaCisRollups | object | yes | Non-negative integer counters; max **24** keys; each key length ≤ 64 |
+
+**Reject:** Trivy CVE bodies, `vulnerabilities` arrays, RBAC-risk blobs, serialized `data` larger than **64 KiB**.
+
+### Durable write path
+
+Successful collector ticks persist only through `CollectionRepository.insertCollection` (Zod validate then SQLite insert). `query collections` and status `collectionsStoredCount` reflect SQLite row counts. In-memory `LocalStorage` is not durable truth, must not drive `collectionsStoredCount`, and is removed from the collector durable write path (historical max-100 buffer is not a SQLite retention cap).
 
 ## SQLite Tables (at /data/kube9.db)
 
@@ -337,26 +390,18 @@ Stores per-requirement results for each conformance run.
 
 ## Open implementation decisions
 
-### Collection payload field catalogs (`performance-metrics`, `security-posture`)
+### Resolved (collection type literals and write-time validation)
 
-- Exact `data` object keys and nested shapes for `performance-metrics` (which utilization / ratio rollups; whether an explicit `prometheusAvailable` or source-status marker is required; max payload size / key count bounds).
-- Exact `data` object keys for `security-posture` (privileged / hostPath / hostNetwork-style counters; NetworkPolicy coverage representation; which basic NSA/CIS rollup keys). Must exclude Trivy CVE bodies and deferred RBAC risk fields.
-- Sanitization wrapping details for hashed / namespaced aggregates, aligned with peer collectors.
-- Resolve via `/refine-issue` into full field tables under Collection Models / serialization once implementation picks concrete keys.
+Closed application set includes `performance-metrics` and `security-posture` alongside the three shipped types. TypeScript `CollectionPayload` / `CollectionRowType` and Zod `CollectionPayloadSchema` use a discriminated union on `type`. `CollectionRepository.insertCollection` rejects `type`/`data` mismatch and malformed envelopes (no row). SQLite `type` remains unconstrained TEXT.
 
-### Zod / TypeScript type literals
+### Resolved (payload field catalogs)
 
-- Extend `CollectionPayload` discriminated union, `CollectionRowType`, CLI `--type` enum, and `CollectionPayloadSchema` with `performance-metrics` and `security-posture`.
-- Write-time rejection rules when `type` and `data` shape mismatch.
-- Keep SQLite `type` as unconstrained TEXT; closed set stays in app validation only.
+Normative `data` catalogs for `performance-metrics` and `security-posture` are under Collection Models above (including `source.available`, utilization/ratio bounds, privilegedHost / networkPolicyCoverage / nsaCisRollups, 64 KiB and key-count caps). Sanitization wrapping matches peer collectors (`rulesApplied`, `timestamp`).
 
-### Degrade-row persistence (Prometheus unavailable)
+### Resolved (durable write path)
 
-- Whether a Prometheus-absent/unreachable tick **omits** a `collections` row, stores a **success** payload with empty/unavailable metrics (and optional source-status marker), or counts as a **collection failure** with no durable row.
-- Coordinate with runtime / integration / error_handling for tick classification; data owns which documents are valid to persist.
-- Security posture (cluster API only) is not gated on Prometheus; degrade semantics above apply to performance-metrics only unless a shared pattern is chosen.
+`CollectionRepository.insertCollection` is the sole durable write. LocalStorage is off the durable path and does not own `collectionsStoredCount`. Existing collectors must use the same durable path so CLI and status match SQLite.
 
-### Durable write path vs in-memory
+### Degrade-row persistence (Prometheus unavailable) — peer collector scope
 
-- Wire both new collectors (and ideally existing ones) through durable `CollectionRepository.insertCollection` so `query collections` and status `collectionsStoredCount` reflect SQLite truth.
-- Document whether in-memory `LocalStorage` (historical max-100 buffer) remains a cache, is removed from the write path, or is transitional only. Single durable write path is the product contract for queryable history.
+Whether a Prometheus-absent/unreachable tick **omits** a `collections` row, stores a **success** payload with `source.available: false`, or counts as a **collection failure** with no durable row is owned by the performance-metrics collector capability (coordinate with runtime / error_handling). Schema accepts `source.available` either way. Security posture is not gated on Prometheus.

--- a/.ai/data/persistence_abstractions.md
+++ b/.ai/data/persistence_abstractions.md
@@ -59,15 +59,24 @@ Queryable event, assessment, and collection history for Desktop Tier 2 (and simi
 ### Collections persistence boundary
 
 - **Store:** Existing SQLite `collections` table via `CollectionRepository` (append-only inserts). No CRDs, no phone-home / kube9-api sync, no second persistence engine.
-- **Queryable truth:** `query collections list|get` and status `collectionsStoredCount` reflect durable SQLite rows.
+- **Queryable truth:** `query collections list|get` and status `collectionsStoredCount` reflect durable SQLite rows (`CollectionRepository.countCollections`).
+- **Sole durable write:** Collectors persist only through `CollectionRepository.insertCollection` (Zod validate then insert). In-memory `LocalStorage` is not durable truth, must not update `collectionsStoredCount`, and is removed from the collector durable write path.
 - **Types:** `cluster-metadata`, `resource-inventory`, `resource-configuration-patterns`, `performance-metrics`, `security-posture`.
 - **Producer ownership:** Operator owns normative write shapes. Peer Desktop foreshadows are non-normative.
 
 ## Open implementation decisions
 
-- **Single durable write path:** Wire collectors through `CollectionRepository.insertCollection` so CLI and `collectionsStoredCount` match SQLite. Decide fate of in-memory `LocalStorage` (cache vs removed vs transitional). See [data_model.md](data_model.md).
-- **Degrade persistence:** Whether Prometheus-unavailable performance ticks omit rows, persist unavailable success payloads, or fail without a row. Coordinate with runtime / integration.
-- **Optional future prune/cap:** Not in contract now; if introduced later, align Helm/env, `RetentionCleanup` (or peer service), and consumer prose via `/refine-issue`.
+### Resolved (single durable write path)
+
+Collectors (existing three and the two additive types) write through `CollectionRepository.insertCollection`. LocalStorage is off the durable path. See [data_model.md](data_model.md).
+
+### Degrade persistence — peer collector scope
+
+Whether Prometheus-unavailable performance ticks omit rows, persist `source.available: false` success payloads, or fail without a row is owned by the performance-metrics collector capability (coordinate with runtime / integration).
+
+### Optional future prune/cap
+
+Not in contract now; if introduced later, align Helm/env, `RetentionCleanup` (or peer service), and consumer prose via `/refine-issue`.
 
 ## Single Binary, Dual Modes
 

--- a/.ai/data/serialization.md
+++ b/.ai/data/serialization.md
@@ -170,16 +170,36 @@ Empty successful `query collections list` (including `--type` with no rows) rema
 
 ### Status surface
 
-`collectionStats` stays aggregate counters (`totalSuccessCount`, `totalFailureCount`, `collectionsStoredCount`, `lastSuccessTime`). New types participate in those counters without changing the CollectionStats field set.
+`collectionStats` stays aggregate counters (`totalSuccessCount`, `totalFailureCount`, `collectionsStoredCount`, `lastSuccessTime`). New types participate in those counters without changing the CollectionStats field set. `collectionsStoredCount` is the SQLite `collections` row count, not an in-memory buffer size. Internal per-type tracker maps are not published on the status ConfigMap.
+
+### performance-metrics `data` serialization
+
+| Field | Notes |
+|-------|-------|
+| `timestamp`, `collectionId`, `clusterId` | Required identity/time |
+| `source.available` | boolean; required |
+| `source.reason` | optional string ≤ 200 chars |
+| `utilization.cpu` / `utilization.memory` | optional; ratio fields in `[0, 1]` |
+| `ratios` | optional named ratios in `[0, 1]`; ≤ 16 keys; key length ≤ 64 |
+
+Reject raw series dumps and serialized `data` > 64 KiB. Zod discriminant `type: "performance-metrics"` must match this shape at write time.
+
+### security-posture `data` serialization
+
+| Field | Notes |
+|-------|-------|
+| `timestamp`, `collectionId`, `clusterId` | Required identity/time |
+| `privilegedHost.*` | required privileged/hostPath/hostNetwork counts; optional hostPID/hostIPC |
+| `networkPolicyCoverage.*` | required namespace totals; optional `coverageRatio` in `[0, 1]` |
+| `nsaCisRollups` | required object of non-negative int counters; ≤ 24 keys; key length ≤ 64 |
+
+Reject CVE / vulnerabilities / RBAC-risk bodies and serialized `data` > 64 KiB. Zod discriminant `type: "security-posture"` must match this shape at write time.
 
 ## Open implementation decisions
 
-### Collection payload field-level serialization
+### Resolved (collection payload field-level serialization)
 
-- Concrete `data` property catalogs and nested JSON shapes for `performance-metrics` and `security-posture` (including optional Prometheus source-status marker and size bounds).
-- Exact Zod / TypeScript literal updates for the two new discriminants and write-time mismatch rejection.
-- Whether degrade ticks serialize a durable unavailable payload vs omit the row (see [data_model.md](data_model.md) open decisions).
-- Resolve via `/refine-issue` into field tables once implementation picks keys.
+Field catalogs and Zod discriminant rules for `performance-metrics` and `security-posture` are normative above and in [data_model.md](data_model.md). Write-time mismatch rejection uses the existing `CollectionPayloadSchema` discriminated union at `CollectionRepository.insertCollection`. Degrade-tick choice (omit row vs persist `source.available: false`) is owned by the performance-metrics collector capability; both outcomes serialize only documents that pass this schema when a row is written.
 
 ### Resolved (retention metadata on query JSON)
 

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -163,10 +163,17 @@ kube9-operator query collections get <collectionId> [--format=json|yaml|table|co
 
 ### Open implementation decisions (collections query / status wire)
 
-- Exact CLI help text / `--type` enum listing once both new tokens ship; table/compact column widths for new summary fields (coordinate with interface).
-- Whether status ConfigMap gains an optional bounded `prometheus` (or equivalent) detection block analogous to `trivy` / `argocd` (coordinate with external_systems + data serialization).
-- Payload field catalogs for `performance-metrics` and `security-posture` (owned by data; integration requires only that wire types stay additive and peer-tolerant).
-- Confirm peers that ignore unknown `type` values need no same-milestone `.ai` edits (default: yes).
+### Resolved (payload catalogs and aggregate status)
+
+Payload field catalogs for `performance-metrics` and `security-posture` are normative in data contracts. Wire types stay additive; `collectionStats` remains the aggregate four-field object; peers that ignore unknown `type` values need no same-milestone peer-repo `.ai` edits.
+
+### CLI help / table polish — peer CLI issue scope
+
+Exact Commander help text listing and table/compact column widths for new summary fields coordinate with interface once tokens ship (tracked with the query-collections CLI completion issue).
+
+### Optional status prometheus block — not required for pipeline types
+
+Whether status ConfigMap gains an optional bounded `prometheus` (or equivalent) detection block analogous to `trivy` / `argocd` remains optional packaging/integration backlog; not required for five-type CollectionPayload acceptance.
 
 ### Assessment API Contract
 

--- a/.ai/interface/input_handling.md
+++ b/.ai/interface/input_handling.md
@@ -118,5 +118,10 @@ kubectl exec -n <namespace> deploy/kube9-operator -- kube9-operator <command> [o
 
 ## Open implementation decisions
 
-- **Exact `--type` tokens:** Lock final kebab-case strings for the two new collectors with data / business_logic (`performance-metrics` and `security-posture` are the working candidates already listed above). CLI Zod enum, Commander help text, and payload discriminants must match.
-- **Help / description copy:** Exact Commander descriptions for `query collections` and the `--type` option once the enum is final (today help lists only the three shipped types).
+### Resolved (`--type` tokens)
+
+CLI `--type`, payload discriminants, and observability labels use `cluster-metadata` | `resource-inventory` | `resource-configuration-patterns` | `performance-metrics` | `security-posture`. Invalid values fail option validation with the existing JSON-on-stderr pattern.
+
+### Help / description copy — peer CLI issue scope
+
+Exact Commander descriptions for `query collections` and the `--type` option once help text lists all five types (today help may still list only the three shipped types until the CLI completion issue lands).

--- a/.ai/operations/observability.md
+++ b/.ai/operations/observability.md
@@ -265,9 +265,11 @@ Agent or Desktop wrapping of `query events list` / `query assessments history` d
 
 ### Open implementation decisions
 
+### Resolved (collection type labels and collectionStats)
+
+Prometheus collection-series `type` label values match payload / CLI ids: `cluster-metadata`, `resource-inventory`, `resource-configuration-patterns`, `performance-metrics`, `security-posture`. Do not rename or remove existing type strings; cardinality stays within this closed set. Status ConfigMap `collectionStats` stays aggregate-only (`totalSuccessCount`, `totalFailureCount`, `collectionsStoredCount`, `lastSuccessTime`) for this initiative; no required per-type status fields.
+
 - **Alert thresholds under query load:** Exact alert thresholds on `kube9_operator_events_dropped_total` / queue depth when clients issue more frequent history queries remain refine-issue backlog, not a packaging or deployment-band change.
-- **Canonical collection `type` label strings:** Confirm Prometheus `type` values match payload / CLI ids (`performance-metrics`, `security-posture` candidates). Do not rename or remove existing type strings; keep cardinality bounded to the known collection-type set.
-- **Prometheus-absent tick → `status` label:** How absent/unreachable Prometheus maps to `kube9_operator_collection_total` `status` (`success` / `failed` / skip-without-increment) so existing dashboards that filter known types keep working; coordinate with runtime degrade classification.
-- **`collectionStats` progressive enhancement:** Whether status ConfigMap stays aggregate-only for this initiative, or gains optional per-type fields under progressive enhancement without breaking required aggregate fields.
+- **Prometheus-absent tick → `status` label:** How absent/unreachable Prometheus maps to `kube9_operator_collection_total` `status` (`success` / `failed` / skip-without-increment) so existing dashboards that filter known types keep working; coordinate with runtime degrade classification (performance-metrics collector scope).
 - **Histogram buckets for ~15m performance ticks:** Confirm shared collection duration buckets remain adequate; any bucket tweak is refine-issue backlog, not a product packaging change.
 - **Collection-series alert thresholds:** Exact alert thresholds on the new type labels stay `/refine-issue` backlog like other collection metrics.

--- a/.ai/specs/data-collection-pipeline.spec.md
+++ b/.ai/specs/data-collection-pipeline.spec.md
@@ -20,16 +20,21 @@ Related capabilities: `performance-metrics-collector` and `security-posture-coll
 - **Runtime:** Node.js `>=22` (package engines); TypeScript operator process; better-sqlite3 for durable store at `{DB_PATH}/kube9.db`.
 - **Components:** CollectionScheduler; per-type collectors; CollectionRepository / SQLite `collections` table; Zod `CollectionPayload` validation; status publisher; CLI query path via `kubectl exec`.
 - **Type tokens (closed set for this pipeline):** `cluster-metadata`, `resource-inventory`, `resource-configuration-patterns`, `performance-metrics`, `security-posture`.
-- **Config:** Helm `metrics.intervals.*` and matching env interval seconds; optional Prometheus client config for performance only.
+- **Validation:** `CollectionPayloadSchema` is a Zod discriminated union on `type`. `CollectionRepository.insertCollection` rejects type/data mismatch and malformed envelopes (no row written). SQLite `type` stays unconstrained TEXT.
+- **Payload catalogs:** Normative `data` shapes for `performance-metrics` and `security-posture` live in `.ai/data/data_model.md` and `.ai/data/serialization.md` (source marker, utilization/ratios bounds, privilegedHost / networkPolicyCoverage / nsaCisRollups, 64 KiB and key-count caps).
+- **Durable write:** Sole durable write is `CollectionRepository.insertCollection`. Status `collectionsStoredCount` equals SQLite row count. In-memory LocalStorage is not queryable truth and is off the durable write path.
+- **Status:** ConfigMap `collectionStats` remains aggregate-only (`totalSuccessCount`, `totalFailureCount`, `collectionsStoredCount`, `lastSuccessTime`); new types participate in those counters.
+- **Config:** Helm `metrics.intervals.*` and matching env interval seconds; optional Prometheus client config for performance only (exact keys / registration gate owned by collector + packaging peers).
 - **Trust / deploy:** Zero-ingress default; cluster-internal egress only for optional Prometheus; read-only ClusterRole for Kubernetes API collectors.
-- Field catalogs, exact env key names, registration gate details, and degrade-row persistence shapes remain open implementation decisions in domain child docs until `/refine-issue`.
+- **Peer collector open items:** Degrade-row persistence when Prometheus is absent, PromQL/auth knobs, and security-posture partial-API tick classification remain in `performance-metrics-collector` / `security-posture-collector` and runtime/integration child docs.
 
 ## Testing Strategy
 
-- Unit: payload schema accept/reject per type; interval min enforcement; empty query success envelope.
-- Integration: scheduler registers expected collectors; SQLite insert + `query collections` round-trip; status aggregates include new types without dropping required fields.
-- Contract / chart: Helm values expose interval keys; ClusterRole remains read-only for posture reads; collection Prometheus metric `type` labels stay within the closed set.
-- Manual / smoke (kind/minikube): install without Prometheus → operator ready, security-posture rows appear over time, performance absent or gated without failing ready; with Prometheus configured → performance rows appear.
+- Unit: payload schema accept/reject per type (including mismatch of `type` vs `data`); reject oversized or forbidden security-posture CVE/RBAC bodies; empty query success envelope.
+- Unit / integration: durable insert via `CollectionRepository.insertCollection`; `collectionsStoredCount` tracks SQLite count after inserts (not LocalStorage size); LocalStorage store alone does not change durable count or CLI visibility.
+- Integration: SQLite insert + `query collections --type performance-metrics|security-posture` round-trip with fixture payloads; status aggregates keep the four required fields when new types succeed/fail.
+- Contract / chart: collection Prometheus metric `type` labels stay within the closed five-type set (label wiring may land with packaging peer); Helm interval keys for the two new types remain packaging peer scope.
+- Manual / smoke (kind/minikube): deferred to collector shipping issues; pipeline contract issue proves schema + durable write with unit/integration fixtures without requiring live Prometheus.
 
 ## References
 

--- a/.ai/specs/performance-metrics-collector.spec.md
+++ b/.ai/specs/performance-metrics-collector.spec.md
@@ -20,11 +20,12 @@ Depends on `data-collection-pipeline`. Does not replace operator `/metrics` expo
 - **Runtime:** Node.js `>=22`; same CollectionScheduler and SQLite path as peer collectors.
 - **Integration:** Trivy-style optional outbound client; cluster-internal egress; prefer not using the operator ServiceAccount token as an implicit Prometheus credential.
 - **Recommended registration:** register performance ticks only when a Prometheus base URL (or equivalent enable+URL) is set; unset is soft miss, not config failure.
-- Exact PromQL vs scrape shape, auth/TLS knobs, timeouts, and whether unavailable ticks omit rows vs store an unavailable marker are open implementation decisions (integration / data / runtime).
+- **Payload accept shape:** Normative `performance-metrics` `data` catalog (including required `source.available`) is defined in `.ai/data/data_model.md` / serialization; this collector fills those fields on ticks.
+- Exact PromQL vs scrape shape, auth/TLS knobs, timeouts, and whether unavailable ticks omit rows vs store `source.available: false` remain open implementation decisions (integration / runtime / error_handling).
 
 ## Testing Strategy
 
-- Unit: payload validation for `performance-metrics`; config reject for invalid Prometheus URL when set.
+- Unit: payload validation for `performance-metrics` against the shared catalog; config reject for invalid Prometheus URL when set.
 - Integration: with Prometheus unset → collector not registered or no failing ticks; `/readyz` stays ready; with mock Prometheus → successful append + query by type.
 - Chart / ops: optional Prometheus values documented; zero-ingress unchanged; metric `type=performance-metrics` appears only on collection series when ticks run.
 - Manual: kind/minikube without Prometheus proves graceful degrade; with in-cluster Prometheus proves snapshot queryability.

--- a/.ai/specs/security-posture-collector.spec.md
+++ b/.ai/specs/security-posture-collector.spec.md
@@ -19,11 +19,12 @@ Depends on `data-collection-pipeline`.
 
 - **Runtime:** Node.js `>=22`; CollectionScheduler + SQLite `collections` + `CollectionPayload`.
 - **Integration / RBAC:** read-only ClusterRole expansion only for resources still missing for the agreed signal set; chart already grants many workload and NetworkPolicy reads. No Secrets API, no pod exec, no cluster-admin for this collector.
-- Field-level counter keys, NSA/CIS rollup catalog, and exact ClusterRole delta vs live chart are open implementation decisions (data / operations / integration).
+- **Payload accept shape:** Normative `security-posture` `data` catalog (`privilegedHost`, `networkPolicyCoverage`, `nsaCisRollups` bounds) is defined in `.ai/data/data_model.md` / serialization; this collector fills those fields on ticks.
+- Exact NSA/CIS rollup key vocabulary beyond the catalog bounds, and exact ClusterRole delta vs live chart, remain open implementation decisions (operations / integration).
 
 ## Testing Strategy
 
-- Unit: payload validation for `security-posture`; reject Trivy CVE bodies or RBAC-risk blobs if presented as this type.
+- Unit: payload validation for `security-posture` against the shared catalog; reject Trivy CVE bodies or RBAC-risk blobs if presented as this type.
 - Integration: successful append from fake/minimal API fixtures; query by type; scheduler always registers security posture when core collectors start.
 - Chart: ClusterRole remains read-only; NetworkPolicy (and any added resources) documented for posture purpose.
 - Manual: kind/minikube shows posture rows after first successful tick without Prometheus or Trivy installed.


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #168
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

### Highlights
- Normative `performance-metrics` and `security-posture` `data` catalogs (bounds, reject rules)
- Zod discriminated-union write-time reject; CollectionRepository sole durable write; LocalStorage off durable path
- Aggregate-only `collectionStats`; closed five-type tokens aligned across data/CLI/observability contracts

Merge before `/build-from-github` when implementation should read merged contracts on `main`.