### PR TITLE
feat(collection): ship performance-metrics Prometheus collector (#169)

### DIFF
--- a/src/assessment/scheduled-tick.test.ts
+++ b/src/assessment/scheduled-tick.test.ts
@@ -30,6 +30,7 @@ const baseConfig = {
   aiConformanceEnabled: false,
   aiConformanceIntervalSeconds: 86400,
   aiConformanceChecklistSource: 'bundled' as const,
+  performanceMetricsIntervalSeconds: 900,
 } satisfies Config;
 
 const mockKubernetes = {

--- a/src/collection/collectors/performance-metrics.test.ts
+++ b/src/collection/collectors/performance-metrics.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+vi.mock('../../cluster/identifier.js', () => ({
+  generateClusterIdForCollection: vi.fn(() => 'cls_' + 'a'.repeat(32)),
+}));
+
+import { PerformanceMetricsCollector } from './performance-metrics.js';
+import type { CollectionRepository } from '../../database/collection-repository.js';
+import type { PerformanceMetrics } from '../types.js';
+
+function promSuccessBody(value: string): string {
+  return JSON.stringify({
+    status: 'success',
+    data: {
+      resultType: 'vector',
+      result: [{ metric: {}, value: [1_700_000_000, value] }],
+    },
+  });
+}
+
+function mockCollectionRepository(
+  insertCollection: ReturnType<typeof vi.fn> = vi.fn().mockReturnValue(true)
+): CollectionRepository {
+  return { insertCollection } as unknown as CollectionRepository;
+}
+
+describe('PerformanceMetricsCollector', () => {
+  let server: Server | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve, reject) => {
+        server!.close((err) => (err ? reject(err) : resolve()));
+      });
+      server = null;
+    }
+  });
+
+  async function startPrometheusMock(
+    handler: (query: string) => { status: number; body: string }
+  ): Promise<string> {
+    server = createServer((req, res) => {
+      const url = new URL(req.url ?? '/', 'http://localhost');
+      const query = url.searchParams.get('query') ?? '';
+      const { status, body } = handler(query);
+      res.writeHead(status, { 'content-type': 'application/json' });
+      res.end(body);
+    });
+    await new Promise<void>((resolve) => server!.listen(0, resolve));
+    const port = (server.address() as AddressInfo).port;
+    return `http://127.0.0.1:${port}`;
+  }
+
+  it('collect() rejects when Prometheus returns no usable scalars', async () => {
+    const baseUrl = await startPrometheusMock(() => ({
+      status: 200,
+      body: JSON.stringify({
+        status: 'success',
+        data: { resultType: 'vector', result: [] },
+      }),
+    }));
+
+    const collector = new PerformanceMetricsCollector(
+      { baseUrl, timeoutMs: 5000, tlsInsecure: false },
+      mockCollectionRepository()
+    );
+
+    await expect(collector.collect()).rejects.toThrow(/no usable scalar aggregates/i);
+  });
+
+  it('collect() returns metrics with source.available true on PromQL success', async () => {
+    const baseUrl = await startPrometheusMock((query) => {
+      if (query.includes('node_cpu_seconds_total')) {
+        return { status: 200, body: promSuccessBody('0.4') };
+      }
+      return {
+        status: 200,
+        body: JSON.stringify({
+          status: 'success',
+          data: { resultType: 'vector', result: [] },
+        }),
+      };
+    });
+
+    const collector = new PerformanceMetricsCollector(
+      { baseUrl, timeoutMs: 5000, tlsInsecure: false },
+      mockCollectionRepository()
+    );
+
+    const metrics = await collector.collect();
+    expect(metrics.source.available).toBe(true);
+    expect(metrics.utilization?.cpu?.clusterAvgRatio).toBe(0.4);
+    expect(metrics.collectionId).toMatch(/^coll_[a-f0-9]{32}$/);
+  });
+
+  it('processCollection() persists a validated performance-metrics payload', async () => {
+    const insertCollection = vi.fn().mockReturnValue(true);
+    const collector = new PerformanceMetricsCollector(
+      { baseUrl: 'http://unused.example:9090', timeoutMs: 5000, tlsInsecure: false },
+      mockCollectionRepository(insertCollection)
+    );
+
+    const metrics: PerformanceMetrics = {
+      timestamp: new Date().toISOString(),
+      collectionId: 'coll_' + 'b'.repeat(32),
+      clusterId: 'cls_' + 'c'.repeat(32),
+      source: { available: true },
+      utilization: {
+        cpu: { clusterAvgRatio: 0.5 },
+        memory: { clusterAvgRatio: 0.6 },
+      },
+    };
+
+    await collector.processCollection(metrics);
+
+    expect(insertCollection).toHaveBeenCalledTimes(1);
+    const payload = insertCollection.mock.calls[0][0] as { type: string; data: PerformanceMetrics };
+    expect(payload.type).toBe('performance-metrics');
+    expect(payload.data.source.available).toBe(true);
+  });
+
+  it('processCollection() throws when durable insert fails', async () => {
+    const insertCollection = vi.fn().mockReturnValue(false);
+    const collector = new PerformanceMetricsCollector(
+      { baseUrl: 'http://unused.example:9090', timeoutMs: 5000, tlsInsecure: false },
+      mockCollectionRepository(insertCollection)
+    );
+
+    const metrics: PerformanceMetrics = {
+      timestamp: new Date().toISOString(),
+      collectionId: 'coll_' + 'd'.repeat(32),
+      clusterId: 'cls_' + 'e'.repeat(32),
+      source: { available: true },
+      ratios: { pending_pods_ratio: 0.1 },
+    };
+
+    await expect(collector.processCollection(metrics)).rejects.toThrow(/Failed to persist performance metrics/i);
+  });
+});

--- a/src/collection/collectors/performance-metrics.ts
+++ b/src/collection/collectors/performance-metrics.ts
@@ -1,0 +1,132 @@
+/**
+ * Performance metrics collector: optional Prometheus PromQL aggregates on ~15m schedule.
+ */
+
+import { randomBytes } from 'crypto';
+import type { CollectionPayload, PerformanceMetrics } from '../types.js';
+import { validatePerformanceMetrics } from '../validation.js';
+import type { CollectionRepository } from '../../database/collection-repository.js';
+import { persistCollection } from '../persist-collection.js';
+import { generateClusterIdForCollection } from '../../cluster/identifier.js';
+import { logger } from '../../logging/logger.js';
+import { PrometheusClient } from '../../prometheus/client.js';
+import type { PrometheusClientConfig } from '../../prometheus/types.js';
+
+export class PerformanceMetricsCollector {
+  private readonly prometheusClient: PrometheusClient;
+  private readonly collectionRepository: CollectionRepository;
+
+  constructor(prometheusConfig: PrometheusClientConfig, collectionRepository: CollectionRepository) {
+    this.prometheusClient = new PrometheusClient(prometheusConfig);
+    this.collectionRepository = collectionRepository;
+  }
+
+  /**
+   * Queries Prometheus and builds a bounded performance-metrics snapshot.
+   * @throws when Prometheus returns no usable scalar aggregates (failed tick; no row persisted)
+   */
+  async collect(): Promise<PerformanceMetrics> {
+    logger.info('Starting performance metrics collection');
+
+    const scalars = await this.prometheusClient.queryPerformanceScalars();
+    const utilization: NonNullable<PerformanceMetrics['utilization']> = {};
+    const ratios: Record<string, number> = {};
+
+    if (scalars.cpuClusterAvg !== undefined || scalars.cpuNodeHigh !== undefined) {
+      utilization.cpu = {
+        ...(scalars.cpuClusterAvg !== undefined
+          ? { clusterAvgRatio: scalars.cpuClusterAvg }
+          : {}),
+        ...(scalars.cpuNodeHigh !== undefined
+          ? { nodeHighWatermarkRatio: scalars.cpuNodeHigh }
+          : {}),
+      };
+    }
+
+    if (scalars.memoryClusterAvg !== undefined || scalars.memoryNodeHigh !== undefined) {
+      utilization.memory = {
+        ...(scalars.memoryClusterAvg !== undefined
+          ? { clusterAvgRatio: scalars.memoryClusterAvg }
+          : {}),
+        ...(scalars.memoryNodeHigh !== undefined
+          ? { nodeHighWatermarkRatio: scalars.memoryNodeHigh }
+          : {}),
+      };
+    }
+
+    if (scalars.pendingPodsRatio !== undefined) {
+      ratios.pending_pods_ratio = scalars.pendingPodsRatio;
+    }
+
+    const hasUtilization =
+      (utilization.cpu && Object.keys(utilization.cpu).length > 0) ||
+      (utilization.memory && Object.keys(utilization.memory).length > 0);
+    const hasRatios = Object.keys(ratios).length > 0;
+
+    if (!hasUtilization && !hasRatios) {
+      const message =
+        'Performance metrics collection failed: Prometheus returned no usable scalar aggregates';
+      logger.error(message);
+      throw new Error(message);
+    }
+
+    const metrics: PerformanceMetrics = {
+      timestamp: new Date().toISOString(),
+      collectionId: this.generateCollectionId(),
+      clusterId: generateClusterIdForCollection(),
+      source: { available: true },
+      ...(hasUtilization ? { utilization } : {}),
+      ...(hasRatios ? { ratios } : {}),
+    };
+
+    logger.info('Performance metrics collected successfully', {
+      collectionId: metrics.collectionId,
+      hasCpu: Boolean(utilization.cpu),
+      hasMemory: Boolean(utilization.memory),
+      ratioKeys: Object.keys(ratios),
+    });
+
+    return metrics;
+  }
+
+  async processCollection(metrics: PerformanceMetrics): Promise<void> {
+    try {
+      const validated = validatePerformanceMetrics(metrics);
+
+      const payload: CollectionPayload = {
+        version: 'v1.0.0',
+        type: 'performance-metrics',
+        data: validated,
+        sanitization: {
+          rulesApplied: ['bounded-ratios', 'hashed-cluster-id'],
+          timestamp: new Date().toISOString(),
+        },
+      };
+
+      logger.info('Persisting performance metrics collection', {
+        collectionId: validated.collectionId,
+      });
+      const inserted = persistCollection(this.collectionRepository, payload);
+      if (!inserted) {
+        throw new Error(
+          `Failed to persist performance metrics collection: ${validated.collectionId}`
+        );
+      }
+
+      logger.info('Performance metrics collection processed successfully', {
+        collectionId: validated.collectionId,
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error('Failed to process performance metrics collection', {
+        error: errorMessage,
+        collectionId: metrics.collectionId,
+      });
+      throw error;
+    }
+  }
+
+  private generateCollectionId(): string {
+    return `coll_${randomBytes(16).toString('hex')}`;
+  }
+}

--- a/src/collection/validation.ts
+++ b/src/collection/validation.ts
@@ -2,7 +2,12 @@
  * Schema validation utilities for collection data
  */
 
-import type { ClusterMetadata, ResourceInventory, ResourceConfigurationPatternsData } from './types.js';
+import type {
+  ClusterMetadata,
+  ResourceInventory,
+  ResourceConfigurationPatternsData,
+  PerformanceMetrics,
+} from './types.js';
 
 /**
  * Custom error class for validation failures
@@ -431,5 +436,108 @@ export function validateResourceConfigurationPatterns(data: unknown): ResourceCo
 
   // Return validated data (type assertion is safe after all validations)
   return data as ResourceConfigurationPatternsData;
+}
+
+function assertRatio(value: unknown, fieldPath: string): number {
+  const n = assertNumber(value, fieldPath);
+  if (n < 0 || n > 1) {
+    throw new ValidationError(fieldPath, `expected ratio in [0, 1], got ${n}`);
+  }
+  return n;
+}
+
+/**
+ * Validates performance metrics against schema
+ */
+export function validatePerformanceMetrics(data: unknown): PerformanceMetrics {
+  const obj = assertObject(data, 'root');
+
+  const timestamp = assertString(obj.timestamp, 'timestamp');
+  assertISO8601Timestamp(timestamp, 'timestamp');
+
+  const collectionId = assertString(obj.collectionId, 'collectionId');
+  assertPattern(collectionId, /^coll_[a-z0-9]{32}$/, 'collectionId', 'collection ID format "coll_[32-char-hash]"');
+
+  const clusterId = assertString(obj.clusterId, 'clusterId');
+  assertPattern(clusterId, /^cls_[a-z0-9]{32}$/, 'clusterId', 'cluster ID format "cls_[32-char-hash]"');
+
+  const sourceObj = assertObject(obj.source, 'source');
+  const available = sourceObj.available;
+  if (typeof available !== 'boolean') {
+    throw new ValidationError('source.available', `expected boolean, got ${typeof available}`);
+  }
+  let reason: string | undefined;
+  if (sourceObj.reason !== undefined) {
+    reason = assertString(sourceObj.reason, 'source.reason');
+    if (reason.length > 200) {
+      throw new ValidationError('source.reason', `expected max 200 characters, got ${reason.length}`);
+    }
+  }
+
+  let utilization: PerformanceMetrics['utilization'];
+  if (obj.utilization !== undefined) {
+    const utilObj = assertObject(obj.utilization, 'utilization');
+    const cpu = utilObj.cpu !== undefined ? assertObject(utilObj.cpu, 'utilization.cpu') : undefined;
+    const memory =
+      utilObj.memory !== undefined ? assertObject(utilObj.memory, 'utilization.memory') : undefined;
+
+    const cpuOut: NonNullable<PerformanceMetrics['utilization']>['cpu'] = {};
+    if (cpu?.clusterAvgRatio !== undefined) {
+      cpuOut.clusterAvgRatio = assertRatio(cpu.clusterAvgRatio, 'utilization.cpu.clusterAvgRatio');
+    }
+    if (cpu?.nodeHighWatermarkRatio !== undefined) {
+      cpuOut.nodeHighWatermarkRatio = assertRatio(
+        cpu.nodeHighWatermarkRatio,
+        'utilization.cpu.nodeHighWatermarkRatio'
+      );
+    }
+
+    const memoryOut: NonNullable<PerformanceMetrics['utilization']>['memory'] = {};
+    if (memory?.clusterAvgRatio !== undefined) {
+      memoryOut.clusterAvgRatio = assertRatio(
+        memory.clusterAvgRatio,
+        'utilization.memory.clusterAvgRatio'
+      );
+    }
+    if (memory?.nodeHighWatermarkRatio !== undefined) {
+      memoryOut.nodeHighWatermarkRatio = assertRatio(
+        memory.nodeHighWatermarkRatio,
+        'utilization.memory.nodeHighWatermarkRatio'
+      );
+    }
+
+    utilization = {
+      ...(Object.keys(cpuOut).length > 0 ? { cpu: cpuOut } : {}),
+      ...(Object.keys(memoryOut).length > 0 ? { memory: memoryOut } : {}),
+    };
+    if (Object.keys(utilization).length === 0) {
+      utilization = undefined;
+    }
+  }
+
+  let ratios: Record<string, number> | undefined;
+  if (obj.ratios !== undefined) {
+    const ratiosObj = assertObject(obj.ratios, 'ratios');
+    const keys = Object.keys(ratiosObj);
+    if (keys.length > 16) {
+      throw new ValidationError('ratios', `expected at most 16 keys, got ${keys.length}`);
+    }
+    ratios = {};
+    for (const key of keys) {
+      if (key.length > 64) {
+        throw new ValidationError(`ratios["${key}"]`, `key length must be <= 64, got ${key.length}`);
+      }
+      ratios[key] = assertRatio(ratiosObj[key], `ratios["${key}"]`);
+    }
+  }
+
+  return {
+    timestamp,
+    collectionId,
+    clusterId,
+    source: { available, ...(reason !== undefined ? { reason } : {}) },
+    ...(utilization !== undefined ? { utilization } : {}),
+    ...(ratios !== undefined ? { ratios } : {}),
+  };
 }
 

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -169,3 +169,64 @@ describe('loadConfig — resource inventory interval', () => {
     await expect(loadConfig()).rejects.toThrow(/RESOURCE_INVENTORY_INTERVAL_SECONDS/);
   });
 });
+
+describe('loadConfig — performance metrics / Prometheus', () => {
+  const promKeys = [
+    'PROMETHEUS_BASE_URL',
+    'PROMETHEUS_TIMEOUT_MS',
+    'PROMETHEUS_TLS_INSECURE',
+    'PERFORMANCE_METRICS_INTERVAL_SECONDS',
+  ] as const;
+  const promSnapshots: Partial<Record<(typeof promKeys)[number], string | undefined>> = {};
+
+  beforeEach(() => {
+    for (const key of promKeys) {
+      promSnapshots[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of promKeys) {
+      const v = promSnapshots[key];
+      if (v === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = v;
+      }
+    }
+  });
+
+  it('defaults performance interval to 900 seconds without Prometheus URL', async () => {
+    const config = await loadConfig();
+    expect(config.performanceMetricsIntervalSeconds).toBe(900);
+    expect(config.prometheus).toBeUndefined();
+  });
+
+  it('includes prometheus config when PROMETHEUS_BASE_URL is set', async () => {
+    process.env.PROMETHEUS_BASE_URL = 'http://prometheus.monitoring.svc:9090';
+    process.env.PROMETHEUS_TIMEOUT_MS = '45000';
+    const config = await loadConfig();
+    expect(config.prometheus).toEqual({
+      baseUrl: 'http://prometheus.monitoring.svc:9090',
+      timeoutMs: 45000,
+      tlsInsecure: false,
+    });
+  });
+
+  it('rejects performance interval below minimum', async () => {
+    process.env.PERFORMANCE_METRICS_INTERVAL_SECONDS = '299';
+    await expect(loadConfig()).rejects.toThrow(/PERFORMANCE_METRICS_INTERVAL_SECONDS/);
+  });
+
+  it('rejects invalid Prometheus URL during config load', async () => {
+    process.env.PROMETHEUS_BASE_URL = ':::bad:::';
+    await expect(loadConfig()).rejects.toThrow(/PROMETHEUS_BASE_URL/);
+  });
+
+  it('rejects invalid Prometheus timeout during config load', async () => {
+    process.env.PROMETHEUS_BASE_URL = 'http://prom.example:9090';
+    process.env.PROMETHEUS_TIMEOUT_MS = '999';
+    await expect(loadConfig()).rejects.toThrow(/PROMETHEUS_TIMEOUT_MS/);
+  });
+});

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,6 +1,7 @@
 import type { Config } from './types.js';
 import { logger } from '../logging/logger.js';
 import { isPillar } from '../assessment/types.js';
+import { parsePrometheusConfigFromEnv } from '../prometheus/env-config.js';
 
 const ASSESSMENT_MODES = ['full', 'pillar', 'single-check'] as const;
 type AssessmentMode = (typeof ASSESSMENT_MODES)[number];
@@ -13,6 +14,8 @@ const ASSESSMENT_TIMEOUT_MAX_SECONDS = 7 * 24 * 3600;
 const RESOURCE_INVENTORY_INTERVAL_MIN_SECONDS = 1800;
 /** Minimum interval for Argo CD Application API collection (30 minutes). */
 const ARGOCD_APP_STATUS_INTERVAL_MIN_SECONDS = 1800;
+/** Minimum interval for performance metrics collection (5 minutes). */
+const PERFORMANCE_METRICS_INTERVAL_MIN_SECONDS = 300;
 
 /**
  * Parses a positive base-10 integer from env or a default string.
@@ -182,6 +185,13 @@ export async function loadConfig(): Promise<Config> {
   const aiConformanceChecklistSource = parseAiConformanceChecklistSource(
     process.env.AI_CONFORMANCE_CHECKLIST_SOURCE
   );
+  const performanceMetricsIntervalSeconds = parsePositiveInt(
+    'PERFORMANCE_METRICS_INTERVAL_SECONDS',
+    process.env.PERFORMANCE_METRICS_INTERVAL_SECONDS,
+    '900',
+    PERFORMANCE_METRICS_INTERVAL_MIN_SECONDS
+  );
+  const prometheus = parsePrometheusConfigFromEnv();
 
   const config: Config = {
     logLevel,
@@ -203,6 +213,8 @@ export async function loadConfig(): Promise<Config> {
     aiConformanceEnabled,
     aiConformanceIntervalSeconds,
     aiConformanceChecklistSource,
+    performanceMetricsIntervalSeconds,
+    ...(prometheus !== undefined ? { prometheus } : {}),
   };
 
   logger.info('Collection intervals configured', {
@@ -239,6 +251,14 @@ export async function loadConfig(): Promise<Config> {
     aiConformanceIntervalOverridden: process.env.AI_CONFORMANCE_INTERVAL_SECONDS !== undefined,
     aiConformanceChecklistSourceOverridden:
       process.env.AI_CONFORMANCE_CHECKLIST_SOURCE !== undefined,
+  });
+
+  logger.info('Performance metrics schedule configured', {
+    performanceMetricsIntervalSeconds: config.performanceMetricsIntervalSeconds,
+    performanceMetricsIntervalOverridden:
+      process.env.PERFORMANCE_METRICS_INTERVAL_SECONDS !== undefined,
+    prometheusConfigured: config.prometheus !== undefined,
+    prometheusBaseUrl: config.prometheus?.baseUrl ?? null,
   });
 
   return config;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,3 +1,5 @@
+import type { PrometheusClientConfig } from '../prometheus/types.js';
+
 /**
  * Configuration interface for kube9-operator
  */
@@ -101,4 +103,15 @@ export interface Config {
    * Checklist source for conformance evaluation. Only bundled data is supported today.
    */
   aiConformanceChecklistSource: 'bundled';
+
+  /**
+   * Performance metrics collection interval in seconds (Prometheus-backed when configured).
+   * Default: 900 (15 minutes). Minimum: 300 (5 minutes).
+   */
+  performanceMetricsIntervalSeconds: number;
+
+  /**
+   * Optional Prometheus outbound client. Present only when PROMETHEUS_BASE_URL is non-empty.
+   */
+  prometheus?: PrometheusClientConfig;
 }

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -13,6 +13,7 @@ import { CollectionScheduler } from './collection/scheduler.js';
 import { ClusterMetadataCollector } from './collection/collectors/cluster-metadata.js';
 import { ResourceInventoryCollector } from './collection/collectors/resource-inventory.js';
 import { ResourceConfigurationPatternsCollector } from './collection/collectors/resource-configuration-patterns.js';
+import { PerformanceMetricsCollector } from './collection/collectors/performance-metrics.js';
 import { CollectionRepository } from './database/collection-repository.js';
 import { recordCollection } from './collection/metrics.js';
 import { collectionStatsTracker } from './collection/stats-tracker.js';
@@ -331,6 +332,45 @@ export async function startOperator() {
         }
       }
     );
+
+    if (config.prometheus) {
+      try {
+        const performanceMetricsCollector = new PerformanceMetricsCollector(
+          config.prometheus,
+          collectionRepository
+        );
+
+        collectionScheduler.register(
+          'performance-metrics',
+          config.performanceMetricsIntervalSeconds,
+          300,
+          300,
+          async () => {
+            const startTime = Date.now();
+            try {
+              const metrics = await performanceMetricsCollector.collect();
+              await performanceMetricsCollector.processCollection(metrics);
+
+              const durationSeconds = (Date.now() - startTime) / 1000;
+              recordCollection('performance-metrics', 'success', durationSeconds);
+              collectionStatsTracker.recordSuccess('performance-metrics');
+            } catch (error) {
+              const errorMessage = error instanceof Error ? error.message : String(error);
+              logger.error('Performance metrics collection failed', { error: errorMessage });
+
+              const durationSeconds = (Date.now() - startTime) / 1000;
+              recordCollection('performance-metrics', 'failed', durationSeconds);
+              collectionStatsTracker.recordFailure('performance-metrics');
+            }
+          }
+        );
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.error('Failed to register performance-metrics collector', { error: errorMessage });
+      }
+    } else {
+      logger.info('Performance metrics collector not registered (PROMETHEUS_BASE_URL unset)');
+    }
 
     collectionScheduler.register(
       'workload-image-scan',

--- a/src/prometheus/client.test.ts
+++ b/src/prometheus/client.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { PrometheusClient, PERFORMANCE_PROMQL } from './client.js';
+
+function promSuccessBody(value: string): string {
+  return JSON.stringify({
+    status: 'success',
+    data: {
+      resultType: 'vector',
+      result: [{ metric: {}, value: [1_700_000_000, value] }],
+    },
+  });
+}
+
+describe('PrometheusClient', () => {
+  let server: Server | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve, reject) => {
+        server!.close((err) => (err ? reject(err) : resolve()));
+      });
+      server = null;
+    }
+  });
+
+  async function startMock(
+    handler: (query: string) => { status: number; body: string }
+  ): Promise<string> {
+    server = createServer((req, res) => {
+      const url = new URL(req.url ?? '/', 'http://localhost');
+      const query = url.searchParams.get('query') ?? '';
+      const { status, body } = handler(query);
+      res.writeHead(status, { 'content-type': 'application/json' });
+      res.end(body);
+    });
+    await new Promise<void>((resolve) => server!.listen(0, resolve));
+    const port = (server.address() as AddressInfo).port;
+    return `http://127.0.0.1:${port}`;
+  }
+
+  it('instantQueryScalar returns a ratio for success responses', async () => {
+    const baseUrl = await startMock((query) => {
+      if (query === 'up') {
+        return { status: 200, body: promSuccessBody('0.42') };
+      }
+      return { status: 200, body: promSuccessBody('0') };
+    });
+
+    const client = new PrometheusClient({ baseUrl, timeoutMs: 5000, tlsInsecure: false });
+    const value = await client.instantQueryScalar('up');
+    expect(value).toBe(0.42);
+  });
+
+  it('instantQueryScalar returns null for empty vector results', async () => {
+    const baseUrl = await startMock(() => ({
+      status: 200,
+      body: JSON.stringify({
+        status: 'success',
+        data: { resultType: 'vector', result: [] },
+      }),
+    }));
+
+    const client = new PrometheusClient({ baseUrl, timeoutMs: 5000, tlsInsecure: false });
+    expect(await client.instantQueryScalar('up')).toBeNull();
+  });
+
+  it('instantQueryScalar returns null for non-2xx HTTP status', async () => {
+    const baseUrl = await startMock(() => ({
+      status: 503,
+      body: JSON.stringify({ status: 'error', error: 'unavailable' }),
+    }));
+
+    const client = new PrometheusClient({ baseUrl, timeoutMs: 5000, tlsInsecure: false });
+    expect(await client.instantQueryScalar('up')).toBeNull();
+  });
+
+  it('instantQueryScalar returns null for ratios outside [0, 1]', async () => {
+    const baseUrl = await startMock(() => ({
+      status: 200,
+      body: promSuccessBody('1.5'),
+    }));
+
+    const client = new PrometheusClient({ baseUrl, timeoutMs: 5000, tlsInsecure: false });
+    expect(await client.instantQueryScalar('up')).toBeNull();
+  });
+
+  it('queryPerformanceScalars collects usable keys only', async () => {
+    const baseUrl = await startMock((query) => {
+      if (query === PERFORMANCE_PROMQL.cpuClusterAvg) {
+        return { status: 200, body: promSuccessBody('0.25') };
+      }
+      return {
+        status: 200,
+        body: JSON.stringify({
+          status: 'success',
+          data: { resultType: 'vector', result: [] },
+        }),
+      };
+    });
+
+    const client = new PrometheusClient({ baseUrl, timeoutMs: 5000, tlsInsecure: false });
+    const scalars = await client.queryPerformanceScalars();
+    expect(scalars.cpuClusterAvg).toBe(0.25);
+    expect(scalars.memoryClusterAvg).toBeUndefined();
+  });
+});

--- a/src/prometheus/client.ts
+++ b/src/prometheus/client.ts
@@ -1,0 +1,112 @@
+/**
+ * Minimal Prometheus PromQL instant-query HTTP client (Role B outbound).
+ * v1: URL + timeout + TLS only. Never sends operator ServiceAccount credentials.
+ */
+
+import { jsonGet } from '../argocd/api-http.js';
+import { logger } from '../logging/logger.js';
+import type { PromInstantQueryResponse, PrometheusClientConfig } from './types.js';
+
+/** v1 PromQL queries for bounded utilization / ratio aggregates. */
+export const PERFORMANCE_PROMQL = {
+  cpuClusterAvg: 'avg(1 - rate(node_cpu_seconds_total{mode="idle"}[5m]))',
+  cpuNodeHigh: 'max(1 - rate(node_cpu_seconds_total{mode="idle"}[5m]))',
+  memoryClusterAvg: '1 - avg(node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)',
+  memoryNodeHigh: 'max(1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes))',
+  pendingPodsRatio:
+    'sum(kube_pod_status_phase{phase="Pending"}) / clamp_min(sum(kube_pod_status_phase), 1)',
+} as const;
+
+export type PerformancePromqlKey = keyof typeof PERFORMANCE_PROMQL;
+
+function buildInstantQueryUrl(baseUrl: string, query: string): string {
+  const params = new URLSearchParams({ query });
+  return `${baseUrl}/api/v1/query?${params.toString()}`;
+}
+
+function parseInstantScalar(response: unknown): number | null {
+  if (!response || typeof response !== 'object') {
+    return null;
+  }
+  const body = response as PromInstantQueryResponse;
+  if (body.status !== 'success' || !body.data) {
+    return null;
+  }
+  if (body.data.resultType !== 'vector' || !Array.isArray(body.data.result)) {
+    return null;
+  }
+  if (body.data.result.length === 0) {
+    return null;
+  }
+  const entry = body.data.result[0];
+  if (!entry?.value || entry.value.length < 2) {
+    return null;
+  }
+  const raw = entry.value[1];
+  const n = typeof raw === 'string' ? parseFloat(raw) : Number(raw);
+  if (!Number.isFinite(n)) {
+    return null;
+  }
+  if (n < 0 || n > 1) {
+    return null;
+  }
+  return n;
+}
+
+export class PrometheusClient {
+  private readonly config: PrometheusClientConfig;
+
+  constructor(config: PrometheusClientConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Runs a PromQL instant query and returns a scalar ratio in [0, 1], or null when unusable.
+   */
+  async instantQueryScalar(query: string): Promise<number | null> {
+    const url = buildInstantQueryUrl(this.config.baseUrl, query);
+    const { status, json } = await jsonGet(url, {
+      headers: { accept: 'application/json' },
+      timeoutMs: this.config.timeoutMs,
+      tlsInsecure: this.config.tlsInsecure,
+    });
+
+    if (status < 200 || status >= 300) {
+      logger.debug('Prometheus instant query returned non-success HTTP status', {
+        status,
+        url,
+      });
+      return null;
+    }
+
+    return parseInstantScalar(json);
+  }
+
+  /**
+   * Runs the v1 performance-metrics PromQL set. Returns only keys with usable scalar values.
+   */
+  async queryPerformanceScalars(): Promise<Partial<Record<PerformancePromqlKey, number>>> {
+    const entries = await Promise.all(
+      (Object.entries(PERFORMANCE_PROMQL) as [PerformancePromqlKey, string][]).map(
+        async ([key, query]) => {
+          try {
+            const value = await this.instantQueryScalar(query);
+            return [key, value] as const;
+          } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            logger.debug('Prometheus instant query failed', { key, error: msg });
+            return [key, null] as const;
+          }
+        }
+      )
+    );
+
+    const out: Partial<Record<PerformancePromqlKey, number>> = {};
+    for (const [key, value] of entries) {
+      if (value !== null) {
+        out[key] = value;
+      }
+    }
+    return out;
+  }
+}

--- a/src/prometheus/env-config.test.ts
+++ b/src/prometheus/env-config.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { parsePrometheusConfigFromEnv } from './env-config.js';
+
+const trackedKeys = [
+  'PROMETHEUS_BASE_URL',
+  'PROMETHEUS_TIMEOUT_MS',
+  'PROMETHEUS_TLS_INSECURE',
+] as const;
+
+const snapshots: Partial<Record<(typeof trackedKeys)[number], string | undefined>> = {};
+
+function stashEnv(): void {
+  for (const key of trackedKeys) {
+    snapshots[key] = process.env[key];
+  }
+}
+
+function restoreEnv(): void {
+  for (const key of trackedKeys) {
+    const v = snapshots[key];
+    if (v === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = v;
+    }
+  }
+}
+
+describe('parsePrometheusConfigFromEnv', () => {
+  beforeEach(() => {
+    stashEnv();
+    delete process.env.PROMETHEUS_BASE_URL;
+    delete process.env.PROMETHEUS_TIMEOUT_MS;
+    delete process.env.PROMETHEUS_TLS_INSECURE;
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('returns undefined when PROMETHEUS_BASE_URL is unset', () => {
+    expect(parsePrometheusConfigFromEnv()).toBeUndefined();
+  });
+
+  it('returns undefined when PROMETHEUS_BASE_URL is empty', () => {
+    process.env.PROMETHEUS_BASE_URL = '   ';
+    expect(parsePrometheusConfigFromEnv()).toBeUndefined();
+  });
+
+  it('parses a valid http URL with defaults', () => {
+    process.env.PROMETHEUS_BASE_URL = 'http://prometheus.monitoring.svc:9090/';
+    const cfg = parsePrometheusConfigFromEnv();
+    expect(cfg).toEqual({
+      baseUrl: 'http://prometheus.monitoring.svc:9090',
+      timeoutMs: 30000,
+      tlsInsecure: false,
+    });
+  });
+
+  it('parses timeout and tls flags when set', () => {
+    process.env.PROMETHEUS_BASE_URL = 'https://prom.example:9090';
+    process.env.PROMETHEUS_TIMEOUT_MS = '5000';
+    process.env.PROMETHEUS_TLS_INSECURE = 'true';
+    const cfg = parsePrometheusConfigFromEnv();
+    expect(cfg?.timeoutMs).toBe(5000);
+    expect(cfg?.tlsInsecure).toBe(true);
+  });
+
+  it('rejects malformed URL when set', () => {
+    process.env.PROMETHEUS_BASE_URL = 'not-a-url';
+    expect(() => parsePrometheusConfigFromEnv()).toThrow(/PROMETHEUS_BASE_URL/);
+  });
+
+  it('rejects non-http(s) scheme when set', () => {
+    process.env.PROMETHEUS_BASE_URL = 'ftp://prom.example:9090';
+    expect(() => parsePrometheusConfigFromEnv()).toThrow(/http or https/);
+  });
+
+  it('rejects timeout below minimum when URL is set', () => {
+    process.env.PROMETHEUS_BASE_URL = 'http://prom.example:9090';
+    process.env.PROMETHEUS_TIMEOUT_MS = '500';
+    expect(() => parsePrometheusConfigFromEnv()).toThrow(/PROMETHEUS_TIMEOUT_MS/);
+  });
+
+  it('rejects invalid TLS boolean when URL is set', () => {
+    process.env.PROMETHEUS_BASE_URL = 'http://prom.example:9090';
+    process.env.PROMETHEUS_TLS_INSECURE = 'maybe';
+    expect(() => parsePrometheusConfigFromEnv()).toThrow(/PROMETHEUS_TLS_INSECURE/);
+  });
+});

--- a/src/prometheus/env-config.ts
+++ b/src/prometheus/env-config.ts
@@ -1,0 +1,84 @@
+/**
+ * Parse optional Prometheus outbound client settings from environment.
+ * Unset PROMETHEUS_BASE_URL is a soft miss (returns undefined).
+ */
+
+import type { PrometheusClientConfig } from './types.js';
+
+const PROMETHEUS_TIMEOUT_MIN_MS = 1000;
+
+function parsePositiveInt(
+  envName: string,
+  raw: string | undefined,
+  defaultValue: string,
+  minInclusive: number
+): number {
+  const s = raw !== undefined && raw !== '' ? raw : defaultValue;
+  const n = parseInt(s, 10);
+  if (Number.isNaN(n) || n < minInclusive) {
+    throw new Error(
+      `${envName} must be an integer >= ${minInclusive}${raw !== undefined && raw !== '' ? ` (got "${raw}")` : ''}`
+    );
+  }
+  return n;
+}
+
+function parseEnvBool(raw: string | undefined, defaultValue: boolean, envName: string): boolean {
+  if (raw === undefined || raw === '') {
+    return defaultValue;
+  }
+  const v = raw.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(v)) {
+    return true;
+  }
+  if (['0', 'false', 'no', 'off'].includes(v)) {
+    return false;
+  }
+  throw new Error(`Invalid boolean for ${envName}: "${raw}" (use true/false, 1/0, yes/no)`);
+}
+
+function normalizeBaseUrl(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return '';
+  }
+  return trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed;
+}
+
+function assertValidHttpUrl(baseUrl: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    throw new Error(`PROMETHEUS_BASE_URL must be a valid http or https URL (got "${baseUrl}")`);
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(
+      `PROMETHEUS_BASE_URL must use http or https scheme (got "${parsed.protocol}")`
+    );
+  }
+}
+
+/**
+ * Returns Prometheus client config when PROMETHEUS_BASE_URL is non-empty; otherwise undefined.
+ * Malformed URL or invalid timeout when URL is set fails config load.
+ */
+export function parsePrometheusConfigFromEnv(): PrometheusClientConfig | undefined {
+  const baseUrl = normalizeBaseUrl(process.env.PROMETHEUS_BASE_URL ?? '');
+  if (!baseUrl) {
+    return undefined;
+  }
+
+  assertValidHttpUrl(baseUrl);
+
+  return {
+    baseUrl,
+    timeoutMs: parsePositiveInt(
+      'PROMETHEUS_TIMEOUT_MS',
+      process.env.PROMETHEUS_TIMEOUT_MS,
+      '30000',
+      PROMETHEUS_TIMEOUT_MIN_MS
+    ),
+    tlsInsecure: parseEnvBool(process.env.PROMETHEUS_TLS_INSECURE, false, 'PROMETHEUS_TLS_INSECURE'),
+  };
+}

--- a/src/prometheus/types.ts
+++ b/src/prometheus/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Prometheus PromQL HTTP API response shapes (instant query).
+ */
+
+export interface PromInstantQueryResponse {
+  status: string;
+  data?: {
+    resultType: string;
+    result: PromInstantQueryVectorEntry[];
+  };
+  error?: string;
+  errorType?: string;
+}
+
+export interface PromInstantQueryVectorEntry {
+  metric: Record<string, string>;
+  value: [number, string];
+}
+
+export interface PrometheusClientConfig {
+  /** Normalized base URL without trailing slash (http/https). */
+  baseUrl: string;
+  timeoutMs: number;
+  tlsInsecure: boolean;
+}

--- a/src/status/ai-conformance-summary.test.ts
+++ b/src/status/ai-conformance-summary.test.ts
@@ -32,6 +32,7 @@ const baseConfig: Config = {
   aiConformanceEnabled: true,
   aiConformanceIntervalSeconds: 86400,
   aiConformanceChecklistSource: 'bundled',
+  performanceMetricsIntervalSeconds: 900,
 };
 
 describe('ai-conformance status summary', () => {


### PR DESCRIPTION
## Description

Adds the optional `performance-metrics` collector: when `PROMETHEUS_BASE_URL` is set, the operator registers ~15m scheduler ticks that run bounded PromQL instant queries, persist successful snapshots to SQLite via `CollectionRepository`, and record failed ticks on collection metrics without affecting `/readyz` or global health.

## Motivation and Context

Closes #169 — finish the M8 collector set with config-gated Prometheus outbound (Role B), separate from operator `/metrics` exposition (Role A). Helm env wiring remains #171.

Fixes #169

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated
- [x] All new and existing tests pass (`npm test:unit`)
- [x] I have run the linter and fixed any issues (`npm run lint`)
- [x] Build succeeds (`npm run build`)

**Commands run**
```bash
npm ci
npm run test:unit
npm run lint
npm run build
```

**Coverage highlights**
- Config: unset URL soft miss; invalid URL/timeout fail load; interval default 900 / min 300
- Prometheus client: mock HTTP `/api/v1/query` success, empty vector, non-2xx, out-of-range ratios
- Collector: PromQL success persists `performance-metrics` with `source.available: true`; empty/unusable PromQL omits row (failed tick path)

## How to Test this Work

1. `npm run test:unit` — includes prometheus env/client and performance-metrics collector tests
2. Serve with `PROMETHEUS_BASE_URL` unset: no `performance-metrics` ticks registered
3. Serve with URL pointing at a mock returning PromQL vectors: after a tick, `query collections list --type performance-metrics --format json` returns a row with `source.available: true`
4. Serve with unreachable mock: no new row; `kube9_operator_collection_total{type="performance-metrics",status="failed"}` increments; `/readyz` stays ready

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)

## Additional Notes

- v1 PromQL set uses node_exporter / kube-state-metrics style queries for CPU, memory, and pending pod ratio aggregates
- No ServiceAccount token is sent to Prometheus; URL + timeout + TLS only
- Does not persist `source.available: false` marker rows on unavailable ticks