### PR TITLE
feat(collection): extend pipeline contracts for five collection types (#168)

### DIFF
--- a/src/cli/commands/collections.ts
+++ b/src/cli/commands/collections.ts
@@ -28,6 +28,8 @@ const collectionTypeEnum = z.enum([
   'cluster-metadata',
   'resource-inventory',
   'resource-configuration-patterns',
+  'performance-metrics',
+  'security-posture',
 ]);
 
 const ListOptionsSchema = z.object({

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -198,7 +198,7 @@ export function createQueryCommands(): Command {
     .description('List stored collections')
     .option(
       '--type <type>',
-      'Filter by type: cluster-metadata, resource-inventory, resource-configuration-patterns'
+      'Filter by type: cluster-metadata, resource-inventory, resource-configuration-patterns, performance-metrics, security-posture'
     )
     .option('--cluster-id <id>', 'Filter by cluster id')
     .option('--since <date>', 'Collected on/after (ISO 8601)')

--- a/src/collection/collectors/cluster-metadata.test.ts
+++ b/src/collection/collectors/cluster-metadata.test.ts
@@ -8,7 +8,7 @@ vi.mock('../../cluster/identifier.js', () => ({
 import { ClusterMetadataCollector } from './cluster-metadata.js';
 import type { KubernetesClient } from '../../kubernetes/client.js';
 import type { ClusterMetadata } from '../types.js';
-import type { LocalStorage } from '../storage.js';
+import type { CollectionRepository } from '../../database/collection-repository.js';
 
 function mockKubernetesClient(
   versionResponse: { gitVersion?: string },
@@ -24,11 +24,17 @@ function mockKubernetesClient(
   } as unknown as KubernetesClient;
 }
 
+function mockCollectionRepository(
+  insertCollection: ReturnType<typeof vi.fn> = vi.fn().mockReturnValue(true)
+): CollectionRepository {
+  return { insertCollection } as unknown as CollectionRepository;
+}
+
 describe('ClusterMetadataCollector', () => {
   it('collect() rejects when the node list is empty', async () => {
     const collector = new ClusterMetadataCollector(
       mockKubernetesClient({ gitVersion: 'v1.28.0' }, []),
-      {} as LocalStorage
+      mockCollectionRepository()
     );
 
     await expect(collector.collect()).rejects.toThrow(/node list is empty/i);
@@ -46,7 +52,7 @@ describe('ClusterMetadataCollector', () => {
 
     const collector = new ClusterMetadataCollector(
       mockKubernetesClient({ gitVersion: 'v1.28.2' }, [node]),
-      {} as LocalStorage
+      mockCollectionRepository()
     );
 
     const meta = await collector.collect();
@@ -59,12 +65,10 @@ describe('ClusterMetadataCollector', () => {
   });
 
   it('processCollection() propagates validation errors (metrics alignment)', async () => {
-    const store = vi.fn().mockResolvedValue(undefined);
-    const localStorage = { store } as unknown as LocalStorage;
-
+    const insertCollection = vi.fn().mockReturnValue(true);
     const collector = new ClusterMetadataCollector(
       mockKubernetesClient({ gitVersion: 'v1.28.0' }, [{ metadata: {} }]),
-      localStorage
+      mockCollectionRepository(insertCollection)
     );
 
     const invalid: ClusterMetadata = {
@@ -76,23 +80,32 @@ describe('ClusterMetadataCollector', () => {
     };
 
     await expect(collector.processCollection(invalid)).rejects.toThrow(/nodeCount/i);
-    expect(store).not.toHaveBeenCalled();
+    expect(insertCollection).not.toHaveBeenCalled();
   });
 
-  it('processCollection() stores a validated payload on success', async () => {
-    const store = vi.fn().mockResolvedValue(undefined);
-    const localStorage = { store } as unknown as LocalStorage;
-
+  it('processCollection() persists a validated payload on success', async () => {
+    const insertCollection = vi.fn().mockReturnValue(true);
     const collector = new ClusterMetadataCollector(
       mockKubernetesClient({ gitVersion: 'v1.29.0' }, [{ metadata: {} }]),
-      localStorage
+      mockCollectionRepository(insertCollection)
     );
 
     const meta = await collector.collect();
     await collector.processCollection(meta);
 
-    expect(store).toHaveBeenCalledTimes(1);
-    const payload = store.mock.calls[0][0] as { type: string };
+    expect(insertCollection).toHaveBeenCalledTimes(1);
+    const payload = insertCollection.mock.calls[0][0] as { type: string };
     expect(payload.type).toBe('cluster-metadata');
+  });
+
+  it('processCollection() throws when durable insert fails', async () => {
+    const insertCollection = vi.fn().mockReturnValue(false);
+    const collector = new ClusterMetadataCollector(
+      mockKubernetesClient({ gitVersion: 'v1.29.0' }, [{ metadata: {} }]),
+      mockCollectionRepository(insertCollection)
+    );
+
+    const meta = await collector.collect();
+    await expect(collector.processCollection(meta)).rejects.toThrow(/Failed to persist cluster metadata/i);
   });
 });

--- a/src/collection/collectors/cluster-metadata.ts
+++ b/src/collection/collectors/cluster-metadata.ts
@@ -105,8 +105,8 @@ export class ClusterMetadataCollector {
   }
 
   /**
-   * Processes collected metadata: validates, wraps in payload, and stores locally
-   * 
+   * Processes collected metadata: validates, wraps in payload, and persists durably
+   *
    * @param metadata - Collected cluster metadata
    * @returns Promise that resolves when processing is complete
    */

--- a/src/collection/collectors/cluster-metadata.ts
+++ b/src/collection/collectors/cluster-metadata.ts
@@ -9,28 +9,29 @@ import { randomBytes } from 'crypto';
 import * as k8s from '@kubernetes/client-node';
 import type { ClusterMetadata, CollectionPayload } from '../types.js';
 import { validateClusterMetadata } from '../validation.js';
-import { LocalStorage } from '../storage.js';
+import type { CollectionRepository } from '../../database/collection-repository.js';
+import { persistCollection } from '../persist-collection.js';
 import { KubernetesClient } from '../../kubernetes/client.js';
 import { generateClusterIdForCollection } from '../../cluster/identifier.js';
 import { logger } from '../../logging/logger.js';
 
 /**
  * ClusterMetadataCollector collects cluster metadata and processes it
- * through validation and local storage.
+ * through validation and durable SQLite persistence.
  */
 export class ClusterMetadataCollector {
   private readonly kubernetesClient: KubernetesClient;
-  private readonly localStorage: LocalStorage;
+  private readonly collectionRepository: CollectionRepository;
 
   /**
    * Creates a new ClusterMetadataCollector instance
    *
    * @param kubernetesClient - Kubernetes client for API access
-   * @param localStorage - Local storage for collection payloads
+   * @param collectionRepository - Durable collection persistence
    */
-  constructor(kubernetesClient: KubernetesClient, localStorage: LocalStorage) {
+  constructor(kubernetesClient: KubernetesClient, collectionRepository: CollectionRepository) {
     this.kubernetesClient = kubernetesClient;
-    this.localStorage = localStorage;
+    this.collectionRepository = collectionRepository;
   }
 
   /**
@@ -125,10 +126,15 @@ export class ClusterMetadataCollector {
         },
       };
 
-      logger.info('Storing cluster metadata collection locally', {
+      logger.info('Persisting cluster metadata collection', {
         collectionId: validatedMetadata.collectionId,
       });
-      await this.localStorage.store(payload);
+      const inserted = persistCollection(this.collectionRepository, payload);
+      if (!inserted) {
+        throw new Error(
+          `Failed to persist cluster metadata collection: ${validatedMetadata.collectionId}`
+        );
+      }
 
       logger.info('Cluster metadata collection processed successfully', {
         collectionId: validatedMetadata.collectionId,

--- a/src/collection/collectors/resource-configuration-patterns.test.ts
+++ b/src/collection/collectors/resource-configuration-patterns.test.ts
@@ -1204,7 +1204,7 @@ it('ResourceConfigurationPatternsCollector - processCollection() persists data d
     expect(persistedPayload.sanitization.rulesApplied).toEqual(['no-resource-names', 'aggregated-configuration-data']);
 });
 
-it('ResourceConfigurationPatternsCollector - processCollection() handles errors gracefully', async () => {
+it('ResourceConfigurationPatternsCollector - processCollection() throws when durable insert fails', async () => {
   const mockKubernetesClient = {
     coreApi: {
       listPodForAllNamespaces: async () => ({ body: { items: [] } }),
@@ -1228,7 +1228,8 @@ it('ResourceConfigurationPatternsCollector - processCollection() handles errors 
 
   const data = await collector.collect();
 
-  // Should not throw - graceful degradation
-  await expect(collector.processCollection(data)).resolves.not.toThrow();
+  await expect(collector.processCollection(data)).rejects.toThrow(
+    /Failed to persist resource configuration patterns/i
+  );
 });
 

--- a/src/collection/collectors/resource-configuration-patterns.test.ts
+++ b/src/collection/collectors/resource-configuration-patterns.test.ts
@@ -966,11 +966,11 @@ it('ResourceConfigurationPatternsCollector - collect() invokes cluster-wide pod,
     },
   };
 
-  const mockLocalStorage = { store: async () => {} };
+  const mockCollectionRepository = { insertCollection: () => true };
 
   const collector = new ResourceConfigurationPatternsCollector(
     mockKubernetesClient as any,
-    mockLocalStorage as any
+    mockCollectionRepository as any
   );
 
   await collector.collect();
@@ -997,14 +997,11 @@ it('ResourceConfigurationPatternsCollector - collect() generates valid collectio
     },
   };
 
-  // Mock LocalStorage
-  const mockLocalStorage = {
-    store: async () => {},
-  };
+  const mockCollectionRepository = { insertCollection: () => true };
 
   const collector = new ResourceConfigurationPatternsCollector(
     mockKubernetesClient as any,
-    mockLocalStorage as any
+    mockCollectionRepository as any
   );
 
   const data = await collector.collect();
@@ -1028,11 +1025,11 @@ it('ResourceConfigurationPatternsCollector - collect() includes timestamp', asyn
     },
   };
 
-  const mockLocalStorage = { store: async () => {} };
+  const mockCollectionRepository = { insertCollection: () => true };
 
   const collector = new ResourceConfigurationPatternsCollector(
     mockKubernetesClient as any,
-    mockLocalStorage as any
+    mockCollectionRepository as any
   );
 
   const data = await collector.collect();
@@ -1075,11 +1072,11 @@ it('ResourceConfigurationPatternsCollector - collect() processes pods', async ()
     },
   };
 
-  const mockLocalStorage = { store: async () => {} };
+  const mockCollectionRepository = { insertCollection: () => true };
 
   const collector = new ResourceConfigurationPatternsCollector(
     mockKubernetesClient as any,
-    mockLocalStorage as any
+    mockCollectionRepository as any
   );
 
   const data = await collector.collect();
@@ -1116,11 +1113,11 @@ it('ResourceConfigurationPatternsCollector - collect() processes deployments', a
     },
   };
 
-  const mockLocalStorage = { store: async () => {} };
+  const mockCollectionRepository = { insertCollection: () => true };
 
   const collector = new ResourceConfigurationPatternsCollector(
     mockKubernetesClient as any,
-    mockLocalStorage as any
+    mockCollectionRepository as any
   );
 
   const data = await collector.collect();
@@ -1155,11 +1152,11 @@ it('ResourceConfigurationPatternsCollector - collect() processes services', asyn
     },
   };
 
-  const mockLocalStorage = { store: async () => {} };
+  const mockCollectionRepository = { insertCollection: () => true };
 
   const collector = new ResourceConfigurationPatternsCollector(
     mockKubernetesClient as any,
-    mockLocalStorage as any
+    mockCollectionRepository as any
   );
 
   const data = await collector.collect();
@@ -1171,8 +1168,8 @@ it('ResourceConfigurationPatternsCollector - collect() processes services', asyn
     expect(data.services.portsPerService).toEqual([1, 2]);
 });
 
-it('ResourceConfigurationPatternsCollector - processCollection() stores data locally', async () => {
-  let storedPayload: any = null;
+it('ResourceConfigurationPatternsCollector - processCollection() persists data durably', async () => {
+  let persistedPayload: any = null;
 
   const mockKubernetesClient = {
     coreApi: {
@@ -1186,25 +1183,25 @@ it('ResourceConfigurationPatternsCollector - processCollection() stores data loc
     },
   };
 
-  const mockLocalStorage = {
-    store: async (payload: any) => {
-      storedPayload = payload;
+  const mockCollectionRepository = {
+    insertCollection: (payload: any) => {
+      persistedPayload = payload;
+      return true;
     },
   };
 
   const collector = new ResourceConfigurationPatternsCollector(
     mockKubernetesClient as any,
-    mockLocalStorage as any
+    mockCollectionRepository as any
   );
 
   const data = await collector.collect();
   await collector.processCollection(data);
 
-  // Verify data was stored
-  expect(storedPayload, 'Payload should be stored');
-  expect(storedPayload.version).toBe('v1.0.0');
-  expect(storedPayload.type).toBe('resource-configuration-patterns');
-    expect(storedPayload.sanitization.rulesApplied).toEqual(['no-resource-names', 'aggregated-configuration-data']);
+  expect(persistedPayload, 'Payload should be persisted').toBeTruthy();
+  expect(persistedPayload.version).toBe('v1.0.0');
+  expect(persistedPayload.type).toBe('resource-configuration-patterns');
+    expect(persistedPayload.sanitization.rulesApplied).toEqual(['no-resource-names', 'aggregated-configuration-data']);
 });
 
 it('ResourceConfigurationPatternsCollector - processCollection() handles errors gracefully', async () => {
@@ -1220,15 +1217,13 @@ it('ResourceConfigurationPatternsCollector - processCollection() handles errors 
     },
   };
 
-  const mockLocalStorage = {
-    store: async () => {
-      throw new Error('Storage error');
-    },
+  const mockCollectionRepository = {
+    insertCollection: () => false,
   };
 
   const collector = new ResourceConfigurationPatternsCollector(
     mockKubernetesClient as any,
-    mockLocalStorage as any
+    mockCollectionRepository as any
   );
 
   const data = await collector.collect();

--- a/src/collection/collectors/resource-configuration-patterns.ts
+++ b/src/collection/collectors/resource-configuration-patterns.ts
@@ -632,8 +632,8 @@ export class ResourceConfigurationPatternsCollector {
   }
 
   /**
-   * Processes collected data: validates, wraps in payload, and stores locally
-   * 
+   * Processes collected data: validates, wraps in payload, and persists durably
+   *
    * @param data - Collected resource configuration patterns data
    * @returns Promise that resolves when processing is complete
    */
@@ -656,7 +656,12 @@ export class ResourceConfigurationPatternsCollector {
       logger.info('Persisting resource configuration patterns collection', {
         collectionId: validatedData.collectionId,
       });
-      persistCollection(this.collectionRepository, payload);
+      const inserted = persistCollection(this.collectionRepository, payload);
+      if (!inserted) {
+        throw new Error(
+          `Failed to persist resource configuration patterns collection: ${validatedData.collectionId}`
+        );
+      }
 
       logger.info('Resource configuration patterns collection processed successfully', {
         collectionId: validatedData.collectionId,
@@ -667,7 +672,7 @@ export class ResourceConfigurationPatternsCollector {
         error: errorMessage,
         collectionId: data.collectionId,
       });
-      // Don't throw - graceful degradation
+      throw error;
     }
   }
 

--- a/src/collection/collectors/resource-configuration-patterns.ts
+++ b/src/collection/collectors/resource-configuration-patterns.ts
@@ -22,7 +22,8 @@ import type {
   CollectionPayload,
 } from '../types.js';
 import { validateResourceConfigurationPatterns } from '../validation.js';
-import { LocalStorage } from '../storage.js';
+import type { CollectionRepository } from '../../database/collection-repository.js';
+import { persistCollection } from '../persist-collection.js';
 import { KubernetesClient } from '../../kubernetes/client.js';
 import { generateClusterIdForCollection } from '../../cluster/identifier.js';
 import { logger } from '../../logging/logger.js';
@@ -526,21 +527,21 @@ export function processServiceType(
 
 /**
  * ResourceConfigurationPatternsCollector collects resource configuration patterns
- * and processes them through validation and local storage.
+ * and processes them through validation and durable SQLite persistence.
  */
 export class ResourceConfigurationPatternsCollector {
   private readonly kubernetesClient: KubernetesClient;
-  private readonly localStorage: LocalStorage;
+  private readonly collectionRepository: CollectionRepository;
 
   /**
    * Creates a new ResourceConfigurationPatternsCollector instance
    *
    * @param kubernetesClient - Kubernetes client for API access
-   * @param localStorage - Local storage for collection payloads
+   * @param collectionRepository - Durable collection persistence
    */
-  constructor(kubernetesClient: KubernetesClient, localStorage: LocalStorage) {
+  constructor(kubernetesClient: KubernetesClient, collectionRepository: CollectionRepository) {
     this.kubernetesClient = kubernetesClient;
-    this.localStorage = localStorage;
+    this.collectionRepository = collectionRepository;
   }
 
   /**
@@ -652,10 +653,10 @@ export class ResourceConfigurationPatternsCollector {
         },
       };
 
-      logger.info('Storing resource configuration patterns collection locally', {
+      logger.info('Persisting resource configuration patterns collection', {
         collectionId: validatedData.collectionId,
       });
-      await this.localStorage.store(payload);
+      persistCollection(this.collectionRepository, payload);
 
       logger.info('Resource configuration patterns collection processed successfully', {
         collectionId: validatedData.collectionId,

--- a/src/collection/collectors/resource-inventory.test.ts
+++ b/src/collection/collectors/resource-inventory.test.ts
@@ -8,7 +8,7 @@ vi.mock('../../cluster/identifier.js', () => ({
 
 import { ResourceInventoryCollector } from './resource-inventory.js';
 import type { KubernetesClient } from '../../kubernetes/client.js';
-import type { LocalStorage } from '../storage.js';
+import type { CollectionRepository } from '../../database/collection-repository.js';
 
 function nsId(name: string): string {
   return `namespace-${createHash('sha256').update(name).digest('hex').substring(0, 12)}`;
@@ -69,7 +69,7 @@ function mockKubernetesClient(): KubernetesClient {
 describe('ResourceInventoryCollector', () => {
   it('collect() hashes namespace names and aggregates counts', async () => {
     const k8sClient = mockKubernetesClient();
-    const collector = new ResourceInventoryCollector(k8sClient, {} as LocalStorage);
+    const collector = new ResourceInventoryCollector(k8sClient, {} as CollectionRepository);
 
     const inv = await collector.collect();
 
@@ -109,24 +109,24 @@ describe('ResourceInventoryCollector', () => {
       items: [{ metadata: {}, spec: {} }],
     });
 
-    const collector = new ResourceInventoryCollector(k8sClient, {} as LocalStorage);
+    const collector = new ResourceInventoryCollector(k8sClient, {} as CollectionRepository);
     const inv = await collector.collect();
 
     expect(inv.resources.services.total).toBe(1);
     expect(inv.resources.services.byType.ClusterIP).toBe(1);
   });
 
-  it('processCollection() stores a validated resource-inventory payload', async () => {
+  it('processCollection() persists a validated resource-inventory payload', async () => {
     const k8sClient = mockKubernetesClient();
-    const store = vi.fn().mockResolvedValue(undefined);
-    const localStorage = { store } as unknown as LocalStorage;
+    const insertCollection = vi.fn().mockReturnValue(true);
+    const collectionRepository = { insertCollection } as unknown as CollectionRepository;
 
-    const collector = new ResourceInventoryCollector(k8sClient, localStorage);
+    const collector = new ResourceInventoryCollector(k8sClient, collectionRepository);
     const inv = await collector.collect();
     await collector.processCollection(inv);
 
-    expect(store).toHaveBeenCalledTimes(1);
-    const payload = store.mock.calls[0][0] as {
+    expect(insertCollection).toHaveBeenCalledTimes(1);
+    const payload = insertCollection.mock.calls[0][0] as {
       type: string;
       sanitization: { rulesApplied: string[] };
     };
@@ -137,12 +137,12 @@ describe('ResourceInventoryCollector', () => {
     ]);
   });
 
-  it('processCollection() does not store when validation fails', async () => {
-    const store = vi.fn().mockResolvedValue(undefined);
-    const localStorage = { store } as unknown as LocalStorage;
+  it('processCollection() does not persist when validation fails', async () => {
+    const insertCollection = vi.fn().mockReturnValue(true);
+    const collectionRepository = { insertCollection } as unknown as CollectionRepository;
     const collector = new ResourceInventoryCollector(
       mockKubernetesClient(),
-      localStorage
+      collectionRepository
     );
 
     await collector.processCollection({
@@ -159,6 +159,6 @@ describe('ResourceInventoryCollector', () => {
       },
     });
 
-    expect(store).not.toHaveBeenCalled();
+    expect(insertCollection).not.toHaveBeenCalled();
   });
 });

--- a/src/collection/collectors/resource-inventory.test.ts
+++ b/src/collection/collectors/resource-inventory.test.ts
@@ -145,20 +145,36 @@ describe('ResourceInventoryCollector', () => {
       collectionRepository
     );
 
-    await collector.processCollection({
-      timestamp: new Date().toISOString(),
-      collectionId: 'bad-id',
-      clusterId: 'cls_' + 'a'.repeat(32),
-      namespaces: { count: 0, list: [] },
-      resources: {
-        pods: { total: 0, byNamespace: {} },
-        deployments: { total: 0 },
-        statefulSets: { total: 0 },
-        replicaSets: { total: 0 },
-        services: { total: 0, byType: {} },
-      },
-    });
+    await expect(
+      collector.processCollection({
+        timestamp: new Date().toISOString(),
+        collectionId: 'bad-id',
+        clusterId: 'cls_' + 'a'.repeat(32),
+        namespaces: { count: 0, list: [] },
+        resources: {
+          pods: { total: 0, byNamespace: {} },
+          deployments: { total: 0 },
+          statefulSets: { total: 0 },
+          replicaSets: { total: 0 },
+          services: { total: 0, byType: {} },
+        },
+      })
+    ).rejects.toThrow();
 
     expect(insertCollection).not.toHaveBeenCalled();
+  });
+
+  it('processCollection() throws when durable insert fails', async () => {
+    const insertCollection = vi.fn().mockReturnValue(false);
+    const collectionRepository = { insertCollection } as unknown as CollectionRepository;
+    const collector = new ResourceInventoryCollector(
+      mockKubernetesClient(),
+      collectionRepository
+    );
+
+    const inv = await collector.collect();
+    await expect(collector.processCollection(inv)).rejects.toThrow(
+      /Failed to persist resource inventory/i
+    );
   });
 });

--- a/src/collection/collectors/resource-inventory.ts
+++ b/src/collection/collectors/resource-inventory.ts
@@ -10,28 +10,29 @@ import { randomBytes, createHash } from 'crypto';
 import * as k8s from '@kubernetes/client-node';
 import type { ResourceInventory, CollectionPayload } from '../types.js';
 import { validateResourceInventory } from '../validation.js';
-import { LocalStorage } from '../storage.js';
+import type { CollectionRepository } from '../../database/collection-repository.js';
+import { persistCollection } from '../persist-collection.js';
 import { KubernetesClient } from '../../kubernetes/client.js';
 import { generateClusterIdForCollection } from '../../cluster/identifier.js';
 import { logger } from '../../logging/logger.js';
 
 /**
  * ResourceInventoryCollector collects resource inventory and processes it
- * through validation and local storage.
+ * through validation and durable SQLite persistence.
  */
 export class ResourceInventoryCollector {
   private readonly kubernetesClient: KubernetesClient;
-  private readonly localStorage: LocalStorage;
+  private readonly collectionRepository: CollectionRepository;
 
   /**
    * Creates a new ResourceInventoryCollector instance
    *
    * @param kubernetesClient - Kubernetes client for API access
-   * @param localStorage - Local storage for collection payloads
+   * @param collectionRepository - Durable collection persistence
    */
-  constructor(kubernetesClient: KubernetesClient, localStorage: LocalStorage) {
+  constructor(kubernetesClient: KubernetesClient, collectionRepository: CollectionRepository) {
     this.kubernetesClient = kubernetesClient;
-    this.localStorage = localStorage;
+    this.collectionRepository = collectionRepository;
   }
 
   /**
@@ -126,10 +127,10 @@ export class ResourceInventoryCollector {
         },
       };
 
-      logger.info('Storing resource inventory collection locally', {
+      logger.info('Persisting resource inventory collection', {
         collectionId: validatedInventory.collectionId,
       });
-      await this.localStorage.store(payload);
+      persistCollection(this.collectionRepository, payload);
 
       logger.info('Resource inventory collection processed successfully', {
         collectionId: validatedInventory.collectionId,

--- a/src/collection/collectors/resource-inventory.ts
+++ b/src/collection/collectors/resource-inventory.ts
@@ -106,8 +106,8 @@ export class ResourceInventoryCollector {
   }
 
   /**
-   * Processes collected inventory: validates, wraps in payload, and stores locally
-   * 
+   * Processes collected inventory: validates, wraps in payload, and persists durably
+   *
    * @param inventory - Collected resource inventory
    * @returns Promise that resolves when processing is complete
    */
@@ -130,7 +130,12 @@ export class ResourceInventoryCollector {
       logger.info('Persisting resource inventory collection', {
         collectionId: validatedInventory.collectionId,
       });
-      persistCollection(this.collectionRepository, payload);
+      const inserted = persistCollection(this.collectionRepository, payload);
+      if (!inserted) {
+        throw new Error(
+          `Failed to persist resource inventory collection: ${validatedInventory.collectionId}`
+        );
+      }
 
       logger.info('Resource inventory collection processed successfully', {
         collectionId: validatedInventory.collectionId,
@@ -141,7 +146,7 @@ export class ResourceInventoryCollector {
         error: errorMessage,
         collectionId: inventory.collectionId,
       });
-      // Don't throw - graceful degradation
+      throw error;
     }
   }
 

--- a/src/collection/payload-schema.test.ts
+++ b/src/collection/payload-schema.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { CollectionPayloadSchema } from './payload-schema.js';
+import type { CollectionPayload } from './types.js';
+
+const ts = '2026-08-03T12:00:00.000Z';
+
+function baseEnvelope(type: CollectionPayload['type'], data: unknown): CollectionPayload {
+  return {
+    version: 'v1.0.0',
+    type,
+    data: data as CollectionPayload['data'],
+    sanitization: {
+      rulesApplied: ['hash-identifiers'],
+      timestamp: ts,
+    },
+  };
+}
+
+function validPerformanceMetricsData(): Record<string, unknown> {
+  return {
+    timestamp: ts,
+    collectionId: 'coll_perf123456789012345678901234',
+    clusterId: 'cls_testabc1234567890123456789012',
+    source: { available: true },
+    utilization: {
+      cpu: { clusterAvgRatio: 0.42, nodeHighWatermarkRatio: 0.88 },
+      memory: { clusterAvgRatio: 0.55 },
+    },
+    ratios: { pending_pods_ratio: 0.1 },
+  };
+}
+
+function validSecurityPostureData(): Record<string, unknown> {
+  return {
+    timestamp: ts,
+    collectionId: 'coll_sec1234567890123456789012345',
+    clusterId: 'cls_testabc1234567890123456789012',
+    privilegedHost: {
+      privilegedContainers: 2,
+      hostPathVolumes: 1,
+      hostNetworkPods: 0,
+      hostPIDPods: 1,
+      hostIPCPods: 0,
+    },
+    networkPolicyCoverage: {
+      namespacesTotal: 10,
+      namespacesWithNetworkPolicy: 7,
+      coverageRatio: 0.7,
+    },
+    nsaCisRollups: {
+      allowPrivilegeEscalationTrueContainers: 3,
+      runAsNonRootFalseContainers: 5,
+      readOnlyRootFilesystemFalseContainers: 8,
+      capabilitiesNotDroppedAllContainers: 2,
+      automountServiceAccountTokenTruePods: 4,
+      hostNamespacesPods: 1,
+    },
+  };
+}
+
+describe('CollectionPayloadSchema', () => {
+  it('accepts valid performance-metrics payload', () => {
+    const payload = baseEnvelope('performance-metrics', validPerformanceMetricsData());
+    expect(CollectionPayloadSchema.safeParse(payload).success).toBe(true);
+  });
+
+  it('accepts valid security-posture payload', () => {
+    const payload = baseEnvelope('security-posture', validSecurityPostureData());
+    expect(CollectionPayloadSchema.safeParse(payload).success).toBe(true);
+  });
+
+  it('rejects performance-metrics type/data mismatch', () => {
+    const payload = baseEnvelope('performance-metrics', validSecurityPostureData() as never);
+    expect(CollectionPayloadSchema.safeParse(payload).success).toBe(false);
+  });
+
+  it('rejects security-posture type/data mismatch', () => {
+    const payload = baseEnvelope('security-posture', validPerformanceMetricsData() as never);
+    expect(CollectionPayloadSchema.safeParse(payload).success).toBe(false);
+  });
+
+  it('rejects performance-metrics data larger than 64 KiB', () => {
+    const data = validPerformanceMetricsData();
+    data.collectionId = `coll_${'a'.repeat(65500)}`;
+
+    const payload = baseEnvelope('performance-metrics', data);
+    expect(CollectionPayloadSchema.safeParse(payload).success).toBe(false);
+  });
+
+  it('rejects security-posture vulnerabilities-shaped body', () => {
+    const data = {
+      ...validSecurityPostureData(),
+      vulnerabilities: [{ id: 'CVE-2024-0001' }],
+    };
+    const payload = baseEnvelope('security-posture', data);
+    expect(CollectionPayloadSchema.safeParse(payload).success).toBe(false);
+  });
+
+  it('rejects security-posture unknown nsaCisRollups keys', () => {
+    const base = validSecurityPostureData();
+    const data = {
+      ...base,
+      nsaCisRollups: {
+        ...(base.nsaCisRollups as Record<string, number>),
+        extraRollup: 1,
+      },
+    };
+    const payload = baseEnvelope('security-posture', data);
+    expect(CollectionPayloadSchema.safeParse(payload).success).toBe(false);
+  });
+
+  it('rejects performance-metrics ratios with more than 16 keys', () => {
+    const data = validPerformanceMetricsData();
+    const ratios: Record<string, number> = Object.fromEntries(
+      Array.from({ length: 17 }, (_, i) => [`key_${i}`, 0.1])
+    );
+    data.ratios = ratios;
+    const payload = baseEnvelope('performance-metrics', data);
+    expect(CollectionPayloadSchema.safeParse(payload).success).toBe(false);
+  });
+
+  it('rejects performance-metrics ratio outside [0, 1]', () => {
+    const data = validPerformanceMetricsData();
+    data.utilization = { cpu: { clusterAvgRatio: 1.5 } };
+    const payload = baseEnvelope('performance-metrics', data);
+    expect(CollectionPayloadSchema.safeParse(payload).success).toBe(false);
+  });
+});

--- a/src/collection/payload-schema.ts
+++ b/src/collection/payload-schema.ts
@@ -4,15 +4,49 @@
 
 import { z } from 'zod';
 
+const MAX_DATA_BYTES = 64 * 1024;
+
 const sanitizationSchema = z.object({
   rulesApplied: z.array(z.string()),
   timestamp: z.string(),
 });
 
-const clusterMetadataDataSchema = z.object({
+const identityFieldsSchema = {
   timestamp: z.string(),
   collectionId: z.string(),
   clusterId: z.string(),
+};
+
+const ratioField = z.number().min(0).max(1);
+
+const utilizationCpuMemorySchema = z
+  .object({
+    clusterAvgRatio: ratioField.optional(),
+    nodeHighWatermarkRatio: ratioField.optional(),
+  })
+  .strict()
+  .optional();
+
+const boundedRatiosSchema = z
+  .record(z.string().max(64), ratioField)
+  .refine((obj) => Object.keys(obj).length <= 16, {
+    message: 'ratios may contain at most 16 keys',
+  });
+
+function rejectOversizedData<T extends z.ZodTypeAny>(schema: T) {
+  return schema.superRefine((data, ctx) => {
+    const serialized = JSON.stringify(data);
+    if (serialized.length > MAX_DATA_BYTES) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `serialized data exceeds ${MAX_DATA_BYTES} bytes`,
+      });
+    }
+  });
+}
+
+const clusterMetadataDataSchema = z.object({
+  ...identityFieldsSchema,
   kubernetesVersion: z.string(),
   nodeCount: z.number(),
   provider: z.enum(['aws', 'gcp', 'azure', 'on-premise', 'other', 'unknown']).optional(),
@@ -21,9 +55,7 @@ const clusterMetadataDataSchema = z.object({
 });
 
 const resourceInventoryDataSchema = z.object({
-  timestamp: z.string(),
-  collectionId: z.string(),
-  clusterId: z.string(),
+  ...identityFieldsSchema,
   namespaces: z.object({
     count: z.number(),
     list: z.array(z.string()),
@@ -54,11 +86,67 @@ const resourceInventoryDataSchema = z.object({
 /** Nested pattern shapes vary; core identifiers and timestamp are required. */
 const resourceConfigurationDataSchema = z
   .object({
-    timestamp: z.string(),
-    collectionId: z.string(),
-    clusterId: z.string(),
+    ...identityFieldsSchema,
   })
   .passthrough();
+
+const performanceMetricsDataSchema = rejectOversizedData(
+  z
+    .object({
+      ...identityFieldsSchema,
+      source: z
+        .object({
+          available: z.boolean(),
+          reason: z.string().max(200).optional(),
+        })
+        .strict(),
+      utilization: z
+        .object({
+          cpu: utilizationCpuMemorySchema,
+          memory: utilizationCpuMemorySchema,
+        })
+        .strict()
+        .optional(),
+      ratios: boundedRatiosSchema.optional(),
+    })
+    .strict()
+);
+
+const nsaCisRollupsSchema = z
+  .object({
+    allowPrivilegeEscalationTrueContainers: z.number().int().min(0),
+    runAsNonRootFalseContainers: z.number().int().min(0),
+    readOnlyRootFilesystemFalseContainers: z.number().int().min(0),
+    capabilitiesNotDroppedAllContainers: z.number().int().min(0),
+    automountServiceAccountTokenTruePods: z.number().int().min(0),
+    hostNamespacesPods: z.number().int().min(0),
+  })
+  .strict();
+
+const securityPostureDataSchema = rejectOversizedData(
+  z
+    .object({
+      ...identityFieldsSchema,
+      privilegedHost: z
+        .object({
+          privilegedContainers: z.number().int().min(0),
+          hostPathVolumes: z.number().int().min(0),
+          hostNetworkPods: z.number().int().min(0),
+          hostPIDPods: z.number().int().min(0).optional(),
+          hostIPCPods: z.number().int().min(0).optional(),
+        })
+        .strict(),
+      networkPolicyCoverage: z
+        .object({
+          namespacesTotal: z.number().int().min(0),
+          namespacesWithNetworkPolicy: z.number().int().min(0),
+          coverageRatio: ratioField.optional(),
+        })
+        .strict(),
+      nsaCisRollups: nsaCisRollupsSchema,
+    })
+    .strict()
+);
 
 export const CollectionPayloadSchema = z.discriminatedUnion('type', [
   z.object({
@@ -77,6 +165,18 @@ export const CollectionPayloadSchema = z.discriminatedUnion('type', [
     version: z.string(),
     type: z.literal('resource-configuration-patterns'),
     data: resourceConfigurationDataSchema,
+    sanitization: sanitizationSchema,
+  }),
+  z.object({
+    version: z.string(),
+    type: z.literal('performance-metrics'),
+    data: performanceMetricsDataSchema,
+    sanitization: sanitizationSchema,
+  }),
+  z.object({
+    version: z.string(),
+    type: z.literal('security-posture'),
+    data: securityPostureDataSchema,
     sanitization: sanitizationSchema,
   }),
 ]);

--- a/src/collection/persist-collection.ts
+++ b/src/collection/persist-collection.ts
@@ -1,0 +1,26 @@
+/**
+ * Thin helper for durable collection persistence via CollectionRepository.
+ */
+
+import type { CollectionRepository } from '../database/collection-repository.js';
+import type { CollectionPayload } from './types.js';
+import { logger } from '../logging/logger.js';
+
+/**
+ * Persists a validated collection payload to SQLite.
+ *
+ * @returns true when a new row was inserted; false on duplicate or validation failure
+ */
+export function persistCollection(
+  repository: CollectionRepository,
+  payload: CollectionPayload
+): boolean {
+  const inserted = repository.insertCollection(payload);
+  if (!inserted) {
+    logger.warn('Collection persist returned false (duplicate or validation failure)', {
+      collectionId: payload.data.collectionId,
+      type: payload.type,
+    });
+  }
+  return inserted;
+}

--- a/src/collection/stats-tracker.ts
+++ b/src/collection/stats-tracker.ts
@@ -82,9 +82,9 @@ export class CollectionStatsTracker {
   }
 
   /**
-   * Updates the count of collections stored locally
-   * 
-   * @param count - Current number of stored collections
+   * Updates the count of collections stored durably in SQLite.
+   *
+   * @param count - Current SQLite collections row count
    */
   updateStoredCount(count: number): void {
     this.collectionsStoredCount = count;

--- a/src/collection/storage.ts
+++ b/src/collection/storage.ts
@@ -5,7 +5,6 @@
 
 import type { CollectionPayload } from './types.js';
 import { logger } from '../logging/logger.js';
-import { collectionStatsTracker } from './stats-tracker.js';
 
 /**
  * Default maximum number of collections to store in memory
@@ -93,9 +92,6 @@ export class LocalStorage {
       currentSize: this.order.length,
       maxCollections: this.maxCollections,
     });
-    
-    // Update stats tracker with new stored count
-    collectionStatsTracker.updateStoredCount(this.order.length);
   }
 
   /**
@@ -169,9 +165,6 @@ export class LocalStorage {
       clearedCount: size,
       action: 'clear',
     });
-    
-    // Update stats tracker with new stored count (0)
-    collectionStatsTracker.updateStoredCount(0);
   }
 }
 

--- a/src/collection/types.ts
+++ b/src/collection/types.ts
@@ -554,6 +554,62 @@ export interface ResourceConfigurationPatternsData {
 }
 
 /**
+ * Performance metrics collection data (bounded Prometheus aggregates)
+ */
+export interface PerformanceMetrics {
+  timestamp: string;
+  collectionId: string;
+  clusterId: string;
+  source: {
+    available: boolean;
+    reason?: string;
+  };
+  utilization?: {
+    cpu?: {
+      clusterAvgRatio?: number;
+      nodeHighWatermarkRatio?: number;
+    };
+    memory?: {
+      clusterAvgRatio?: number;
+      nodeHighWatermarkRatio?: number;
+    };
+  };
+  ratios?: Record<string, number>;
+}
+
+/** v1 closed nsaCisRollups key set for security-posture payloads */
+export type SecurityPostureNsaCisRollups = {
+  allowPrivilegeEscalationTrueContainers: number;
+  runAsNonRootFalseContainers: number;
+  readOnlyRootFilesystemFalseContainers: number;
+  capabilitiesNotDroppedAllContainers: number;
+  automountServiceAccountTokenTruePods: number;
+  hostNamespacesPods: number;
+};
+
+/**
+ * Security posture collection data (bounded cluster-API aggregates)
+ */
+export interface SecurityPosture {
+  timestamp: string;
+  collectionId: string;
+  clusterId: string;
+  privilegedHost: {
+    privilegedContainers: number;
+    hostPathVolumes: number;
+    hostNetworkPods: number;
+    hostPIDPods?: number;
+    hostIPCPods?: number;
+  };
+  networkPolicyCoverage: {
+    namespacesTotal: number;
+    namespacesWithNetworkPolicy: number;
+    coverageRatio?: number;
+  };
+  nsaCisRollups: SecurityPostureNsaCisRollups;
+}
+
+/**
  * Collection payload wrapper for all collection types
  */
 export interface CollectionPayload {
@@ -565,12 +621,22 @@ export interface CollectionPayload {
   /**
    * Collection type identifier
    */
-  type: "cluster-metadata" | "resource-inventory" | "resource-configuration-patterns";
+  type:
+    | "cluster-metadata"
+    | "resource-inventory"
+    | "resource-configuration-patterns"
+    | "performance-metrics"
+    | "security-posture";
 
   /**
    * Collection data (type-specific)
    */
-  data: ClusterMetadata | ResourceInventory | ResourceConfigurationPatternsData;
+  data:
+    | ClusterMetadata
+    | ResourceInventory
+    | ResourceConfigurationPatternsData
+    | PerformanceMetrics
+    | SecurityPosture;
 
   /**
    * Sanitization metadata

--- a/src/database/collection-repository.test.ts
+++ b/src/database/collection-repository.test.ts
@@ -118,4 +118,89 @@ describe('CollectionRepository', () => {
     expect(repo.insertCollection(payload)).toBe(true);
     expect(repo.insertCollection(payload)).toBe(false);
   });
+
+  it('inserts and retrieves valid performance-metrics payload', () => {
+    const repo = new CollectionRepository();
+    const ts = new Date().toISOString();
+    const payload: CollectionPayload = {
+      version: 'v1.0.0',
+      type: 'performance-metrics',
+      data: {
+        timestamp: ts,
+        collectionId: 'coll_perf123456789012345678901234',
+        clusterId: 'cls_testabc1234567890123456789012',
+        source: { available: true },
+        utilization: { cpu: { clusterAvgRatio: 0.25 } },
+      },
+      sanitization: { rulesApplied: ['hash-identifiers'], timestamp: ts },
+    };
+    expect(repo.insertCollection(payload)).toBe(true);
+    const got = repo.getCollectionById('coll_perf123456789012345678901234');
+    expect(got?.type).toBe('performance-metrics');
+    expect(got?.data).toEqual(payload.data);
+  });
+
+  it('inserts and retrieves valid security-posture payload', () => {
+    const repo = new CollectionRepository();
+    const ts = new Date().toISOString();
+    const payload: CollectionPayload = {
+      version: 'v1.0.0',
+      type: 'security-posture',
+      data: {
+        timestamp: ts,
+        collectionId: 'coll_sec1234567890123456789012345',
+        clusterId: 'cls_testabc1234567890123456789012',
+        privilegedHost: {
+          privilegedContainers: 1,
+          hostPathVolumes: 0,
+          hostNetworkPods: 0,
+        },
+        networkPolicyCoverage: {
+          namespacesTotal: 5,
+          namespacesWithNetworkPolicy: 3,
+        },
+        nsaCisRollups: {
+          allowPrivilegeEscalationTrueContainers: 0,
+          runAsNonRootFalseContainers: 1,
+          readOnlyRootFilesystemFalseContainers: 2,
+          capabilitiesNotDroppedAllContainers: 0,
+          automountServiceAccountTokenTruePods: 1,
+          hostNamespacesPods: 0,
+        },
+      },
+      sanitization: { rulesApplied: ['hash-identifiers'], timestamp: ts },
+    };
+    expect(repo.insertCollection(payload)).toBe(true);
+    const got = repo.getCollectionById('coll_sec1234567890123456789012345');
+    expect(got?.type).toBe('security-posture');
+    expect(got?.data).toEqual(payload.data);
+  });
+
+  it('rejects security-posture payload with vulnerabilities field', () => {
+    const repo = new CollectionRepository();
+    const ts = new Date().toISOString();
+    const bad = {
+      version: 'v1.0.0',
+      type: 'security-posture',
+      data: {
+        timestamp: ts,
+        collectionId: 'coll_bad123456789012345678901234',
+        clusterId: 'cls_testabc1234567890123456789012',
+        privilegedHost: { privilegedContainers: 0, hostPathVolumes: 0, hostNetworkPods: 0 },
+        networkPolicyCoverage: { namespacesTotal: 1, namespacesWithNetworkPolicy: 0 },
+        nsaCisRollups: {
+          allowPrivilegeEscalationTrueContainers: 0,
+          runAsNonRootFalseContainers: 0,
+          readOnlyRootFilesystemFalseContainers: 0,
+          capabilitiesNotDroppedAllContainers: 0,
+          automountServiceAccountTokenTruePods: 0,
+          hostNamespacesPods: 0,
+        },
+        vulnerabilities: [],
+      },
+      sanitization: { rulesApplied: [], timestamp: ts },
+    };
+    expect(repo.insertCollection(bad)).toBe(false);
+    expect(repo.countCollections({})).toBe(0);
+  });
 });

--- a/src/database/collection-repository.ts
+++ b/src/database/collection-repository.ts
@@ -12,7 +12,9 @@ import { ZodError } from 'zod';
 export type CollectionRowType =
   | 'cluster-metadata'
   | 'resource-inventory'
-  | 'resource-configuration-patterns';
+  | 'resource-configuration-patterns'
+  | 'performance-metrics'
+  | 'security-posture';
 
 export interface CollectionFilters {
   type?: CollectionRowType;

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -7,7 +7,7 @@ import Database from 'better-sqlite3';
 import { logger } from '../logging/logger.js';
 
 /** Latest schema version - bump when adding migrations */
-const LATEST_SCHEMA_VERSION = 6;
+const LATEST_SCHEMA_VERSION = 7;
 
 /**
  * SchemaManager handles database schema initialization and migrations
@@ -65,6 +65,10 @@ export class SchemaManager {
       {
         version: 6,
         apply: () => this.migrateToV6(),
+      },
+      {
+        version: 7,
+        apply: () => this.migrateToV7(),
       },
     ];
 
@@ -269,6 +273,34 @@ export class SchemaManager {
         ON ai_conformance_requirement_results(status);
       CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_conformance_requirement_results_run_requirement
         ON ai_conformance_requirement_results(run_id, requirement_id);
+    `);
+  }
+
+  /**
+   * Migration v7: Drop SQLite CHECK on collections.type (closed set enforced in app/Zod only).
+   */
+  private migrateToV7(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS collections_v7 (
+        collection_id TEXT PRIMARY KEY,
+        cluster_id TEXT NOT NULL,
+        type TEXT NOT NULL,
+        collected_at TEXT NOT NULL,
+        payload_json TEXT NOT NULL
+      );
+
+      INSERT INTO collections_v7 (
+        collection_id, cluster_id, type, collected_at, payload_json
+      )
+      SELECT collection_id, cluster_id, type, collected_at, payload_json
+      FROM collections;
+
+      DROP TABLE collections;
+      ALTER TABLE collections_v7 RENAME TO collections;
+
+      CREATE INDEX IF NOT EXISTS idx_collections_cluster_id ON collections(cluster_id);
+      CREATE INDEX IF NOT EXISTS idx_collections_type ON collections(type);
+      CREATE INDEX IF NOT EXISTS idx_collections_collected_at ON collections(collected_at DESC);
     `);
   }
 

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -13,7 +13,7 @@ import { CollectionScheduler } from './collection/scheduler.js';
 import { ClusterMetadataCollector } from './collection/collectors/cluster-metadata.js';
 import { ResourceInventoryCollector } from './collection/collectors/resource-inventory.js';
 import { ResourceConfigurationPatternsCollector } from './collection/collectors/resource-configuration-patterns.js';
-import { LocalStorage } from './collection/storage.js';
+import { CollectionRepository } from './database/collection-repository.js';
 import { recordCollection } from './collection/metrics.js';
 import { collectionStatsTracker } from './collection/stats-tracker.js';
 import { logger } from './logging/logger.js';
@@ -225,10 +225,13 @@ export async function startOperator() {
       logger.info('Collection scheduler created successfully');
 
       // Initialize collection infrastructure
-      const localStorage = new LocalStorage();
+      const collectionRepository = new CollectionRepository();
 
       // Initialize cluster metadata collector
-      const clusterMetadataCollector = new ClusterMetadataCollector(kubernetesClient, localStorage);
+      const clusterMetadataCollector = new ClusterMetadataCollector(
+        kubernetesClient,
+        collectionRepository
+      );
     
     // Register cluster metadata collection task
     collectionScheduler.register(
@@ -260,7 +263,10 @@ export async function startOperator() {
     );
     
     // Initialize resource inventory collector
-    const resourceInventoryCollector = new ResourceInventoryCollector(kubernetesClient, localStorage);
+    const resourceInventoryCollector = new ResourceInventoryCollector(
+      kubernetesClient,
+      collectionRepository
+    );
     
     // Register resource inventory collection task
     collectionScheduler.register(
@@ -294,7 +300,7 @@ export async function startOperator() {
     // Initialize resource configuration patterns collector
     const resourceConfigurationPatternsCollector = new ResourceConfigurationPatternsCollector(
       kubernetesClient,
-      localStorage
+      collectionRepository
     );
     
     // Register resource configuration patterns collection task

--- a/src/shutdown/handler.ts
+++ b/src/shutdown/handler.ts
@@ -8,6 +8,7 @@ import { stopHealthServer } from '../health/server.js';
 import type { OperatorStatus } from '../status/types.js';
 import { logger } from '../logging/logger.js';
 import { collectionStatsTracker } from '../collection/stats-tracker.js';
+import { CollectionRepository } from '../database/collection-repository.js';
 import { argocdStatusTracker } from '../argocd/state.js';
 import { trivyStatusTracker } from '../trivy/state.js';
 import { withPersistedArgoApplicationsSummary } from '../status/argocd-for-status.js';
@@ -100,6 +101,8 @@ export async function gracefulShutdown(
 
     await stopHealthServer();
 
+    const collectionRepository = new CollectionRepository();
+    collectionStatsTracker.updateStoredCount(collectionRepository.countCollections({}));
     const collectionStats = collectionStatsTracker.getStats();
     const argocdStatus = withPersistedArgoApplicationsSummary(argocdStatusTracker.getStatus());
     const trivyStatus = trivyStatusTracker.getStatus();

--- a/src/status/writer.ts
+++ b/src/status/writer.ts
@@ -21,6 +21,7 @@ import { AssessmentRepository } from '../database/assessment-repository.js';
 import { AiConformanceRepository } from '../database/ai-conformance-repository.js';
 import { logger } from '../logging/logger.js';
 import { collectionStatsTracker } from '../collection/stats-tracker.js';
+import { CollectionRepository } from '../database/collection-repository.js';
 import { argocdStatusTracker } from '../argocd/state.js';
 import { trivyStatusTracker } from '../trivy/state.js';
 import { withPersistedArgoApplicationsSummary } from './argocd-for-status.js';
@@ -172,6 +173,8 @@ export class StatusWriter {
     try {
       const canWriteConfigMap = true;
 
+      const collectionRepository = new CollectionRepository();
+      collectionStatsTracker.updateStoredCount(collectionRepository.countCollections({}));
       const collectionStats = collectionStatsTracker.getStats();
       const argocdStatus = withPersistedArgoApplicationsSummary(argocdStatusTracker.getStatus());
       const trivyStatus = trivyStatusTracker.getStatus();


### PR DESCRIPTION
## Description

Implements the **pipeline-contract slice** of parent epic #168 on branch `feature/issue-168`:

- **#174** — Add `performance-metrics` and `security-posture` to the five-type CollectionPayload closed set (Zod/TS catalogs, repository row types, CLI `--type` filters, v7 migration dropping SQLite type CHECK).
- **#175** — Route the three existing collectors through `CollectionRepository.insertCollection`; sync status `collectionsStoredCount` from SQLite row count; remove LocalStorage from the durable write path.

Remaining sub-issues (#169 performance-metrics collector, #170 security-posture collector, #171 Helm/RBAC/labels, #172 CLI polish) are **out of scope** for this PR and will land on the same branch in follow-up builds.

## Motivation and Context

The Finish M8 collector set needs shared pipeline contracts for all five collection types and a single SQLite durable write path so `query collections` and status metrics reflect durable truth before collectors #169/#170 ship.

Closes #174
Closes #175
Part of #168

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated
- [x] All new and existing tests pass (`npm run test:unit`)
- [x] Linter passes (`npm run lint`)
- [x] Build passes (`npm run build`)

```bash
npm install
npm run test:unit
npm run lint
npm run build
```

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass
- [x] I have run the linter and fixed any issues

## How to Test this Work

1. Run full validation: `npm install && npm run test:unit && npm run lint && npm run build`
2. Confirm valid `performance-metrics` and `security-posture` fixtures insert via `CollectionRepository.insertCollection`
3. Confirm collector `processCollection` tests mock `insertCollection` (not LocalStorage)
4. Confirm type/data mismatch and oversized payloads are rejected with no row written
5. Confirm `collectionsStoredCount` publishing reads SQLite count (not in-memory buffer size)

## Additional Notes

- Does **not** close #168; sibling sub-issues remain open.
- SQLite migration v7 drops the `collections.type` CHECK constraint; closed set stays in app/Zod validation only.