### PR TITLE
docs(ai): refine issue #172 contract updates

### DIFF
--- a/.ai/business_logic/user_stories.md
+++ b/.ai/business_logic/user_stories.md
@@ -212,7 +212,6 @@ Assessment check history is queryable via CLI (`kube9-operator query assessments
 
 Operator business-logic and integration contracts state the user-visible outcome: info/warning **7** days, error/critical **30** days by default, with cleanup every **6 hours** and Helm/env overrides of the effective store window. kube9-desktop interface contracts own evidence-footer and Pro retention microcopy; those surfaces must cite the severity-split pair (or both bands), not a single longer “N days” promise. No 90-day (or other unified) agent/history retention claim belongs in operator consumer prose.
 
-### Performance metrics and security posture (collections)
+### Resolved (performance metrics and security posture collections CLI)
 
-- **CLI `--type` presentation:** Exact enum strings, help text, and table column widths for the two new types are locked with interface contracts; behavior stays on the existing collections list/get archetype (filters, formats, pagination, stderr errors).
-- **Empty-list and degrade copy:** User-facing wording for empty successful lists vs Prometheus-degrade tick outcomes stays coordinated with interface and error_handling; business logic only fixes the outcome classes above.
+CLI `--type` tokens are `performance-metrics` and `security-posture` (with the three shipped types). Help lists all five kebab-case values. Behavior stays on the existing collections list/get archetype (filters, formats, pagination, stderr errors). Empty successful list is a normal evidence gap. Prometheus-absent ticks are producer omit+failed (no special CLI degrade mode); interface owns the shared `No results found` empty-list string and TYPE column widths.

--- a/.ai/data/data_model.md
+++ b/.ai/data/data_model.md
@@ -419,6 +419,6 @@ Normative `data` catalogs for `performance-metrics` and `security-posture` are u
 
 Security-posture ticks that cannot produce a complete schema-valid snapshot (including mid-tick cluster-API list failures) **omit** a `collections` row and count as **failed**. Partial snapshots are not persisted.
 
-### Degrade-row persistence (Prometheus unavailable) — peer collector scope
+### Resolved (Prometheus unavailable degrade-row)
 
-Whether a Prometheus-absent/unreachable tick **omits** a `collections` row, stores a **success** payload with `source.available: false`, or counts as a **collection failure** with no durable row is owned by the performance-metrics collector capability (coordinate with runtime / error_handling). Schema accepts `source.available` either way. Security posture is not gated on Prometheus.
+Unavailable / unreachable / empty Prometheus ticks for registered performance-metrics collectors **omit** a `collections` row and count as **failed** (no durable `source.available: false` marker rows). Locked in `performance-metrics-collector` / external_systems / observability. Schema still requires `source.available` on success rows (`true`). Security posture is not gated on Prometheus. Collections CLI has no Prometheus-specific presentation mode.

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -157,7 +157,9 @@ kube9-operator query collections get <collectionId> [--format=json|yaml|table|co
 
 **Failure / degrade (consumer-facing)**:
 - CLI validation and not-found follow existing collections stderr JSON + non-zero exit patterns.
-- Prometheus absence affects whether new `performance-metrics` rows appear over time; it does not invent a separate query error family for list/get of stored rows. Exact collector tick failure codes are open implementation decisions (see [external_systems.md](external_systems.md)).
+- Prometheus absence affects whether new `performance-metrics` rows appear over time; it does not invent a separate query error family for list/get of stored rows. Unavailable performance ticks omit a row and count failed (see [external_systems.md](external_systems.md)); CLI presents empty filters or missing rows only.
+
+**CLI help / table presentation**: Commander `--type` help lists all five kebab-case tokens. List table/compact columns stay `COLLECTION_ID`, `CLUSTER_ID`, `TYPE`, `COLLECTED_AT` with TYPE truncation 24 compact / 36 table. Empty table/compact copy is `No results found`. Get uses generic payload formatting. No retention metadata fields on list/get JSON.
 
 **Retention (consumer narrative)**: No time-based TTL and no count-based cap for `collections` rows in this initiative (assessments-class: rows persist until explicit remove / operational cleanup). Consumers rely only on rows still stored. Authoritative persistence wording lives in `.ai/data/consistency.md`.
 
@@ -167,13 +169,13 @@ kube9-operator query collections get <collectionId> [--format=json|yaml|table|co
 
 Payload field catalogs for `performance-metrics` and `security-posture` are normative in data contracts. Wire types stay additive; `collectionStats` remains the aggregate four-field object; peers that ignore unknown `type` values need no same-milestone peer-repo `.ai` edits.
 
-### CLI help / table polish — peer CLI issue scope
+### Resolved (CLI help / table polish)
 
-Exact Commander help text listing and table/compact column widths for new summary fields coordinate with interface once tokens ship (tracked with the query-collections CLI completion issue).
+Collections CLI help lists all five `--type` tokens. Table/compact column set and TYPE truncation (24/36), shared empty-list copy, and generic get formatting are locked in interface contracts. No retention metadata on collections JSON.
 
 ### Optional status prometheus block — not required for pipeline types
 
-Whether status ConfigMap gains an optional bounded `prometheus` (or equivalent) detection block analogous to `trivy` / `argocd` remains optional packaging/integration backlog; not required for five-type CollectionPayload acceptance.
+Whether status ConfigMap gains an optional bounded `prometheus` (or equivalent) detection block analogous to `trivy` / `argocd` remains optional packaging/integration backlog; not required for five-type CollectionPayload acceptance or collections CLI.
 
 ### Assessment API Contract
 

--- a/.ai/interface/input_handling.md
+++ b/.ai/interface/input_handling.md
@@ -99,6 +99,12 @@ Persisted M8 collection snapshots (SQLite). Extends the existing `query collecti
 - Filtering to a type with no stored rows is a valid list input; empty success is presentation, not an error (see [presentation.md](presentation.md)).
 - Invalid `--type` values fail option validation (Zod/Commander) with the existing JSON-on-stderr error pattern.
 
+**Collections help / Commander copy:**
+- `query collections list` description names persisted collection snapshots and does not invent parallel subcommands per type.
+- `query collections get` description names retrieval by `collectionId`.
+- The `--type` option description lists all five tokens in kebab-case, comma-separated: `cluster-metadata`, `resource-inventory`, `resource-configuration-patterns`, `performance-metrics`, `security-posture`.
+- Help must not claim Prometheus presence, retention windows, or vscode/desktop consumer UX.
+
 ## Output Formats
 - `json` (default): Pretty-printed JSON with 2-space indentation
 - `yaml`: YAML format with 2-space indentation
@@ -122,6 +128,6 @@ kubectl exec -n <namespace> deploy/kube9-operator -- kube9-operator <command> [o
 
 CLI `--type`, payload discriminants, and observability labels use `cluster-metadata` | `resource-inventory` | `resource-configuration-patterns` | `performance-metrics` | `security-posture`. Invalid values fail option validation with the existing JSON-on-stderr pattern.
 
-### Help / description copy — peer CLI issue scope
+### Resolved (collections help / Commander copy)
 
-Exact Commander descriptions for `query collections` and the `--type` option once help text lists all five types (today help may still list only the three shipped types until the CLI completion issue lands).
+`query collections list|get` and `--type` help list all five kebab-case tokens (comma-separated in the `--type` description). No new flags or subcommands. Help does not mention Prometheus presence, retention windows, or peer UX.

--- a/.ai/interface/presentation.md
+++ b/.ai/interface/presentation.md
@@ -80,15 +80,23 @@ Operator CLI only this milestone (no vscode/desktop consumer UX contracts). Surf
 
 ### Degrade and errors
 
-- Prometheus absence / performance degrade is not a distinct CLI presentation mode. Operators see missing or failed persisted rows (or empty type filters), not a special “Prometheus unavailable” list/get cue, unless a later data contract stores an explicit payload marker that json/yaml already surface.
+- Prometheus absence / performance degrade is not a distinct CLI presentation mode. Unavailable performance ticks omit durable rows (collector contract); operators see empty type filters or missing rows, not a special “Prometheus unavailable” list/get cue.
 - Not-found get and validation/runtime failures keep the existing JSON-on-stderr pattern and non-zero exit; they are distinct from empty successful list.
 
 ### Status ConfigMap
 
 - New collection types participate in aggregate `collectionStats` counters only. No new status fields or per-type presentation schema for this milestone. Peer extensions continue progressive enhancement on the existing status shape.
 
+### Table / compact TYPE column
+
+- TYPE truncation stays **24** characters (compact) and **36** (table). New tokens (`performance-metrics`, `security-posture`) fit both widths. Longest shipped token `resource-configuration-patterns` (32) truncates in compact only; do not widen TYPE solely for the two new types.
+
+### Empty-list copy
+
+- Table/compact empty success uses the shared empty-results line `No results found` (same family as events/assessments). Do not invent a type-specific “no collections of this type yet” string.
+
 ## Open implementation decisions
 
-- **TYPE column truncation:** Confirm whether current table/compact TYPE truncation (24 compact / 36 table) remains sufficient for the final type tokens, or widen only the TYPE column.
-- **Get formatting:** Keep generic `formatOutput` for new payload bodies in v1 (no type-specific table columns). Any human-oriented summary view is deferred.
-- **Empty-list copy:** Keep existing empty-results language consistent with events/assessments; do not invent a type-specific “no collections of this type yet” string unless product copy requires it at implement time.
+### Resolved (TYPE truncation, get formatting, empty-list copy)
+
+Keep TYPE truncation at 24 compact / 36 table. Keep generic `formatOutput` for get of new payload bodies in v1 (no type-specific table columns; human-oriented summary views deferred). Keep shared `No results found` empty-list copy; no type-specific empty string.

--- a/.ai/specs/data-collection-pipeline.spec.md
+++ b/.ai/specs/data-collection-pipeline.spec.md
@@ -25,6 +25,7 @@ Related capabilities: `performance-metrics-collector` and `security-posture-coll
 - **Payload catalogs:** Normative `data` shapes for `performance-metrics` and `security-posture` live in `.ai/data/data_model.md` and `.ai/data/serialization.md` (source marker, utilization/ratios bounds, privilegedHost / networkPolicyCoverage / nsaCisRollups, 64 KiB and key-count caps).
 - **Durable write:** Sole durable write is `CollectionRepository.insertCollection`. Status `collectionsStoredCount` equals SQLite row count. In-memory LocalStorage is not queryable truth and is off the durable write path.
 - **Status:** ConfigMap `collectionStats` remains aggregate-only; new types participate in those counters.
+- **CLI query surface:** `kube9-operator query collections list|get` via kubectl-exec. Additive `--type` enum accepts all five closed tokens. Commander `--type` help lists the five kebab-case values. Formats `json|yaml|table|compact`; list columns `COLLECTION_ID`, `CLUSTER_ID`, `TYPE`, `COLLECTED_AT` with TYPE truncation 24 compact / 36 table; empty table/compact is `No results found`; get uses generic `formatOutput`. No retention metadata on list/get JSON. Invalid `--type` → JSON-on-stderr + non-zero exit. No parallel query API or Prometheus-specific CLI mode.
 - **Config / packaging:**
   - Helm `metrics.intervals.performanceMetrics` (default `900`, min `300`) → `PERFORMANCE_METRICS_INTERVAL_SECONDS`
   - Helm `metrics.intervals.securityPosture` (default `86400`, min `3600`) → `SECURITY_POSTURE_INTERVAL_SECONDS`
@@ -36,15 +37,17 @@ Related capabilities: `performance-metrics-collector` and `security-posture-coll
 ## Testing Strategy
 
 - Unit: payload schema accept/reject per type (including mismatch of `type` vs `data`); reject oversized or forbidden security-posture CVE/RBAC bodies; empty query success envelope.
+- Unit / CLI: `--type` Zod/Commander enum accepts `performance-metrics` and `security-posture` alongside the three shipped types; rejects unknown type strings with JSON-on-stderr + non-zero exit; help/`--help` text lists all five tokens.
+- Unit / presentation: list table/compact for rows of either new type still emit headers `COLLECTION_ID`, `CLUSTER_ID`, `TYPE`, `COLLECTED_AT`; empty list prints `No results found`; TYPE cells use 24/36 truncation; get formatting stays generic `formatOutput` (no type-specific get tables).
 - Unit / integration: durable insert via `CollectionRepository.insertCollection`; `collectionsStoredCount` tracks SQLite count after inserts (not LocalStorage size); LocalStorage store alone does not change durable count or CLI visibility.
-- Integration: SQLite insert + `query collections --type performance-metrics|security-posture` round-trip with fixture payloads; status aggregates keep the four required fields when new types succeed/fail.
+- Integration: SQLite insert of fixture `performance-metrics` and `security-posture` payloads + `query collections list --type …` / `get <id>` round-trip for json and at least one of table|compact; empty `--type` filter for a type with zero rows returns success with empty `collections` and zero pagination totals (not an error); status aggregates keep the four required fields when new types succeed/fail; list/get JSON has no retention-window metadata fields.
 - Contract / chart (packaging):
   - Collection metric `type` labels stay within the closed five-type set
   - `helm template` / `./scripts/test-helm-chart.sh` Phase 2: default Deployment includes both new interval env vars; no `PROMETHEUS_BASE_URL` when `prometheus.baseUrl` empty; URL/timeout/TLS when baseUrl set
   - `values.schema.json` accepts the new interval and `prometheus.*` keys
   - Phase 5 (kind): default install pod Ready without Prometheus
   - ClusterRole: no new rules; NetworkPolicy comment dual-purpose
-- Manual / smoke: collector shipping issues prove gather paths; packaging proves chart wiring and Ready-without-Prometheus.
+- Manual / smoke: collector shipping issues prove gather paths; packaging proves chart wiring and Ready-without-Prometheus; after collectors persist rows, exec `query collections list --type performance-metrics|security-posture` against a live pod confirms CLI visibility.
 
 ## References
 


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #172
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

Locks collections CLI help listing all five `--type` tokens, TYPE truncation 24/36, shared `No results found` empty-list copy, generic get formatting, and deepened `data-collection-pipeline` CLI testing strategy. No retention metadata on collections JSON; no Prometheus-specific CLI mode.

Merge before `/build-from-github` when implementation should read merged contracts on `main`.