### PR TITLE
docs(ai): refine issue #171 contract updates

### DIFF
--- a/.ai/integration/authorization.md
+++ b/.ai/integration/authorization.md
@@ -42,9 +42,9 @@
   - `namespaces` - To verify ArgoCD namespace exists
   - `deployments` (apps) - To find ArgoCD server deployment
 
-**Security-posture collector**: Uses the same read-only Kubernetes API surface (pods, namespaces, networkpolicies, and related object fields already readable). No Secrets API, no `pods/exec`, no cluster-admin. Any additional API-group reads required for agreed NSA/CIS-oriented rollups are additive ClusterRole deltas coordinated with operations (open implementation decision below).
+**Security-posture collector**: Uses the same read-only Kubernetes API surface (pods, namespaces, networkpolicies, and related object fields already readable). No Secrets API, no `pods/exec`, no cluster-admin. Locked v1 signals require **no ClusterRole expansion**; packaging only updates the NetworkPolicy purpose comment.
 
-**Prometheus outbound client**: Optional HTTP egress to a configured in-cluster Prometheus. Does **not** require new Kubernetes RBAC verbs for Prometheus itself. Credential mounts (if any) follow optional Secret patterns; do not imply SA token as Prometheus credential by default (see [external_systems.md](external_systems.md)).
+**Prometheus outbound client**: Optional HTTP egress to a configured in-cluster Prometheus. Does **not** require new Kubernetes RBAC verbs for Prometheus itself. v1 uses URL + timeout + TLS only (no Secret mount); never use the operator SA token as an implicit Prometheus credential (see [external_systems.md](external_systems.md)).
 
 **Binding**: `ClusterRoleBinding` binds ServiceAccount to ClusterRole
 
@@ -155,9 +155,12 @@ rules:
 ## Open implementation decisions
 
 - **Agent auth model**: Closed for this epic. Desktop AI agent Tier 2 uses the same Extension / Desktop User RBAC and kubectl-exec path; no new Role, ClusterRole, or token type.
-- **Prometheus outbound auth knobs**: Exact none / bearer / basic / Secret-mount defaults and TLS verify vs insecure. Confirm operator SA token is never an implicit Prometheus credential. Align Secret mount patterns with chart precedents if dedicated credentials are supported. Peer scope `#169` / `#171`.
+
+### Resolved (Prometheus outbound auth knobs)
+
+v1 uses URL + timeout + TLS only (`PROMETHEUS_BASE_URL` / `PROMETHEUS_TIMEOUT_MS` / `PROMETHEUS_TLS_INSECURE`; Helm `prometheus.*`). No bearer, basic, or Secret mount for Prometheus. Operator ServiceAccount token is never an implicit Prometheus credential. Chart does not create Secrets from plaintext.
 
 ### Resolved (security-posture RBAC and health)
 
-- **RBAC delta:** None for the locked v1 posture signal set (pods, apps workloads, namespaces, networkpolicies already granted). Keep read-only; no Secrets, no pod exec, no cluster-admin.
+- **RBAC delta:** None for the locked v1 posture signal set (pods, apps workloads, namespaces, networkpolicies already granted). Keep read-only; no Secrets, no pod exec, no cluster-admin. Packaging only updates the NetworkPolicy purpose comment (no new rules).
 - **Degrade vs global health:** Posture API list failures follow omit-row + failed metrics + retry next interval. Do not widen `health: degraded` / `unhealthy` or fail `/readyz` solely for posture collect failures (coordinate with runtime/error_handling).

--- a/.ai/integration/external_systems.md
+++ b/.ai/integration/external_systems.md
@@ -118,33 +118,34 @@ Prometheus has two distinct roles for kube9-operator. They must not be conflated
 
 ### Role B: Optional outbound client (performance-metrics collector)
 
-**Scope boundary**: The performance-metrics collector may call an **in-cluster Prometheus** HTTP API (and/or scrape selected in-cluster targets) to build a **bounded aggregate snapshot** for SQLite `collections`. This path is **optional** and **additive** to Role A. The kube9-operator chart does **not** install Prometheus or Prometheus Operator. Absence or unreachability must not block other collectors, readiness, or serve startup.
+**Scope boundary**: The performance-metrics collector may call an **in-cluster Prometheus** PromQL HTTP API to build a **bounded aggregate snapshot** for SQLite `collections`. This path is **optional** and **additive** to Role A. The kube9-operator chart does **not** install Prometheus or Prometheus Operator. Absence or unreachability must not block other collectors, readiness, or serve startup.
 
 **Opt-in posture** (align with Trivy optional outbound):
-- No performance-metrics pull until an in-cluster Prometheus endpoint is configured (or explicitly enabled via chart/env).
-- Do **not** silently auto-query arbitrary discovered scrapers without configuration.
+- No performance-metrics pull until `PROMETHEUS_BASE_URL` / Helm `prometheus.baseUrl` is non-empty (config-gated registration; no separate enable flag).
+- Do **not** silently auto-query arbitrary discovered scrapers without configuration. No chart `autoDetect` for Prometheus in v1.
 - Default install stays zero-ingress: cluster-internal egress only when configured.
-- **Non-goals**: metrics-server / Kubernetes Metrics API fallback; multi-cluster federation; phone-home or upload of collections/metrics to kube9-api; replacing Prometheus Operator as a metrics stack.
+- **Non-goals**: metrics-server / Kubernetes Metrics API fallback; multi-cluster federation; phone-home or upload of collections/metrics to kube9-api; replacing Prometheus Operator as a metrics stack; required `status.prometheus` block.
+
+**Helm / env (packaging + runtime):**
+- `prometheus.baseUrl` → `PROMETHEUS_BASE_URL` (emit only when non-empty)
+- `prometheus.timeoutMs` (default `30000`, min `1000`) → `PROMETHEUS_TIMEOUT_MS`
+- `prometheus.tlsInsecure` (default `false`) → `PROMETHEUS_TLS_INSECURE`
 
 **Behavior**:
-- **Detection / readiness of the integration**: When configured, the operator may probe the configured Prometheus endpoint (timeouts and periodic refresh are implementation-defined, Trivy/Argo CD-adjacent). Exact Helm/env key names and whether a bounded `status.prometheus` (or equivalent) block is published are open implementation decisions below.
+- **Call shape (v1):** PromQL HTTP instant queries against the configured base URL (`/api/v1/query` class). Direct target scrape is out of scope for v1.
 - **Collection**: On CollectionScheduler ticks for the performance-metrics type, fetch a bounded utilization/ratio rollup snapshot. Persist as an append-only SQLite `collections` row when successful (see `.ai/data/`).
-- **Resilience**: Unreachable, auth-failed, timed-out, or empty Prometheus responses degrade **this collection type only** (log + metric + retry next interval). Operator global `health` does not become `unhealthy` solely because Prometheus is missing. Exact tick classification (failed vs skipped vs success-with-unavailable) is coordinated with runtime/data/error_handling.
+- **Resilience**: Unreachable, auth-failed, timed-out, or empty/unusable Prometheus responses **omit** a `collections` row, count the tick as **failed** on collection metrics / `totalFailureCount`, and retry next interval. Operator global `health` does not become `unhealthy` and `/readyz` stays ready. Do not persist `source.available: false` marker rows.
 
-**Auth family** (shape):
-- Stay inside existing optional in-cluster HTTP patterns (base URL, timeout, TLS verify / insecure).
-- Prefer **not** sending the operator Kubernetes ServiceAccount token to Prometheus by default.
-- Dedicated optional credentials only when a platform admin configures them (Secret mount pattern may follow Argo CD / chart precedents). Exact schemes and defaults are open implementation decisions below.
+**Auth family** (v1):
+- URL + timeout + TLS only. No bearer, basic, or Secret mount for Prometheus credentials in v1.
+- Never send the operator Kubernetes ServiceAccount token as an implicit Prometheus credential.
 
 **Consumption**: Snapshots feed SQLite `collections`, `query collections`, status `collectionStats` participation, and observability `type` labels. kube9-vscode / kube9-desktop are progressive-enhancement consumers later; this initiative is operator-producer only.
 
-### Open implementation decisions (Prometheus outbound)
+### Resolved (Prometheus outbound packaging + client contract)
 
-- Discovery / URL keys: exact Helm values and env names for base URL, enable flag, namespace/service defaults, timeouts; whether any presence probe populates a bounded `status.prometheus` (or equivalent) analogous to `status.trivy`.
-- Call shape: PromQL HTTP API vs direct scrape of selected targets (or both); requirements-level query set / series allowlist; body/size bounds; retries.
-- Auth knobs: none vs bearer vs basic (and Secret mount if any); TLS verify / insecure default; confirm SA token is never used as an implicit Prometheus credential.
-- Degrade signals: failure codes for unreachable / auth failed / timeout / empty result, and how they surface in collectionStats / CLI without changing global health semantics beyond existing collector failure practice.
-- Registration gate consistency with runtime: Trivy-style opt-in until configured (integration default). Exact always-register-with-skip vs gated-register wiring must match `.ai/runtime/` after Phase D open-impl lock.
+- Discovery / URL keys, registration gate, auth (none), call shape (PromQL instant), and unavailable degrade (omit + failed) are locked above and in `.ai/runtime/configuration.md` / performance-metrics collector capability.
+- Exact PromQL query set / series allowlist and body/size bounds remain the performance-metrics collector implementation detail within the bounded payload catalog.
 
 ## In-cluster clients (kube9-vscode and kube9-desktop)
 

--- a/.ai/operations/build_packaging.md
+++ b/.ai/operations/build_packaging.md
@@ -56,19 +56,25 @@ The Helm chart supports comprehensive configuration through `values.yaml`:
 - `metrics.intervals.clusterMetadata`: Cluster metadata collection interval in seconds (default: `86400` = 24 hours, minimum: `3600`)
 - `metrics.intervals.resourceInventory`: Resource inventory collection interval in seconds (default: `21600` = 6 hours, minimum: `1800`)
 - `metrics.intervals.resourceConfigurationPatterns`: Resource configuration patterns collection interval in seconds (default: `43200` = 12 hours, minimum: `3600`)
-- `metrics.intervals.performanceMetrics`: Performance metrics collection interval in seconds (default: `900` = 15 minutes; enforced minimum locked with runtime)
-- `metrics.intervals.securityPosture`: Security posture collection interval in seconds (default: `86400` = 24 hours; enforced minimum locked with runtime)
+- `metrics.intervals.performanceMetrics`: Performance metrics collection interval in seconds (default: `900` = 15 minutes, chart/schema minimum: `300`) → Deployment env `PERFORMANCE_METRICS_INTERVAL_SECONDS`. Runtime also applies random offset `0–300` (not a Helm value).
+- `metrics.intervals.securityPosture`: Security posture collection interval in seconds (default: `86400` = 24 hours, chart/schema minimum: `3600`) → Deployment env `SECURITY_POSTURE_INTERVAL_SECONDS`. Runtime also applies random offset `0–3600` (not a Helm value).
 
-Chart `values.yaml` also carries intervals for Argo CD Application status and workload image scan under the same `metrics.intervals` map; those stay documented in the chart README.
+Chart `values.yaml` also carries intervals for Argo CD Application status and workload image scan under the same `metrics.intervals` map; those stay documented in the chart README. `values.schema.json` must list the new interval keys (intervals object uses `additionalProperties: false`).
 
 #### Optional Prometheus (performance collector, outbound)
 
-Performance metrics use an optional in-cluster Prometheus HTTP client (query and/or scrape). Packaging posture mirrors Trivy / Argo CD optional integrations:
+Performance metrics use an optional in-cluster Prometheus HTTP client (PromQL). Packaging posture mirrors Trivy / Argo CD optional integrations as a **top-level `prometheus.*` sibling** of `trivy.*`:
 
-- Default install stays **zero-ingress**. Prometheus integration is **outbound** cluster-internal traffic when configured or discovered.
+| Helm value | Default | Deployment env | Notes |
+|------------|---------|----------------|-------|
+| `prometheus.baseUrl` | `""` | `PROMETHEUS_BASE_URL` | Emit env only when non-empty (mirror `trivy.serverUrl`). Empty = default-off; runtime does not register performance ticks. |
+| `prometheus.timeoutMs` | `30000` | `PROMETHEUS_TIMEOUT_MS` | Minimum `1000` in schema / runtime. |
+| `prometheus.tlsInsecure` | `false` | `PROMETHEUS_TLS_INSECURE` | Labs / mis-signed certs only. |
+
+- Default install stays **zero-ingress**. Prometheus traffic is **outbound** cluster-internal when `prometheus.baseUrl` is set.
 - Chart must not install Prometheus, create a ServiceMonitor for kube9 ownership of Prometheus, or invent an inbound scrape surface for this collector.
-- Chart must not create Secrets from plaintext credentials. If bearer/auth is ever required, use an existingSecret mount pattern (same class as `argocd.api.token.existingSecret`).
-- Exact values-tree keys (`prometheus.*` vs `performanceMetrics.*`), discovery defaults, timeout/TLS knobs, and enable vs always-register wiring are open implementation decisions below (coordinate with runtime + integration).
+- v1 chart ships **URL + timeout + TLS only**. No `autoDetect`, no enable flag, no `existingSecret` / Secret mount for Prometheus credentials. Chart does not create Secrets from plaintext. Operator ServiceAccount token must not be sent as an implicit Prometheus credential.
+- Readiness must not depend on Prometheus. Default install (empty `prometheus.baseUrl`) reaches Ready without Prometheus installed.
 
 #### Event Storage
 - `events.persistence.enabled`: Enable persistent storage (default: `true`)
@@ -138,8 +144,15 @@ Performance metrics use an optional in-cluster Prometheus HTTP client (query and
 - App version matches chart version
 - Chart versioning independent of operator binary version
 
-## Open implementation decisions
+### Chart harness, schema, and README (packaging acceptance)
 
-- **Exact Helm interval keys and env mapping:** Lock camelCase under `metrics.intervals` (candidates above: `performanceMetrics`, `securityPosture`) and Deployment env names (candidates: `PERFORMANCE_METRICS_INTERVAL_SECONDS`, `SECURITY_POSTURE_INTERVAL_SECONDS`). Defaults stay in the ~900s / ~86400s class; enforced minima and random-offset seconds align with runtime config loader.
-- **Prometheus values block shape:** Whether outbound client knobs live under `prometheus.*` (mirror `trivy.*` sibling) or nested under `performanceMetrics.*`; which of base URL, autoDetect/discovery, timeoutMs, tlsInsecure, and existingSecret auth are chart-first vs env-only; default-off until configured vs always-register collector with graceful degrade (must match runtime + integration).
-- **Chart harness / README tables:** `test-helm-chart.sh` Phase 5 assertions and README value tables for new interval env keys, optional Prometheus knobs, and any status fields; consumer wording that performance needs optional Prometheus and security posture is cluster-API only.
+- **`values.schema.json`:** Add `metrics.intervals.performanceMetrics` (min `300`, default `900`), `metrics.intervals.securityPosture` (min `3600`, default `86400`), and a `prometheus` object (`baseUrl`, `timeoutMs` min `1000` default `30000`, `tlsInsecure` default `false`) with `additionalProperties: false`.
+- **`./scripts/test-helm-chart.sh`:** Phase 2 template output must include `PERFORMANCE_METRICS_INTERVAL_SECONDS` and `SECURITY_POSTURE_INTERVAL_SECONDS` on default install; must not emit `PROMETHEUS_BASE_URL` when `prometheus.baseUrl` is empty; with `--set prometheus.baseUrl=http://prometheus.monitoring.svc:9090` must emit that URL plus timeout/TLS env. Phase 5 (when kind is available) must show the operator pod Ready on default install without Prometheus. Chart unit tests under `charts/kube9-operator/` may cover the same env mappings.
+- **README:** Document the two interval keys, the `prometheus.*` table, consumer wording that performance needs optional Prometheus and security posture is cluster-API only, and that SQLite `collections` has no TTL / count cap (PVC growth under ~15m performance ticks is an operational concern).
+- **ClusterRole:** No new rules for this packaging deliverable. Update the NetworkPolicy grant comment to name both AI conformance and security-posture coverage purposes.
+
+### Resolved (Helm intervals, Prometheus values, harness)
+
+- Interval Helm↔env mapping and numerics are locked above (aligned with runtime peers).
+- Prometheus values live under top-level `prometheus.*` (not nested under `performanceMetrics.*`); v1 is URL/timeout/TLS only, default-off until `baseUrl` is set.
+- Harness / schema / README expectations are locked in the packaging acceptance bullets above.

--- a/.ai/operations/deployment_environments.md
+++ b/.ai/operations/deployment_environments.md
@@ -98,4 +98,11 @@ Desktop and other clients may query retained events and assessments history via 
 
 - **Local dogfood paths:** Whether minikube / kind checklists should call out an explicit operator-present vs operator-absent history query smoke step (Desktop owns acceptance scoring; operator side only needs confirmable query + chart defaults).
 - **emptyDir wording in install docs:** Exact operator install-doc phrasing that persistence-off means ephemeral history for agent/evidence consumers (packaging already documents the volume switch).
-- **Collector smoke in Helm Phase 5 / minikube:** Whether `test-helm-chart.sh` Phase 5 or deploy:minikube docs assert new interval env keys and (when Prometheus is absent) graceful performance-collector degrade without failing readiness; exact assertions stay refine-issue / harness work.
+
+### Resolved (collector smoke in Helm Phase 5 / chart harness)
+
+For the packaging deliverable that wires performance-metrics and security-posture intervals plus optional Prometheus client values:
+
+- **`./scripts/test-helm-chart.sh` Phase 2:** Assert default-rendered Deployment includes `PERFORMANCE_METRICS_INTERVAL_SECONDS` and `SECURITY_POSTURE_INTERVAL_SECONDS`; assert `PROMETHEUS_BASE_URL` is absent when `prometheus.baseUrl` is empty; assert URL/timeout/TLS env appear when `prometheus.baseUrl` is set via `--set`.
+- **Phase 5 (kind, when available):** Default install reaches pod Ready without Prometheus installed (Prometheus absence must not fail readiness).
+- **README / chart docs:** Note collections append-only growth (no TTL) and that performance is optional-Prometheus while security posture is cluster-API only. Minikube deploy docs do not need a separate Prometheus install step for default smoke.

--- a/.ai/operations/observability.md
+++ b/.ai/operations/observability.md
@@ -265,11 +265,14 @@ Agent or Desktop wrapping of `query events list` / `query assessments history` d
 
 ### Open implementation decisions
 
+- **Alert thresholds under query load:** Exact alert thresholds on `kube9_operator_events_dropped_total` / queue depth when clients issue more frequent history queries remain refine-issue backlog, not a packaging or deployment-band change.
+- **Histogram buckets for ~15m performance ticks:** Confirm shared collection duration buckets remain adequate; any bucket tweak is refine-issue backlog, not a product packaging change.
+- **Collection-series alert thresholds:** Exact alert thresholds on the new type labels stay refine-issue backlog like other collection metrics.
+
 ### Resolved (collection type labels and collectionStats)
 
-Prometheus collection-series `type` label values match payload / CLI ids: `cluster-metadata`, `resource-inventory`, `resource-configuration-patterns`, `performance-metrics`, `security-posture`. Do not rename or remove existing type strings; cardinality stays within this closed set. Status ConfigMap `collectionStats` stays aggregate-only (`totalSuccessCount`, `totalFailureCount`, `collectionsStoredCount`, `lastSuccessTime`) for this initiative; no required per-type status fields.
+Prometheus collection-series `type` label values match payload / CLI ids: `cluster-metadata`, `resource-inventory`, `resource-configuration-patterns`, `performance-metrics`, `security-posture`. Do not rename or remove existing type strings; cardinality stays within this closed set. Status ConfigMap `collectionStats` stays aggregate-only (`totalSuccessCount`, `totalFailureCount`, `collectionsStoredCount`, `lastSuccessTime`) for this initiative; no required per-type status fields. Packaging and chart docs must not invent additional type label strings.
 
-- **Alert thresholds under query load:** Exact alert thresholds on `kube9_operator_events_dropped_total` / queue depth when clients issue more frequent history queries remain refine-issue backlog, not a packaging or deployment-band change.
-- **Prometheus-absent tick → `status` label:** How absent/unreachable Prometheus maps to `kube9_operator_collection_total` `status` (`success` / `failed` / skip-without-increment) so existing dashboards that filter known types keep working; coordinate with runtime degrade classification (performance-metrics collector scope).
-- **Histogram buckets for ~15m performance ticks:** Confirm shared collection duration buckets remain adequate; any bucket tweak is refine-issue backlog, not a product packaging change.
-- **Collection-series alert thresholds:** Exact alert thresholds on the new type labels stay `/refine-issue` backlog like other collection metrics.
+### Resolved (Prometheus-absent tick → `status` label)
+
+When the performance-metrics collector is registered and Prometheus is unreachable, auth-failed, timed out, or returns unusable/empty results: increment `kube9_operator_collection_total` with `type="performance-metrics"` and `status="failed"` (and aggregate `totalFailureCount`). Do not use skip-without-increment for that path. Unset Prometheus URL means the collector is not registered (no series increments for that type until configured).

--- a/.ai/operations/security.md
+++ b/.ai/operations/security.md
@@ -166,8 +166,12 @@ securityContext:
 
 ## Open implementation decisions
 
-- **Prometheus credential mount:** Whether v1 ships URL/timeout/TLS only (no Secret mount) or includes an optional existingSecret path in the same release; coordinate with packaging and integration / `#169` / `#171`.
+_(none for packaging / Prometheus credential mount or security-posture RBAC)_
+
+### Resolved (Prometheus credential mount)
+
+v1 ships **URL + timeout + TLS only** via Helm `prometheus.baseUrl` / `prometheus.timeoutMs` / `prometheus.tlsInsecure` → `PROMETHEUS_BASE_URL` / `PROMETHEUS_TIMEOUT_MS` / `PROMETHEUS_TLS_INSECURE`. No Secret mount, no `existingSecret`, no bearer env for Prometheus in this release. Do not send the operator ServiceAccount token as an implicit Prometheus credential. A future existingSecret path would follow the Argo CD API token class and is out of scope for v1.
 
 ### Resolved (security-posture RBAC delta)
 
-For the locked v1 signal set (privilegedHost + networkPolicyCoverage + six `nsaCisRollups` keys), **no ClusterRole expansion** is required beyond the live chart grants listed above. Keep read-only. Do not add Secrets, pods/exec, or deferred RBAC-risk analysis. NetworkPolicy comment dual-purpose update is packaging (`#171`).
+For the locked v1 signal set (privilegedHost + networkPolicyCoverage + six `nsaCisRollups` keys), **no ClusterRole expansion** is required beyond the live chart grants listed above. Keep read-only. Do not add Secrets, pods/exec, or deferred RBAC-risk analysis. Packaging updates the NetworkPolicy resource comment in `charts/kube9-operator/templates/clusterrole.yaml` to name both AI conformance and security-posture coverage (no rule change).

--- a/.ai/runtime/configuration.md
+++ b/.ai/runtime/configuration.md
@@ -227,12 +227,22 @@ metrics:
     clusterMetadata: 86400                    # 24 hours (default), minimum 3600 (1h)
     resourceInventory: 21600                  # 6 hours (default), minimum 1800 (30m)
     resourceConfigurationPatterns: 43200     # 12 hours (default), minimum 3600 (1h)
-    performanceMetrics: 900                   # 15 minutes (target default); min/offset under Open implementation decisions
-    securityPosture: 86400                    # 24 hours; min 3600; offset 0–3600 (runtime)
+    performanceMetrics: 900                   # 15 minutes (default), minimum 300; offset 0–300 (runtime)
+    securityPosture: 86400                    # 24 hours (default), minimum 3600; offset 0–3600 (runtime)
 ```
-- Maps to `*_INTERVAL_SECONDS` environment variables
-- Operator enforces minimum intervals to prevent abuse
-- Performance metrics also need optional Prometheus client values (URL / timeout / TLS); exact keys under Open implementation decisions. Chart RBAC and ServiceMonitor ownership stay in operations; runtime only loads the env contract and must not treat Prometheus as required for ready.
+- Maps to `CLUSTER_METADATA_INTERVAL_SECONDS`, `RESOURCE_INVENTORY_INTERVAL_SECONDS`, `RESOURCE_CONFIGURATION_PATTERNS_INTERVAL_SECONDS`, `PERFORMANCE_METRICS_INTERVAL_SECONDS`, `SECURITY_POSTURE_INTERVAL_SECONDS`
+- Operator enforces minimum intervals to prevent abuse; non-numeric / below-minimum values fail config load
+- Random offsets are runtime-only (not Helm values)
+
+### Optional Prometheus client (performance collector)
+```yaml
+prometheus:
+  baseUrl: ""              # empty = default-off (no PROMETHEUS_BASE_URL / no performance registration)
+  timeoutMs: 30000         # → PROMETHEUS_TIMEOUT_MS (minimum 1000)
+  tlsInsecure: false       # → PROMETHEUS_TLS_INSECURE
+```
+- Runtime loads `PROMETHEUS_BASE_URL`, `PROMETHEUS_TIMEOUT_MS`, `PROMETHEUS_TLS_INSECURE`. Register performance ticks only when base URL is non-empty. Malformed URL or invalid timeout when set → fail config load. Unset URL is a soft miss, not config failure.
+- Chart RBAC and ServiceMonitor ownership stay in operations; runtime must not treat Prometheus as required for ready.
 
 ### Kubernetes AI Conformance Configuration
 ```yaml
@@ -280,12 +290,22 @@ events:
 
 ## Open implementation decisions
 
-- **Performance interval / Prometheus / registration:** Owned by the performance-metrics collector capability / peer refine (`#169`). Candidates remain: `PERFORMANCE_METRICS_INTERVAL_SECONDS` ↔ `metrics.intervals.performanceMetrics`; config-gated registration on non-empty Prometheus URL; `PROMETHEUS_*` client env. Do not invent a new readiness or secrets-before-traffic trust boundary.
-- **Ops vs runtime home:** Env semantics and load/validation live here. Helm value schema, chart NetworkPolicy comment, and any ServiceMonitor for operator `/metrics` exposition stay in operations with a one-line pointer back to this doc for interval/Prometheus client env names.
+_(none for interval / Prometheus env packaging coordination)_
+
+### Resolved (performance interval / Prometheus / registration)
+
+- Env / Helm names: `PERFORMANCE_METRICS_INTERVAL_SECONDS` ↔ `metrics.intervals.performanceMetrics` (default `900`, min `300`, offset `0–300`).
+- Prometheus client env: `PROMETHEUS_BASE_URL`, `PROMETHEUS_TIMEOUT_MS` (default `30000`, min `1000`), `PROMETHEUS_TLS_INSECURE` (default `false`). Helm tree: top-level `prometheus.baseUrl` / `timeoutMs` / `tlsInsecure` (operations packaging).
+- Registration: config-gated on non-empty Prometheus base URL; no separate enable flag; no required bearer/existingSecret in v1.
+- Do not invent a new readiness or secrets-before-traffic trust boundary. Collector PromQL / unavailable-tick behavior remains the performance-metrics collector capability.
+
+### Resolved (ops vs runtime home)
+
+Env semantics and load/validation live here. Helm value schema, chart NetworkPolicy comment, harness assertions, and any ServiceMonitor for operator `/metrics` exposition stay in operations (`build_packaging.md` / `security.md`) with interval/Prometheus client env names matching this doc.
 
 ### Resolved (security posture interval and registration)
 
-- Env / Helm names: `SECURITY_POSTURE_INTERVAL_SECONDS` ↔ `metrics.intervals.securityPosture` (chart wiring is packaging peer `#171`).
+- Env / Helm names: `SECURITY_POSTURE_INTERVAL_SECONDS` ↔ `metrics.intervals.securityPosture`.
 - Numerics: default `86400`, minimum `3600`, random offset `0–3600`. Non-numeric / below-minimum values fail config load.
 - Registration: always-on; **no** enable flag in v1.
 - Failed/partial gather: omit row + failed metrics; health/`/readyz` unchanged (see error_handling).

--- a/.ai/specs/data-collection-pipeline.spec.md
+++ b/.ai/specs/data-collection-pipeline.spec.md
@@ -20,21 +20,31 @@ Related capabilities: `performance-metrics-collector` and `security-posture-coll
 - **Runtime:** Node.js `>=22` (package engines); TypeScript operator process; better-sqlite3 for durable store at `{DB_PATH}/kube9.db`.
 - **Components:** CollectionScheduler; per-type collectors; CollectionRepository / SQLite `collections` table; Zod `CollectionPayload` validation; status publisher; CLI query path via `kubectl exec`.
 - **Type tokens (closed set for this pipeline):** `cluster-metadata`, `resource-inventory`, `resource-configuration-patterns`, `performance-metrics`, `security-posture`.
+- **Observability labels:** Collection Prometheus series `type` label values use exactly those five strings; do not invent aliases. Status ConfigMap `collectionStats` stays aggregate-only (`totalSuccessCount`, `totalFailureCount`, `collectionsStoredCount`, `lastSuccessTime`).
 - **Validation:** `CollectionPayloadSchema` is a Zod discriminated union on `type`. `CollectionRepository.insertCollection` rejects type/data mismatch and malformed envelopes (no row written). SQLite `type` stays unconstrained TEXT.
 - **Payload catalogs:** Normative `data` shapes for `performance-metrics` and `security-posture` live in `.ai/data/data_model.md` and `.ai/data/serialization.md` (source marker, utilization/ratios bounds, privilegedHost / networkPolicyCoverage / nsaCisRollups, 64 KiB and key-count caps).
 - **Durable write:** Sole durable write is `CollectionRepository.insertCollection`. Status `collectionsStoredCount` equals SQLite row count. In-memory LocalStorage is not queryable truth and is off the durable write path.
-- **Status:** ConfigMap `collectionStats` remains aggregate-only (`totalSuccessCount`, `totalFailureCount`, `collectionsStoredCount`, `lastSuccessTime`); new types participate in those counters.
-- **Config:** Helm `metrics.intervals.*` and matching env interval seconds; optional Prometheus client config for performance only (exact keys / registration gate owned by collector + packaging peers).
-- **Trust / deploy:** Zero-ingress default; cluster-internal egress only for optional Prometheus; read-only ClusterRole for Kubernetes API collectors.
-- **Peer collector items:** Performance Prometheus unavailable / PromQL / auth knobs live in `performance-metrics-collector` (`#169`). Security-posture partial-API tick classification is locked in `security-posture-collector` (omit row + failed; closed six-key `nsaCisRollups`).
+- **Status:** ConfigMap `collectionStats` remains aggregate-only; new types participate in those counters.
+- **Config / packaging:**
+  - Helm `metrics.intervals.performanceMetrics` (default `900`, min `300`) → `PERFORMANCE_METRICS_INTERVAL_SECONDS`
+  - Helm `metrics.intervals.securityPosture` (default `86400`, min `3600`) → `SECURITY_POSTURE_INTERVAL_SECONDS`
+  - Helm top-level `prometheus.baseUrl` / `timeoutMs` / `tlsInsecure` → `PROMETHEUS_BASE_URL` / `PROMETHEUS_TIMEOUT_MS` / `PROMETHEUS_TLS_INSECURE` (emit base URL env only when non-empty; v1 has no Secret mount)
+  - Performance registration is config-gated on non-empty Prometheus URL; security posture is always-on
+- **Trust / deploy:** Zero-ingress default; cluster-internal egress only for optional Prometheus; read-only ClusterRole with **no** posture-driven expansion; NetworkPolicy grant comment names AI conformance + security-posture coverage. Collections have no TTL / count cap (PVC growth is operational).
+- **Peer collector items:** Performance PromQL / unavailable omit+failed live in `performance-metrics-collector`. Security-posture partial-API tick classification lives in `security-posture-collector` (omit row + failed; closed six-key `nsaCisRollups`).
 
 ## Testing Strategy
 
 - Unit: payload schema accept/reject per type (including mismatch of `type` vs `data`); reject oversized or forbidden security-posture CVE/RBAC bodies; empty query success envelope.
 - Unit / integration: durable insert via `CollectionRepository.insertCollection`; `collectionsStoredCount` tracks SQLite count after inserts (not LocalStorage size); LocalStorage store alone does not change durable count or CLI visibility.
 - Integration: SQLite insert + `query collections --type performance-metrics|security-posture` round-trip with fixture payloads; status aggregates keep the four required fields when new types succeed/fail.
-- Contract / chart: collection Prometheus metric `type` labels stay within the closed five-type set (label wiring may land with packaging peer); Helm interval keys for the two new types remain packaging peer scope.
-- Manual / smoke (kind/minikube): deferred to collector shipping issues; pipeline contract issue proves schema + durable write with unit/integration fixtures without requiring live Prometheus.
+- Contract / chart (packaging):
+  - Collection metric `type` labels stay within the closed five-type set
+  - `helm template` / `./scripts/test-helm-chart.sh` Phase 2: default Deployment includes both new interval env vars; no `PROMETHEUS_BASE_URL` when `prometheus.baseUrl` empty; URL/timeout/TLS when baseUrl set
+  - `values.schema.json` accepts the new interval and `prometheus.*` keys
+  - Phase 5 (kind): default install pod Ready without Prometheus
+  - ClusterRole: no new rules; NetworkPolicy comment dual-purpose
+- Manual / smoke: collector shipping issues prove gather paths; packaging proves chart wiring and Ready-without-Prometheus.
 
 ## References
 

--- a/.ai/specs/performance-metrics-collector.spec.md
+++ b/.ai/specs/performance-metrics-collector.spec.md
@@ -8,26 +8,28 @@ Depends on `data-collection-pipeline`. Does not replace operator `/metrics` expo
 
 ## Functional Specification
 
-- Default schedule target ~15 minutes with enforced minimum and random offset (exact seconds in runtime open-impl).
-- Data source v1: in-cluster Prometheus only (optional outbound HTTP query and/or scrape). No metrics-server / Kubernetes metrics API fallback.
-- Opt-in / degrade: no performance pull until Prometheus endpoint is configured (recommended: config-gated registration). When Prometheus is absent or unreachable, other collectors and readiness continue; operator health does not become unhealthy solely for that reason.
-- Persisted payload class: bounded utilization / ratio style aggregates inside `CollectionPayload`, not a raw time-series warehouse.
+- Default schedule: `PERFORMANCE_METRICS_INTERVAL_SECONDS` default `900` (15 minutes), enforced minimum `300` (5 minutes), random offset `0–300`. Invalid or below-minimum values fail config load.
+- Data source v1: in-cluster Prometheus PromQL HTTP instant queries only (`/api/v1/query` class). No metrics-server / Kubernetes metrics API fallback. Direct target scrape is out of scope for v1.
+- Opt-in / degrade: register performance ticks only when `PROMETHEUS_BASE_URL` is non-empty (no separate enable flag). When Prometheus is absent or unreachable, omit a row, count failed, retry next interval; other collectors and readiness continue; operator health does not become unhealthy solely for that reason. Do not persist `source.available: false` marker rows.
+- Persisted payload class: bounded utilization / ratio style aggregates inside `CollectionPayload`, not a raw time-series warehouse. Success rows set `source.available: true`.
 - Queryable via `query collections` with `--type performance-metrics`; empty list before first success is normal.
-- **Non-goals:** installing Prometheus/Prometheus Operator; phone-home; peer UX this milestone; storing unsanitized high-cardinality series dumps.
+- **Non-goals:** installing Prometheus/Prometheus Operator; phone-home; peer UX this milestone; storing unsanitized high-cardinality series dumps; required bearer/existingSecret; required `status.prometheus` block.
 
 ## Technical Specification
 
 - **Runtime:** Node.js `>=22`; same CollectionScheduler and SQLite path as peer collectors.
-- **Integration:** Trivy-style optional outbound client; cluster-internal egress; prefer not using the operator ServiceAccount token as an implicit Prometheus credential.
-- **Recommended registration:** register performance ticks only when a Prometheus base URL (or equivalent enable+URL) is set; unset is soft miss, not config failure.
-- **Payload accept shape:** Normative `performance-metrics` `data` catalog (including required `source.available`) is defined in `.ai/data/data_model.md` / serialization; this collector fills those fields on ticks.
-- Exact PromQL vs scrape shape, auth/TLS knobs, timeouts, and whether unavailable ticks omit rows vs store `source.available: false` remain open implementation decisions (integration / runtime / error_handling).
+- **Interval / config:** `PERFORMANCE_METRICS_INTERVAL_SECONDS` (default `900`, min `300`, offset `0–300`). Helm `metrics.intervals.performanceMetrics` wiring is packaging peer.
+- **Prometheus client env:** `PROMETHEUS_BASE_URL`, `PROMETHEUS_TIMEOUT_MS` (default `30000`, min `1000`), `PROMETHEUS_TLS_INSECURE` (default `false`). Helm top-level `prometheus.baseUrl` / `timeoutMs` / `tlsInsecure` (packaging). Malformed URL or invalid timeout when set → fail config load. Unset URL is soft miss.
+- **Auth:** v1 URL + timeout + TLS only. Never send the operator ServiceAccount token as an implicit Prometheus credential. No Secret mount in v1.
+- **Registration:** Config-gated on non-empty base URL. Bootstrap must not probe Prometheus before ready; init/register failures log-and-continue.
+- **Payload accept shape:** Normative `performance-metrics` `data` catalog (including required `source.available`) is defined in `.ai/data/data_model.md` / serialization; this collector fills those fields on successful ticks.
+- **Unavailable path:** omit row + `status=failed` on `kube9_operator_collection_total` / `totalFailureCount`; health and `/readyz` unchanged.
 
 ## Testing Strategy
 
-- Unit: payload validation for `performance-metrics` against the shared catalog; config reject for invalid Prometheus URL when set.
-- Integration: with Prometheus unset → collector not registered or no failing ticks; `/readyz` stays ready; with mock Prometheus → successful append + query by type.
-- Chart / ops: optional Prometheus values documented; zero-ingress unchanged; metric `type=performance-metrics` appears only on collection series when ticks run.
+- Unit: payload validation for `performance-metrics` against the shared catalog; config reject for invalid Prometheus URL / timeout when set; config-gated registration.
+- Integration: with Prometheus unset → collector not registered; `/readyz` stays ready; with mock Prometheus → successful append + query by type; unreachable/empty mock → no row + failed metrics.
+- Chart / ops (packaging peer): `prometheus.*` and interval keys documented; zero-ingress unchanged; default install Ready without Prometheus; metric `type=performance-metrics` on collection series when ticks run.
 - Manual: kind/minikube without Prometheus proves graceful degrade; with in-cluster Prometheus proves snapshot queryability.
 
 ## References


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #171
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

Locks Helm↔env for performance/security intervals, top-level `prometheus.*` (URL/timeout/TLS only), no ClusterRole delta, five-type observability labels, and chart harness/README packaging acceptance.

Merge before `/build-from-github` when implementation should read merged contracts on `main`.