### PR TITLE
docs(ai): refine issue #169 contract updates

### DIFF
--- a/.ai/business_logic/domain_model.md
+++ b/.ai/business_logic/domain_model.md
@@ -127,10 +127,10 @@ User-facing operator docs (`charts/kube9-operator/README.md`) list **kube9-vscod
 
 Additive kebab-case tokens are `performance-metrics` and `security-posture`. Business logic, data Zod/TS literals, CLI `--type`, and observability `type` labels use the same strings. Do not rename or remove the three shipped type strings.
 
-### Interval seconds and minima — peer packaging / runtime scope
+### Resolved (performance-metrics interval and registration)
 
-Exact default seconds and enforced minima for the ~15m performance and ~24h security-posture collectors are locked with runtime and operations (Helm/env keys); product defaults remain ~15m and ~24h with random offset matching peer collectors.
+Performance-metrics defaults to `900` seconds (minimum `300`, offset `0–300`) via `PERFORMANCE_METRICS_INTERVAL_SECONDS`. Registration is config-gated on non-empty `PROMETHEUS_BASE_URL`. Unavailable Prometheus when registered omits rows and counts failed ticks without blocking ready or other collectors.
 
-### Performance collector registration gate — peer collector / runtime scope
+### Interval seconds — security-posture peer scope
 
-Whether the performance collector always registers on `CollectionScheduler` or registers only when a Prometheus endpoint is configured/enabled is locked with runtime and integration; either choice must preserve graceful degrade when Prometheus is absent or unreachable and must not block ready or other collectors.
+Exact default seconds and enforced minima for the ~24h security-posture collector remain locked with that collector / packaging peers; product default remains ~24h with random offset matching long-interval peers.

--- a/.ai/business_logic/error_handling.md
+++ b/.ai/business_logic/error_handling.md
@@ -23,7 +23,7 @@
 
 ### External Endpoint Failures
 - **Prometheus unreachable (optional assessment checks)**: Log warning, skip optional checks that depend on Prometheus
-- **Prometheus unreachable (performance metrics collector)**: Log warning; that collector tick degrades gracefully (no metrics-server / Kubernetes metrics API fallback). Operator continues; other collectors keep their schedules. Prometheus miss alone does **not** set operator `health` to `unhealthy`, and does **not** promote reserved `degraded` health. Exact tick classification (failed vs skipped vs success-with-unavailable) is under Open implementation decisions.
+- **Prometheus unreachable (performance metrics collector)**: When the collector is registered and Prometheus is unreachable, auth-failed, timed out, or returns unusable/empty results: log warning; **omit** a `collections` row; count the tick as **failed** on `kube9_operator_collection_total` (`status=failed`) and `totalFailureCount`; retry next interval. Do not persist `source.available: false` marker rows; do not classify as skipped. No metrics-server / Kubernetes metrics API fallback. Operator continues; other collectors keep their schedules. Prometheus miss alone does **not** set operator `health` to `unhealthy`, and does **not** promote reserved `degraded` health. When `PROMETHEUS_BASE_URL` is unset, the collector is not registered (no ticks).
 - **ArgoCD endpoint unreachable**: Detection returns not detected, operator continues
 - **Trivy server unreachable**: Detection returns not detected; workload scans are skipped until a server is configured
 
@@ -88,6 +88,9 @@
 
 ### Open implementation decisions
 
+### Resolved (performance-metrics unavailable tick)
+
+When registered and Prometheus is unreachable / auth-failed / timed out / unusable/empty: omit `collections` row; record **failed** (not skipped, not success-with-unavailable). Empty `--type performance-metrics` until a successful snapshot is a normal evidence gap. Must not invent a new operator `health` value.
+
 - **Consumer error copy:** Exact Desktop/vscode strings for empty history vs exec/RBAC failure stay in peer interface contracts; operator BL only distinguishes outcome classes.
-- **Performance collector tick classification:** When Prometheus is absent or unreachable, lock whether the tick is recorded as failed, skipped, or success-with-unavailable (coordinate with runtime and data). Must not invent a new operator `health` value.
-- **Security posture partial-failure classification:** When some cluster API reads fail mid-tick, lock whether the outcome is a failed tick, a partial persisted snapshot, or skipped (coordinate with runtime and data). Same health constraint as Prometheus miss.
+- **Security posture partial-failure classification:** When some cluster API reads fail mid-tick, lock whether the outcome is a failed tick, a partial persisted snapshot, or skipped (coordinate with runtime and data). Same health constraint as Prometheus miss (security-posture collector scope).

--- a/.ai/data/data_model.md
+++ b/.ai/data/data_model.md
@@ -402,6 +402,6 @@ Normative `data` catalogs for `performance-metrics` and `security-posture` are u
 
 `CollectionRepository.insertCollection` is the sole durable write. LocalStorage is off the durable path and does not own `collectionsStoredCount`. Existing collectors must use the same durable path so CLI and status match SQLite.
 
-### Degrade-row persistence (Prometheus unavailable) — peer collector scope
+### Resolved (performance-metrics unavailable ticks)
 
-Whether a Prometheus-absent/unreachable tick **omits** a `collections` row, stores a **success** payload with `source.available: false`, or counts as a **collection failure** with no durable row is owned by the performance-metrics collector capability (coordinate with runtime / error_handling). Schema accepts `source.available` either way. Security posture is not gated on Prometheus.
+When the performance-metrics collector is registered and Prometheus is unreachable / auth-failed / timed out / unusable/empty: **omit** a `collections` row and count the tick as a **collection failure** (no durable row). Do not persist success payloads with `source.available: false` for that path. Successful ticks write catalog payloads with `source.available: true` (optional utilization / ratios). Schema still accepts `source.available: false` for validation completeness, but the collector does not produce unavailable marker rows in v1. Security posture is not gated on Prometheus.

--- a/.ai/data/persistence_abstractions.md
+++ b/.ai/data/persistence_abstractions.md
@@ -70,9 +70,9 @@ Queryable event, assessment, and collection history for Desktop Tier 2 (and simi
 
 Collectors (existing three and the two additive types) write through `CollectionRepository.insertCollection`. LocalStorage is off the durable path. See [data_model.md](data_model.md).
 
-### Degrade persistence — peer collector scope
+### Resolved (performance-metrics degrade persistence)
 
-Whether Prometheus-unavailable performance ticks omit rows, persist `source.available: false` success payloads, or fail without a row is owned by the performance-metrics collector capability (coordinate with runtime / integration).
+Prometheus-unavailable / unusable performance ticks **omit** rows and count as collection failures (no durable row). They do not persist `source.available: false` success payloads. See [data_model.md](data_model.md) and `.ai/specs/performance-metrics-collector.spec.md`.
 
 ### Optional future prune/cap
 

--- a/.ai/data/serialization.md
+++ b/.ai/data/serialization.md
@@ -199,7 +199,7 @@ Reject CVE / vulnerabilities / RBAC-risk bodies and serialized `data` > 64 KiB. 
 
 ### Resolved (collection payload field-level serialization)
 
-Field catalogs and Zod discriminant rules for `performance-metrics` and `security-posture` are normative above and in [data_model.md](data_model.md). Write-time mismatch rejection uses the existing `CollectionPayloadSchema` discriminated union at `CollectionRepository.insertCollection`. Degrade-tick choice (omit row vs persist `source.available: false`) is owned by the performance-metrics collector capability; both outcomes serialize only documents that pass this schema when a row is written.
+Field catalogs and Zod discriminant rules for `performance-metrics` and `security-posture` are normative above and in [data_model.md](data_model.md). Write-time mismatch rejection uses the existing `CollectionPayloadSchema` discriminated union at `CollectionRepository.insertCollection`. Performance-metrics unavailable ticks omit rows (no serialized unavailable marker); successful ticks serialize catalog documents with `source.available: true` (and optional utilization / ratios) that pass this schema.
 
 ### Resolved (retention metadata on query JSON)
 

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -171,9 +171,9 @@ Payload field catalogs for `performance-metrics` and `security-posture` are norm
 
 Exact Commander help text listing and table/compact column widths for new summary fields coordinate with interface once tokens ship (tracked with the query-collections CLI completion issue).
 
-### Optional status prometheus block — not required for pipeline types
+### Resolved (optional status prometheus block)
 
-Whether status ConfigMap gains an optional bounded `prometheus` (or equivalent) detection block analogous to `trivy` / `argocd` remains optional packaging/integration backlog; not required for five-type CollectionPayload acceptance.
+No required bounded `status.prometheus` (or equivalent) detection block for performance-metrics or five-type CollectionPayload acceptance. Optional packaging/integration backlog may add one later analogous to `trivy` / `argocd`; not part of collector accept for this initiative.
 
 ### Assessment API Contract
 

--- a/.ai/integration/external_systems.md
+++ b/.ai/integration/external_systems.md
@@ -118,33 +118,33 @@ Prometheus has two distinct roles for kube9-operator. They must not be conflated
 
 ### Role B: Optional outbound client (performance-metrics collector)
 
-**Scope boundary**: The performance-metrics collector may call an **in-cluster Prometheus** HTTP API (and/or scrape selected in-cluster targets) to build a **bounded aggregate snapshot** for SQLite `collections`. This path is **optional** and **additive** to Role A. The kube9-operator chart does **not** install Prometheus or Prometheus Operator. Absence or unreachability must not block other collectors, readiness, or serve startup.
+**Scope boundary**: The performance-metrics collector calls an **in-cluster Prometheus** PromQL HTTP API to build a **bounded aggregate snapshot** for SQLite `collections`. This path is **optional** and **additive** to Role A. The kube9-operator chart does **not** install Prometheus or Prometheus Operator. Absence or unreachability must not block other collectors, readiness, or serve startup.
 
 **Opt-in posture** (align with Trivy optional outbound):
-- No performance-metrics pull until an in-cluster Prometheus endpoint is configured (or explicitly enabled via chart/env).
+- No performance-metrics pull until `PROMETHEUS_BASE_URL` is non-empty (config-gated registration; no separate enable flag in v1).
 - Do **not** silently auto-query arbitrary discovered scrapers without configuration.
 - Default install stays zero-ingress: cluster-internal egress only when configured.
-- **Non-goals**: metrics-server / Kubernetes Metrics API fallback; multi-cluster federation; phone-home or upload of collections/metrics to kube9-api; replacing Prometheus Operator as a metrics stack.
+- **Non-goals**: metrics-server / Kubernetes Metrics API fallback; multi-cluster federation; phone-home or upload of collections/metrics to kube9-api; replacing Prometheus Operator as a metrics stack; required `status.prometheus` block; direct target scrape in v1.
 
 **Behavior**:
-- **Detection / readiness of the integration**: When configured, the operator may probe the configured Prometheus endpoint (timeouts and periodic refresh are implementation-defined, Trivy/Argo CD-adjacent). Exact Helm/env key names and whether a bounded `status.prometheus` (or equivalent) block is published are open implementation decisions below.
-- **Collection**: On CollectionScheduler ticks for the performance-metrics type, fetch a bounded utilization/ratio rollup snapshot. Persist as an append-only SQLite `collections` row when successful (see `.ai/data/`).
-- **Resilience**: Unreachable, auth-failed, timed-out, or empty Prometheus responses degrade **this collection type only** (log + metric + retry next interval). Operator global `health` does not become `unhealthy` solely because Prometheus is missing. Exact tick classification (failed vs skipped vs success-with-unavailable) is coordinated with runtime/data/error_handling.
+- **Env contract:** `PROMETHEUS_BASE_URL`, `PROMETHEUS_TIMEOUT_MS` (default `30000`, min `1000`), `PROMETHEUS_TLS_INSECURE` (default `false`). Helm values-tree wiring is packaging peer; runtime owns validation.
+- **Collection:** On CollectionScheduler ticks, issue PromQL instant queries (`/api/v1/query` class) and map results into the normative `performance-metrics` catalog (`.ai/data/data_model.md`). Persist via `CollectionRepository.insertCollection` only on success (`source.available: true`).
+- **Resilience:** Unreachable, auth-failed, timed-out, or empty/unusable Prometheus responses degrade **this collection type only**: log warn, **omit** row, count tick as **failed** (`kube9_operator_collection_total` `status=failed`, `totalFailureCount`), retry next interval. Do not persist `source.available: false` success markers. Operator global `health` does not become `unhealthy` solely because Prometheus is missing.
 
-**Auth family** (shape):
-- Stay inside existing optional in-cluster HTTP patterns (base URL, timeout, TLS verify / insecure).
-- Prefer **not** sending the operator Kubernetes ServiceAccount token to Prometheus by default.
-- Dedicated optional credentials only when a platform admin configures them (Secret mount pattern may follow Argo CD / chart precedents). Exact schemes and defaults are open implementation decisions below.
+**Auth family**:
+- v1: URL + timeout + TLS only.
+- Never send the operator Kubernetes ServiceAccount token as an implicit Prometheus credential.
+- Optional dedicated credentials / existingSecret mount remain packaging backlog if a platform requires them later.
 
 **Consumption**: Snapshots feed SQLite `collections`, `query collections`, status `collectionStats` participation, and observability `type` labels. kube9-vscode / kube9-desktop are progressive-enhancement consumers later; this initiative is operator-producer only.
 
 ### Open implementation decisions (Prometheus outbound)
 
-- Discovery / URL keys: exact Helm values and env names for base URL, enable flag, namespace/service defaults, timeouts; whether any presence probe populates a bounded `status.prometheus` (or equivalent) analogous to `status.trivy`.
-- Call shape: PromQL HTTP API vs direct scrape of selected targets (or both); requirements-level query set / series allowlist; body/size bounds; retries.
-- Auth knobs: none vs bearer vs basic (and Secret mount if any); TLS verify / insecure default; confirm SA token is never used as an implicit Prometheus credential.
-- Degrade signals: failure codes for unreachable / auth failed / timeout / empty result, and how they surface in collectionStats / CLI without changing global health semantics beyond existing collector failure practice.
-- Registration gate consistency with runtime: Trivy-style opt-in until configured (integration default). Exact always-register-with-skip vs gated-register wiring must match `.ai/runtime/` after Phase D open-impl lock.
+### Resolved (performance-metrics outbound client)
+
+Registration is config-gated on non-empty `PROMETHEUS_BASE_URL`. Call shape is PromQL HTTP API (not target scrape in v1). Unavailable ticks omit rows and count as failed. No required `status.prometheus` block. SA token is never an implicit credential; v1 auth knobs are URL/TLS only.
+
+- **Helm values-tree shape:** Whether chart knobs live under `prometheus.*` vs nested under `performanceMetrics.*` remains packaging peer (#171) as long as Deployment env names match the runtime contract above.
 
 ## In-cluster clients (kube9-vscode and kube9-desktop)
 

--- a/.ai/operations/build_packaging.md
+++ b/.ai/operations/build_packaging.md
@@ -56,19 +56,19 @@ The Helm chart supports comprehensive configuration through `values.yaml`:
 - `metrics.intervals.clusterMetadata`: Cluster metadata collection interval in seconds (default: `86400` = 24 hours, minimum: `3600`)
 - `metrics.intervals.resourceInventory`: Resource inventory collection interval in seconds (default: `21600` = 6 hours, minimum: `1800`)
 - `metrics.intervals.resourceConfigurationPatterns`: Resource configuration patterns collection interval in seconds (default: `43200` = 12 hours, minimum: `3600`)
-- `metrics.intervals.performanceMetrics`: Performance metrics collection interval in seconds (default: `900` = 15 minutes; enforced minimum locked with runtime)
-- `metrics.intervals.securityPosture`: Security posture collection interval in seconds (default: `86400` = 24 hours; enforced minimum locked with runtime)
+- `metrics.intervals.performanceMetrics`: Performance metrics collection interval in seconds (default: `900` = 15 minutes; minimum: `300`; maps to `PERFORMANCE_METRICS_INTERVAL_SECONDS`)
+- `metrics.intervals.securityPosture`: Security posture collection interval in seconds (default: `86400` = 24 hours; enforced minimum locked with security-posture / runtime peers)
 
 Chart `values.yaml` also carries intervals for Argo CD Application status and workload image scan under the same `metrics.intervals` map; those stay documented in the chart README.
 
 #### Optional Prometheus (performance collector, outbound)
 
-Performance metrics use an optional in-cluster Prometheus HTTP client (query and/or scrape). Packaging posture mirrors Trivy / Argo CD optional integrations:
+Performance metrics use an optional in-cluster Prometheus **PromQL HTTP** client. Packaging posture mirrors Trivy / Argo CD optional integrations:
 
-- Default install stays **zero-ingress**. Prometheus integration is **outbound** cluster-internal traffic when configured or discovered.
+- Default install stays **zero-ingress**. Prometheus integration is **outbound** cluster-internal traffic when configured.
 - Chart must not install Prometheus, create a ServiceMonitor for kube9 ownership of Prometheus, or invent an inbound scrape surface for this collector.
-- Chart must not create Secrets from plaintext credentials. If bearer/auth is ever required, use an existingSecret mount pattern (same class as `argocd.api.token.existingSecret`).
-- Exact values-tree keys (`prometheus.*` vs `performanceMetrics.*`), discovery defaults, timeout/TLS knobs, and enable vs always-register wiring are open implementation decisions below (coordinate with runtime + integration).
+- Chart must not create Secrets from plaintext credentials. v1 collector accept does **not** require a credential mount; if bearer/auth is added later, use an existingSecret mount pattern (same class as `argocd.api.token.existingSecret`).
+- Deployment must be able to set runtime env: `PROMETHEUS_BASE_URL`, `PROMETHEUS_TIMEOUT_MS` (default class `30000`), `PROMETHEUS_TLS_INSECURE` (default `false`). Non-empty base URL gates collector registration (not always-register). Exact values-tree nesting (`prometheus.*` vs under `performanceMetrics.*`) is packaging open work (#171) as long as env names match runtime.
 
 #### Event Storage
 - `events.persistence.enabled`: Enable persistent storage (default: `true`)
@@ -140,6 +140,13 @@ Performance metrics use an optional in-cluster Prometheus HTTP client (query and
 
 ## Open implementation decisions
 
-- **Exact Helm interval keys and env mapping:** Lock camelCase under `metrics.intervals` (candidates above: `performanceMetrics`, `securityPosture`) and Deployment env names (candidates: `PERFORMANCE_METRICS_INTERVAL_SECONDS`, `SECURITY_POSTURE_INTERVAL_SECONDS`). Defaults stay in the ~900s / ~86400s class; enforced minima and random-offset seconds align with runtime config loader.
-- **Prometheus values block shape:** Whether outbound client knobs live under `prometheus.*` (mirror `trivy.*` sibling) or nested under `performanceMetrics.*`; which of base URL, autoDetect/discovery, timeoutMs, tlsInsecure, and existingSecret auth are chart-first vs env-only; default-off until configured vs always-register collector with graceful degrade (must match runtime + integration).
-- **Chart harness / README tables:** `test-helm-chart.sh` Phase 5 assertions and README value tables for new interval env keys, optional Prometheus knobs, and any status fields; consumer wording that performance needs optional Prometheus and security posture is cluster-API only.
+### Resolved (performance-metrics chart env contract)
+
+- Interval key: `metrics.intervals.performanceMetrics` → `PERFORMANCE_METRICS_INTERVAL_SECONDS` (default `900`, minimum `300`, offset `0–300` per runtime).
+- Prometheus Deployment env names: `PROMETHEUS_BASE_URL`, `PROMETHEUS_TIMEOUT_MS`, `PROMETHEUS_TLS_INSECURE`. Registration gated on non-empty base URL (default-off until configured).
+
+### Packaging peer backlog (#171 / chart)
+
+- **Prometheus values-tree shape:** Nest under `prometheus.*` (mirror `trivy.*`) or under `performanceMetrics.*`; README / `test-helm-chart.sh` Phase 5 assertions for new interval and Prometheus knobs.
+- **Security-posture interval mapping:** `metrics.intervals.securityPosture` → `SECURITY_POSTURE_INTERVAL_SECONDS` (defaults/minima with security-posture collector).
+- **Consumer wording:** README notes that performance needs optional Prometheus and security posture is cluster-API only.

--- a/.ai/operations/observability.md
+++ b/.ai/operations/observability.md
@@ -269,7 +269,10 @@ Agent or Desktop wrapping of `query events list` / `query assessments history` d
 
 Prometheus collection-series `type` label values match payload / CLI ids: `cluster-metadata`, `resource-inventory`, `resource-configuration-patterns`, `performance-metrics`, `security-posture`. Do not rename or remove existing type strings; cardinality stays within this closed set. Status ConfigMap `collectionStats` stays aggregate-only (`totalSuccessCount`, `totalFailureCount`, `collectionsStoredCount`, `lastSuccessTime`) for this initiative; no required per-type status fields.
 
+### Resolved (performance-metrics collection metric status)
+
+When the performance-metrics collector is registered and Prometheus is unreachable / unusable: increment `kube9_operator_collection_total` with `type=performance-metrics` and `status=failed` (and `totalFailureCount`). Do not skip-without-increment and do not emit `status=success` for unavailable ticks. When URL is unset, no performance ticks run (no series for that type until registration).
+
 - **Alert thresholds under query load:** Exact alert thresholds on `kube9_operator_events_dropped_total` / queue depth when clients issue more frequent history queries remain refine-issue backlog, not a packaging or deployment-band change.
-- **Prometheus-absent tick → `status` label:** How absent/unreachable Prometheus maps to `kube9_operator_collection_total` `status` (`success` / `failed` / skip-without-increment) so existing dashboards that filter known types keep working; coordinate with runtime degrade classification (performance-metrics collector scope).
-- **Histogram buckets for ~15m performance ticks:** Confirm shared collection duration buckets remain adequate; any bucket tweak is refine-issue backlog, not a product packaging change.
+- **Histogram buckets for ~15m performance ticks:** Shared collection duration buckets remain adequate for v1; any bucket tweak is refine-issue backlog, not a product packaging change.
 - **Collection-series alert thresholds:** Exact alert thresholds on the new type labels stay `/refine-issue` backlog like other collection metrics.

--- a/.ai/operations/security.md
+++ b/.ai/operations/security.md
@@ -140,10 +140,10 @@ securityContext:
 
 ## Optional Prometheus (performance collector, outbound)
 
-- **Prometheus is optional**: The performance-metrics collector may query or scrape an in-cluster Prometheus HTTP endpoint when configured or discovered. There is **no** requirement to install Prometheus via the kube9-operator Helm chart, and kube9 does not own Prometheus Operator / ServiceMonitor lifecycle.
+- **Prometheus is optional**: The performance-metrics collector issues PromQL HTTP queries to an in-cluster Prometheus endpoint when `PROMETHEUS_BASE_URL` is configured. There is **no** requirement to install Prometheus via the kube9-operator Helm chart, and kube9 does not own Prometheus Operator / ServiceMonitor lifecycle.
 - **Zero-ingress unchanged**: Traffic is operator → Prometheus (cluster-internal egress). Operator `/metrics` exposition for scrapers of the operator itself remains a separate inbound path on the existing Service/port model.
-- **Safe degradation**: When Prometheus is absent or unreachable, the operator Deployment stays ready; only that collection type degrades. Absence must not become a readiness failure and must not imply phone-home or kube9-api sync.
-- **Auth hygiene**: Prefer not sending the operator ServiceAccount token to Prometheus by default. If a dedicated credential is ever required, use an out-of-band Secret + existingSecret mount (same class as Argo CD API token); chart does not create Secrets from plaintext. Tokens must not appear in status ConfigMap or CLI success stdout.
+- **Safe degradation**: When Prometheus is absent or unreachable, the operator Deployment stays ready; that collection type fails the tick without a durable row. Absence must not become a readiness failure and must not imply phone-home or kube9-api sync.
+- **Auth hygiene**: Never send the operator ServiceAccount token to Prometheus as an implicit credential. v1 ships URL / timeout / TLS only (no required Secret mount). If a dedicated credential is added later, use an out-of-band Secret + existingSecret mount (same class as Argo CD API token); chart does not create Secrets from plaintext. Tokens must not appear in status ConfigMap or CLI success stdout.
 
 ## Security posture collector (RBAC class)
 
@@ -168,4 +168,6 @@ securityContext:
 - **RBAC delta vs live chart:** Diff agreed security-posture v1 reads against `charts/kube9-operator/templates/clusterrole.yaml`. Add only missing resources/verbs; keep read-only. Confirm privileged / hostPath / hostNetwork signals need no new API groups beyond current pod/workload grants.
 - **NetworkPolicy purpose comment:** Chart comment today cites ai-conformance; update template comment (and this doc) so NetworkPolicy reads also cover security-posture coverage rollups (same verbs).
 - **Additional API groups for basic NSA/CIS rollups:** If implementation needs resources not already listed (for example namespaces already granted, or other policy objects), list them explicitly here and in the ClusterRole before merge; do not silently widen to Secrets, pods/exec, or deferred RBAC-risk analysis.
-- **Prometheus credential mount:** Whether v1 ships URL/timeout/TLS only (no Secret mount) or includes an optional existingSecret path in the same release; coordinate with packaging and integration.
+### Resolved (Prometheus credential mount for v1)
+
+v1 ships URL / timeout / TLS only (no Secret mount required for collector accept). Optional existingSecret auth remains packaging backlog if a platform requires it later; never use the operator SA token as an implicit Prometheus credential.

--- a/.ai/runtime/configuration.md
+++ b/.ai/runtime/configuration.md
@@ -42,12 +42,13 @@
   - Random offset range: 0-1 hour
 
 - **PERFORMANCE_METRICS_INTERVAL_SECONDS**: Performance metrics collection interval (Prometheus-backed)
-  - Default target: `900` (15 minutes); exact default/min/offset candidates under Open implementation decisions
-  - Enforced minimum and random offset required (same family as other `*_INTERVAL_SECONDS` collectors)
+  - Default: `900` (15 minutes)
+  - Minimum enforced: `300` (5 minutes)
+  - Random offset range: 0–300 seconds (0–5 minutes)
   - Invalid or below-minimum values fail config load (match existing interval fail-fast), not silent clamp after ready
 
 - **SECURITY_POSTURE_INTERVAL_SECONDS**: Security posture collection interval (cluster API aggregates)
-  - Default target: `86400` (24 hours); exact default/min/offset candidates under Open implementation decisions
+  - Default target: `86400` (24 hours); exact default/min/offset candidates under Open implementation decisions (security-posture collector scope)
   - Enforced minimum and random offset required
   - Invalid or below-minimum values fail config load
 
@@ -55,10 +56,14 @@
 
 Optional **operator → in-cluster Prometheus** client used only by the performance metrics collector. Distinct from the operator’s own `/metrics` exposition on `HEALTH_PORT`. Same optional-outbound family as Trivy / Argo CD HTTP (not a new trust boundary and not a readiness gate).
 
-- **Registration (recommended default):** Register the performance collector on `CollectionScheduler` only when a Prometheus base URL (or equivalent enable+URL pair) is configured. When unset, do not schedule performance ticks and do not treat absence as config failure. See Open implementation decisions for exact env names and the alternate always-register path.
-- **When configured but unreachable:** Degrade that collection type on the tick only; do not fail `/readyz`, do not stop other collectors, and do not require metrics-server / Kubernetes metrics API fallback.
-- **Secrets vs config:** Endpoint, timeout, and TLS flags are configuration. Optional auth (if any) follows existing chart secret-mount precedents (Argo CD API token style). Prefer not sending the operator ServiceAccount token to Prometheus by default. Auth must not become a bootstrap readiness dependency.
-- Exact Prometheus env/Helm keys (URL, timeout, TLS, auth) are Open implementation decisions; Helm chart wiring for those keys is owned with operations (`deployment_environments.md` / chart values), with runtime as the env contract home.
+- **Registration:** Config-gated. Register the performance collector on `CollectionScheduler` only when `PROMETHEUS_BASE_URL` is non-empty. No separate `*_ENABLED` flag in v1. When unset, do not schedule performance ticks and do not treat absence as config failure.
+- **Connection env (runtime contract):**
+  - `PROMETHEUS_BASE_URL` — base URL for PromQL HTTP API; non-empty gates registration; malformed when set → fail config load; unset → soft miss
+  - `PROMETHEUS_TIMEOUT_MS` — default `30000`, minimum `1000`; invalid → fail config load
+  - `PROMETHEUS_TLS_INSECURE` — default `false`
+- **v1 auth:** URL + timeout + TLS only. Do not send the operator ServiceAccount token as an implicit Prometheus credential. Optional bearer / existingSecret mount is packaging backlog (chart peer); not required for collector accept.
+- **When registered but unreachable / unusable:** Log warn; omit a `collections` row; count the tick as **failed** for collection metrics and `totalFailureCount`; retry next interval. Do not fail `/readyz`, do not stop other collectors, do not persist `source.available: false` marker rows, and do not require metrics-server / Kubernetes metrics API fallback.
+- **Helm:** Chart wiring for interval and Prometheus env keys is owned by operations (`build_packaging.md` / chart values); runtime owns env semantics and validation.
 
 ### Security posture collector
 
@@ -225,12 +230,12 @@ metrics:
     clusterMetadata: 86400                    # 24 hours (default), minimum 3600 (1h)
     resourceInventory: 21600                  # 6 hours (default), minimum 1800 (30m)
     resourceConfigurationPatterns: 43200     # 12 hours (default), minimum 3600 (1h)
-    performanceMetrics: 900                   # 15 minutes (target default); min/offset under Open implementation decisions
-    securityPosture: 86400                    # 24 hours (target default); min/offset under Open implementation decisions
+    performanceMetrics: 900                   # 15 minutes (default); minimum 300; offset 0–300s
+    securityPosture: 86400                    # 24 hours (target default); min/offset under security-posture Open implementation decisions
 ```
 - Maps to `*_INTERVAL_SECONDS` environment variables
 - Operator enforces minimum intervals to prevent abuse
-- Performance metrics also need optional Prometheus client values (URL / timeout / TLS); exact keys under Open implementation decisions. Chart RBAC and ServiceMonitor ownership stay in operations; runtime only loads the env contract and must not treat Prometheus as required for ready.
+- Performance metrics also need optional Prometheus client values mapped to `PROMETHEUS_BASE_URL`, `PROMETHEUS_TIMEOUT_MS`, `PROMETHEUS_TLS_INSECURE` (Helm values-tree shape is packaging peer). Chart RBAC and ServiceMonitor ownership stay in operations; runtime only loads the env contract and must not treat Prometheus as required for ready.
 
 ### Kubernetes AI Conformance Configuration
 ```yaml
@@ -278,13 +283,15 @@ events:
 
 ## Open implementation decisions
 
-- **Interval env / Helm keys:** Lock exact names. Recommended: `PERFORMANCE_METRICS_INTERVAL_SECONDS` ↔ `metrics.intervals.performanceMetrics`; `SECURITY_POSTURE_INTERVAL_SECONDS` ↔ `metrics.intervals.securityPosture`. Wire through `loadConfig()` and chart env like peer collectors.
-- **Numeric defaults, minima, offsets (candidates):**
-  - Performance: default `900` (15m), minimum `300` (5m), random offset `0–300` (0–5m). Shorter floor than inventory because the product default is already ~15m.
-  - Security posture: default `86400` (24h), minimum `3600` (1h), random offset `0–3600` (0–1h). Align with cluster-metadata long-interval peers.
-  - Config-load rejection for non-numeric / below-minimum values (fail-fast), matching existing `*_INTERVAL_SECONDS` behavior.
-- **Performance registration policy (recommended default):** **Config-gated registration** — register on `CollectionScheduler` only when an in-cluster Prometheus base URL is configured (optional explicit enable flag may AND with URL). Rationale: there is no useful performance tick without Prometheus (unlike workload-image-scan, which still collects image refs); matches integration’s Trivy-style “no pull until configured” and Argo CD API `collectionEnabled` family; avoids empty ~15m ticks and collectionStats noise when Prometheus was never intended. Alternate (not recommended): always-register and degrade/skip every tick when URL unset. Either choice must not invent a new readiness or secrets-before-traffic trust boundary.
-- **Enable flags:** Prefer URL-nonempty as the gate for performance (no separate `*_ENABLED` required in v1). Security posture: no enable flag (always-on) unless implementation adds one for chart symmetry (default on).
-- **Prometheus connection env / Helm keys (candidates):** `PROMETHEUS_BASE_URL` (or `PERFORMANCE_METRICS_PROMETHEUS_URL`), `PROMETHEUS_TIMEOUT_MS` (default class `30000`, minimum class `1000`), `PROMETHEUS_TLS_INSECURE` (default `false`). Optional auth only if needed: bearer env and/or token file + chart `existingSecret` mount patterned after Argo CD API token (do not default to SA token). Unset URL → soft miss (no register / no fail load). Invalid timeout or malformed URL when set → fail config load.
-- **Degrade tick semantics (runtime boundary):** When registered and Prometheus is missing/unreachable: log warn, do not throw out of the scheduler, retry next interval, do not flip `/readyz` or whole-operator `health` to unhealthy, and do not use reserved `health: degraded` for this miss. Exact tick classification in `collectionStats` / metrics (`failed` vs skipped vs success-with-unavailable) is locked with business_logic error_handling and data. When not registered (URL unset): no performance ticks at all.
-- **Ops vs runtime home:** Env semantics and load/validation live here. Helm value schema, RBAC for posture reads, and any ServiceMonitor for operator `/metrics` exposition stay in operations with a one-line pointer back to this doc for interval/Prometheus client env names.
+### Resolved (performance-metrics interval, registration, Prometheus env)
+
+- Interval: `PERFORMANCE_METRICS_INTERVAL_SECONDS` ↔ Helm `metrics.intervals.performanceMetrics`; default `900`, minimum `300`, random offset `0–300`. Fail-fast on invalid / below-minimum.
+- Registration: config-gated on non-empty `PROMETHEUS_BASE_URL` (no separate enable flag in v1). Always-register-with-degrade is rejected.
+- Prometheus outbound: `PROMETHEUS_BASE_URL`, `PROMETHEUS_TIMEOUT_MS` (default `30000`, min `1000`), `PROMETHEUS_TLS_INSECURE` (default `false`). v1 URL+TLS only; never implicit SA token.
+- Degrade when registered but unreachable/unusable: omit `collections` row; count tick as **failed** (metrics + `totalFailureCount`); do not flip `/readyz` or promote reserved `health: degraded`. When URL unset: no performance ticks.
+- Ops vs runtime home: env semantics and load/validation live here. Helm values-tree shape, RBAC for posture, and ServiceMonitor for operator `/metrics` stay in operations with a pointer back to these env names.
+
+### Security-posture collector — peer issue scope
+
+- Interval env / Helm keys: `SECURITY_POSTURE_INTERVAL_SECONDS` ↔ `metrics.intervals.securityPosture` (candidates: default `86400`, minimum `3600`, offset `0–3600`) remain locked with the security-posture collector / packaging peers.
+- Registration: always-on (no enable flag unless chart symmetry adds default-on). Not owned by performance-metrics.

--- a/.ai/runtime/execution_model.md
+++ b/.ai/runtime/execution_model.md
@@ -130,9 +130,9 @@ The kube9-operator binary supports multiple execution modes via Commander.js CLI
      - Collector: `ResourceConfigurationPatternsCollector`
 
   4. **Performance Metrics Collection**
-     - Interval: ~15m class (exact default/min/offset in configuration Open implementation decisions)
-     - Collector: performance metrics collector (optional in-cluster Prometheus HTTP client)
-     - **Recommended registration:** Config-gated until Prometheus base URL configured; when registered, tick degrades on unreachable Prometheus without stopping the scheduler or failing ready
+     - Interval: `performanceMetricsIntervalSeconds` (default: 900s = 15m; minimum: 300s; random offset: 0–300s)
+     - Collector: performance metrics collector (optional in-cluster Prometheus PromQL HTTP client)
+     - **Registration:** Config-gated until `PROMETHEUS_BASE_URL` is non-empty; when registered and Prometheus is unreachable/unusable, omit row and count tick as failed without stopping the scheduler or failing ready
      - Storage: existing SQLite `collections` path; no CRDs; no phone-home
 
   5. **Security Posture Collection**
@@ -212,6 +212,8 @@ The kube9-operator binary supports multiple execution modes via Commander.js CLI
 
 ## Open implementation decisions
 
-- **Registration policy lock:** Confirm recommended config-gated performance registration vs always-register-with-degrade with integration contracts; security posture stays always-register. See configuration.md Open implementation decisions for the recommendation rationale.
-- **Degrade tick → stats/metrics:** How a Prometheus miss maps to `collectionStats` counters and `kube9_operator_collection_*` labels (`failed` vs skipped vs success-with-unavailable) is coordinated with business_logic and data; execution model only requires that the scheduler keeps running and ready stays up.
+### Resolved (performance-metrics registration and degrade)
+
+Config-gated registration on non-empty `PROMETHEUS_BASE_URL`. Unavailable ticks omit rows and increment failure counters / `status=failed` metrics; scheduler keeps running and ready stays up. Security posture stays always-register (peer collector).
+
 - **Query mode process boundary unchanged:** `query collections` for the new types remains a separate CLI process via `kubectl exec`, same as today. No in-serve query API.

--- a/.ai/runtime/startup_bootstrap.md
+++ b/.ai/runtime/startup_bootstrap.md
@@ -149,7 +149,9 @@ Each step logs its progress:
 
 ## Open implementation decisions
 
-- **Bootstrap registration order:** Register performance (when gated condition met) and security posture after the three core collectors and before or alongside existing optional scheduler tasks; exact order among optional tasks is TW as long as failures for one collector still “log and continue.”
-- **Performance gate check at bootstrap:** Whether the gate is “non-empty Prometheus URL”, “explicit enable + URL”, or “enable with default-off until URL set” is locked with configuration Open implementation decisions. Recommended: non-empty URL (no separate enable required).
-- **First-tick vs scheduled-tick when Prometheus miss:** Prefer the same degrade path for first tick and later ticks (no special bootstrap scrape). Do not delay `setInitialized(true)` waiting on a Prometheus probe.
-- **Init failure isolation:** Constructing or registering either new collector must follow today’s collection-init catch: log error, continue serve without that collector if needed, still mark ready when the rest of bootstrap succeeds.
+### Resolved (performance-metrics bootstrap)
+
+- **Gate:** Non-empty `PROMETHEUS_BASE_URL` (no separate enable flag in v1).
+- **Order:** Register performance (when gate met) and security posture after the three core collectors and before or alongside existing optional scheduler tasks; failures for one collector still “log and continue.”
+- **First tick:** Same degrade path as later ticks (omit row + failed when Prometheus miss); no special bootstrap scrape; do not delay `setInitialized(true)` waiting on a Prometheus probe.
+- **Init failure isolation:** Constructing or registering either new collector follows today’s collection-init catch: log error, continue serve without that collector if needed, still mark ready when the rest of bootstrap succeeds.

--- a/.ai/specs/data-collection-pipeline.spec.md
+++ b/.ai/specs/data-collection-pipeline.spec.md
@@ -24,9 +24,10 @@ Related capabilities: `performance-metrics-collector` and `security-posture-coll
 - **Payload catalogs:** Normative `data` shapes for `performance-metrics` and `security-posture` live in `.ai/data/data_model.md` and `.ai/data/serialization.md` (source marker, utilization/ratios bounds, privilegedHost / networkPolicyCoverage / nsaCisRollups, 64 KiB and key-count caps).
 - **Durable write:** Sole durable write is `CollectionRepository.insertCollection`. Status `collectionsStoredCount` equals SQLite row count. In-memory LocalStorage is not queryable truth and is off the durable write path.
 - **Status:** ConfigMap `collectionStats` remains aggregate-only (`totalSuccessCount`, `totalFailureCount`, `collectionsStoredCount`, `lastSuccessTime`); new types participate in those counters.
-- **Config:** Helm `metrics.intervals.*` and matching env interval seconds; optional Prometheus client config for performance only (exact keys / registration gate owned by collector + packaging peers).
+- **Config:** Helm `metrics.intervals.*` and matching env interval seconds; optional Prometheus client for performance (`PROMETHEUS_BASE_URL`, timeout, TLS; config-gated registration). Chart wiring is packaging peer; runtime semantics live in configuration + `performance-metrics-collector` spec.
 - **Trust / deploy:** Zero-ingress default; cluster-internal egress only for optional Prometheus; read-only ClusterRole for Kubernetes API collectors.
-- **Peer collector open items:** Degrade-row persistence when Prometheus is absent, PromQL/auth knobs, and security-posture partial-API tick classification remain in `performance-metrics-collector` / `security-posture-collector` and runtime/integration child docs.
+- **Performance degrade:** Unavailable Prometheus ticks omit rows and count as failed (see `performance-metrics-collector` spec).
+- **Peer collector open items:** Security-posture partial-API tick classification remains in `security-posture-collector` and runtime/integration child docs.
 
 ## Testing Strategy
 

--- a/.ai/specs/performance-metrics-collector.spec.md
+++ b/.ai/specs/performance-metrics-collector.spec.md
@@ -8,27 +8,42 @@ Depends on `data-collection-pipeline`. Does not replace operator `/metrics` expo
 
 ## Functional Specification
 
-- Default schedule target ~15 minutes with enforced minimum and random offset (exact seconds in runtime open-impl).
-- Data source v1: in-cluster Prometheus only (optional outbound HTTP query and/or scrape). No metrics-server / Kubernetes metrics API fallback.
-- Opt-in / degrade: no performance pull until Prometheus endpoint is configured (recommended: config-gated registration). When Prometheus is absent or unreachable, other collectors and readiness continue; operator health does not become unhealthy solely for that reason.
-- Persisted payload class: bounded utilization / ratio style aggregates inside `CollectionPayload`, not a raw time-series warehouse.
-- Queryable via `query collections` with `--type performance-metrics`; empty list before first success is normal.
-- **Non-goals:** installing Prometheus/Prometheus Operator; phone-home; peer UX this milestone; storing unsanitized high-cardinality series dumps.
+- Default schedule: `900` seconds (15 minutes), enforced minimum `300` seconds (5 minutes), random offset `0–300` seconds.
+- Data source v1: in-cluster Prometheus only via optional outbound **PromQL HTTP API** (`/api/v1/query` class). No metrics-server / Kubernetes metrics API fallback. Direct target scrape is out of v1.
+- **Config-gated registration:** register on `CollectionScheduler` only when `PROMETHEUS_BASE_URL` is non-empty. Unset URL is a soft miss (no ticks, not config failure). No separate enable flag in v1.
+- When registered and Prometheus is unreachable, auth-failed, timed out, or returns unusable/empty results: **omit** a `collections` row; count the tick as **failed** on collection metrics / `totalFailureCount`; do not persist `source.available: false` marker rows; do not classify as skipped. Operator `/readyz` and other collectors continue; Prometheus miss alone does not set `health: unhealthy` or reserved `health: degraded`.
+- Successful ticks persist bounded utilization aggregates via `CollectionRepository.insertCollection` with catalog `source.available: true` (optional utilization / ratios fields).
+- Queryable via `query collections` with `--type performance-metrics`; empty list before first success is a normal evidence gap.
+- **Non-goals:** installing Prometheus/Prometheus Operator; phone-home; peer UX this milestone; storing unsanitized high-cardinality series dumps; required `status.prometheus` block; SA token as implicit Prometheus credential.
 
 ## Technical Specification
 
-- **Runtime:** Node.js `>=22`; same CollectionScheduler and SQLite path as peer collectors.
-- **Integration:** Trivy-style optional outbound client; cluster-internal egress; prefer not using the operator ServiceAccount token as an implicit Prometheus credential.
-- **Recommended registration:** register performance ticks only when a Prometheus base URL (or equivalent enable+URL) is set; unset is soft miss, not config failure.
-- **Payload accept shape:** Normative `performance-metrics` `data` catalog (including required `source.available`) is defined in `.ai/data/data_model.md` / serialization; this collector fills those fields on ticks.
-- Exact PromQL vs scrape shape, auth/TLS knobs, timeouts, and whether unavailable ticks omit rows vs store `source.available: false` remain open implementation decisions (integration / runtime / error_handling).
+- **Runtime:** Node.js `>=22`; same `CollectionScheduler` and SQLite path as peer collectors.
+- **Interval env:** `PERFORMANCE_METRICS_INTERVAL_SECONDS` (default `900`, minimum `300`, random offset `0–300`). Invalid or below-minimum values fail config load. Helm mapping `metrics.intervals.performanceMetrics` is packaging peer (#171).
+- **Prometheus outbound env (runtime contract):**
+  - `PROMETHEUS_BASE_URL` — non-empty registers the collector; unset → no register / no fail load; malformed when set → fail config load.
+  - `PROMETHEUS_TIMEOUT_MS` — default `30000`, minimum `1000`; invalid → fail config load.
+  - `PROMETHEUS_TLS_INSECURE` — default `false`.
+  - v1 ships URL + timeout + TLS only (no bearer/basic/existingSecret required for collector accept). Never send the operator ServiceAccount token as an implicit Prometheus credential. Optional auth mount is packaging backlog (#171 / later).
+- **Call shape:** PromQL instant queries against `{PROMETHEUS_BASE_URL}/api/v1/query` (or equivalent instant-query path on that base). Map successful numeric results into the normative `performance-metrics` `data` catalog in `.ai/data/data_model.md`:
+  - Required on success: identity fields (`timestamp`, `collectionId`, `clusterId`) and `source: { available: true }` (optional `reason` unused on success).
+  - Optional when PromQL supplies them: `utilization.cpu.clusterAvgRatio`, `utilization.cpu.nodeHighWatermarkRatio`, `utilization.memory.clusterAvgRatio`, `utilization.memory.nodeHighWatermarkRatio` (each in `[0, 1]`).
+  - Optional `ratios` map may be omitted in v1 (or filled only with a small allowlisted set of named ratios in `[0, 1]`, ≤16 keys).
+  - Reject raw series dumps / unbounded label maps / serialized `data` > 64 KiB at write validation.
+- **Unavailable / unusable tick:** unreachable, auth-failed, timeout, empty vector, or results that cannot yield a valid catalog payload → log warn, **no** `collections` row, increment `kube9_operator_collection_total{type="performance-metrics",status="failed"}` and `totalFailureCount`, retry next interval. Do not use `source.available: false` success rows for this path.
+- **Success tick:** insert via `CollectionRepository.insertCollection`; increment success counters; participate in aggregate `collectionStats`.
+- **Bootstrap:** same degrade path for first and later ticks; do not probe Prometheus before `setInitialized(true)`; register after core collectors when URL gate passes; init failure log-and-continue.
+- **Status:** no required bounded `status.prometheus` block for this capability.
+- **Chart ownership:** Helm values tree and Deployment env wiring for the keys above are owned by packaging peer (#171); this capability owns runtime semantics and validation.
 
 ## Testing Strategy
 
-- Unit: payload validation for `performance-metrics` against the shared catalog; config reject for invalid Prometheus URL when set.
-- Integration: with Prometheus unset → collector not registered or no failing ticks; `/readyz` stays ready; with mock Prometheus → successful append + query by type.
-- Chart / ops: optional Prometheus values documented; zero-ingress unchanged; metric `type=performance-metrics` appears only on collection series when ticks run.
-- Manual: kind/minikube without Prometheus proves graceful degrade; with in-cluster Prometheus proves snapshot queryability.
+- Unit: payload validation for successful `performance-metrics` fixtures (`source.available: true`, utilization bounds); config reject for malformed `PROMETHEUS_BASE_URL` or invalid timeout when set; config accept when URL unset (collector not registered).
+- Unit: mock PromQL client — success maps into catalog fields and calls `CollectionRepository.insertCollection`; unreachable / timeout / empty → no insert, failed metric path.
+- Integration: Prometheus unset → no performance ticks / no failing ready; `/readyz` ready; other collectors unaffected. Mock Prometheus → successful append + `query collections --type performance-metrics` returns the row.
+- Integration: registered URL + failing mock → no row, `totalFailureCount` / collection `status=failed` increments, operator health stays healthy, `/readyz` ready.
+- Chart / ops (peer #171): optional Prometheus values documented; zero-ingress unchanged; `type=performance-metrics` on collection series when ticks run.
+- Manual: kind/minikube without Prometheus URL proves no registration / ready; with in-cluster Prometheus URL proves snapshot queryability.
 
 ## References
 
@@ -36,7 +51,9 @@ Depends on `data-collection-pipeline`. Does not replace operator `/metrics` expo
 - `.ai/integration/external_systems.md`
 - `.ai/runtime/configuration.md`
 - `.ai/runtime/startup_bootstrap.md`
+- `.ai/data/data_model.md`
 - `.ai/data/serialization.md`
 - `.ai/business_logic/error_handling.md`
 - `.ai/operations/build_packaging.md`
+- `.ai/operations/observability.md`
 - `.ai/vision.json` (primary competitor: Prometheus Operator)


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #169
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

### Highlights
- Config-gated registration on non-empty `PROMETHEUS_BASE_URL`; PromQL HTTP client (v1)
- Unavailable ticks: omit `collections` row; count as **failed** (not skipped, not `source.available: false` success markers)
- Locked interval (`900`/`300`/`0–300`) and Prometheus env contract (`PROMETHEUS_BASE_URL` / timeout / TLS)
- Deepened `performance-metrics-collector` Technical Specification and Testing Strategy

Merge before `/build-from-github` when implementation should read merged contracts on `main`.