### PR TITLE
feat(collection): ship always-on security-posture collector (#170)

### DIFF
--- a/src/assessment/scheduled-tick.test.ts
+++ b/src/assessment/scheduled-tick.test.ts
@@ -31,6 +31,7 @@ const baseConfig = {
   aiConformanceIntervalSeconds: 86400,
   aiConformanceChecklistSource: 'bundled' as const,
   performanceMetricsIntervalSeconds: 900,
+  securityPostureIntervalSeconds: 86400,
 } satisfies Config;
 
 const mockKubernetes = {

--- a/src/collection/collectors/security-posture.test.ts
+++ b/src/collection/collectors/security-posture.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as k8s from '@kubernetes/client-node';
+
+vi.mock('../../cluster/identifier.js', () => ({
+  generateClusterIdForCollection: vi.fn(() => 'cls_' + 'a'.repeat(32)),
+}));
+
+import {
+  SecurityPostureCollector,
+  aggregateSecurityPostureFromPods,
+  computeNetworkPolicyCoverage,
+} from './security-posture.js';
+import type { KubernetesClient } from '../../kubernetes/client.js';
+import type { CollectionRepository } from '../../database/collection-repository.js';
+import type { SecurityPosture } from '../types.js';
+import { validateSecurityPosture } from '../validation.js';
+
+function mockCollectionRepository(
+  insertCollection: ReturnType<typeof vi.fn> = vi.fn().mockReturnValue(true)
+): CollectionRepository {
+  return { insertCollection } as unknown as CollectionRepository;
+}
+
+function mockKubernetesClient(options: {
+  pods?: k8s.V1Pod[];
+  namespaces?: k8s.V1Namespace[];
+  networkPolicies?: k8s.V1NetworkPolicy[];
+  podListError?: Error;
+}): KubernetesClient {
+  const listPodForAllNamespaces = options.podListError
+    ? vi.fn().mockRejectedValue(options.podListError)
+    : vi.fn().mockResolvedValue({ items: options.pods ?? [] });
+
+  return {
+    coreApi: {
+      listPodForAllNamespaces,
+      listNamespace: vi.fn().mockResolvedValue({ items: options.namespaces ?? [] }),
+    },
+    networkingApi: {
+      listNetworkPolicyForAllNamespaces: vi
+        .fn()
+        .mockResolvedValue({ items: options.networkPolicies ?? [] }),
+    },
+  } as unknown as KubernetesClient;
+}
+
+describe('aggregateSecurityPostureFromPods', () => {
+  it('counts privileged, hostPath, host network/PID/IPC, and nsaCis rollups', () => {
+    const pod: k8s.V1Pod = {
+      metadata: { name: 'p1', namespace: 'default' },
+      spec: {
+        hostNetwork: true,
+        hostPID: true,
+        automountServiceAccountToken: true,
+        volumes: [{ name: 'hp', hostPath: { path: '/data' } }],
+        containers: [
+          {
+            name: 'c1',
+            securityContext: {
+              privileged: true,
+              allowPrivilegeEscalation: true,
+              runAsNonRoot: false,
+              readOnlyRootFilesystem: false,
+              capabilities: { drop: ['NET_RAW'] },
+            },
+          },
+          {
+            name: 'c2',
+            securityContext: {
+              runAsNonRoot: true,
+              readOnlyRootFilesystem: true,
+              capabilities: { drop: ['ALL'] },
+            },
+          },
+        ],
+      },
+    };
+
+    const counts = aggregateSecurityPostureFromPods([pod]);
+    expect(counts.privilegedContainers).toBe(1);
+    expect(counts.hostPathVolumes).toBe(1);
+    expect(counts.hostNetworkPods).toBe(1);
+    expect(counts.hostPIDPods).toBe(1);
+    expect(counts.hostIPCPods).toBe(0);
+    expect(counts.nsaCisRollups.allowPrivilegeEscalationTrueContainers).toBe(1);
+    expect(counts.nsaCisRollups.runAsNonRootFalseContainers).toBe(1);
+    expect(counts.nsaCisRollups.readOnlyRootFilesystemFalseContainers).toBe(1);
+    expect(counts.nsaCisRollups.capabilitiesNotDroppedAllContainers).toBe(1);
+    expect(counts.nsaCisRollups.automountServiceAccountTokenTruePods).toBe(1);
+    expect(counts.nsaCisRollups.hostNamespacesPods).toBe(1);
+  });
+
+  it('treats unset automountServiceAccountToken as true', () => {
+    const pod: k8s.V1Pod = {
+      metadata: { name: 'p1', namespace: 'default' },
+      spec: { containers: [{ name: 'c1' }] },
+    };
+
+    const counts = aggregateSecurityPostureFromPods([pod]);
+    expect(counts.nsaCisRollups.automountServiceAccountTokenTruePods).toBe(1);
+  });
+
+  it('does not count automountServiceAccountToken when explicitly false', () => {
+    const pod: k8s.V1Pod = {
+      metadata: { name: 'p1', namespace: 'default' },
+      spec: {
+        automountServiceAccountToken: false,
+        containers: [{ name: 'c1' }],
+      },
+    };
+
+    const counts = aggregateSecurityPostureFromPods([pod]);
+    expect(counts.nsaCisRollups.automountServiceAccountTokenTruePods).toBe(0);
+  });
+});
+
+describe('computeNetworkPolicyCoverage', () => {
+  it('computes coverageRatio when namespaces exist', () => {
+    const namespaces: k8s.V1Namespace[] = [
+      { metadata: { name: 'a' } },
+      { metadata: { name: 'b' } },
+      { metadata: { name: 'c' } },
+    ];
+    const networkPolicies: k8s.V1NetworkPolicy[] = [
+      { metadata: { name: 'np1', namespace: 'a' } },
+      { metadata: { name: 'np2', namespace: 'b' } },
+    ];
+
+    const coverage = computeNetworkPolicyCoverage(namespaces, networkPolicies);
+    expect(coverage).toEqual({
+      namespacesTotal: 3,
+      namespacesWithNetworkPolicy: 2,
+      coverageRatio: 2 / 3,
+    });
+  });
+
+  it('omits coverageRatio when namespacesTotal is 0', () => {
+    const coverage = computeNetworkPolicyCoverage([], []);
+    expect(coverage).toEqual({
+      namespacesTotal: 0,
+      namespacesWithNetworkPolicy: 0,
+    });
+    expect(coverage.coverageRatio).toBeUndefined();
+  });
+});
+
+describe('validateSecurityPosture', () => {
+  it('requires all six nsaCisRollups keys', () => {
+    const incomplete = {
+      timestamp: new Date().toISOString(),
+      collectionId: 'coll_' + 'b'.repeat(32),
+      clusterId: 'cls_' + 'c'.repeat(32),
+      privilegedHost: {
+        privilegedContainers: 0,
+        hostPathVolumes: 0,
+        hostNetworkPods: 0,
+        hostPIDPods: 0,
+        hostIPCPods: 0,
+      },
+      networkPolicyCoverage: {
+        namespacesTotal: 1,
+        namespacesWithNetworkPolicy: 0,
+      },
+      nsaCisRollups: {
+        allowPrivilegeEscalationTrueContainers: 0,
+        runAsNonRootFalseContainers: 0,
+        readOnlyRootFilesystemFalseContainers: 0,
+        capabilitiesNotDroppedAllContainers: 0,
+        automountServiceAccountTokenTruePods: 0,
+      },
+    };
+
+    expect(() => validateSecurityPosture(incomplete)).toThrow(/expected exactly 6 keys/);
+  });
+
+  it('rejects unknown nsaCisRollups keys', () => {
+    const withExtra = {
+      timestamp: new Date().toISOString(),
+      collectionId: 'coll_' + 'b'.repeat(32),
+      clusterId: 'cls_' + 'c'.repeat(32),
+      privilegedHost: {
+        privilegedContainers: 0,
+        hostPathVolumes: 0,
+        hostNetworkPods: 0,
+      },
+      networkPolicyCoverage: {
+        namespacesTotal: 0,
+        namespacesWithNetworkPolicy: 0,
+      },
+      nsaCisRollups: {
+        allowPrivilegeEscalationTrueContainers: 0,
+        runAsNonRootFalseContainers: 0,
+        readOnlyRootFilesystemFalseContainers: 0,
+        capabilitiesNotDroppedAllContainers: 0,
+        automountServiceAccountTokenTruePods: 0,
+        hostNamespacesPods: 0,
+        extraKey: 1,
+      },
+    };
+
+    expect(() => validateSecurityPosture(withExtra)).toThrow(/expected exactly 6 keys, got 7/);
+  });
+});
+
+describe('SecurityPostureCollector', () => {
+  it('collect() returns a complete security-posture snapshot from API fixtures', async () => {
+    const collector = new SecurityPostureCollector(
+      mockKubernetesClient({
+        pods: [
+          {
+            metadata: { name: 'p1', namespace: 'default' },
+            spec: {
+              containers: [{ name: 'c1', securityContext: { privileged: true } }],
+            },
+          },
+        ],
+        namespaces: [{ metadata: { name: 'default' } }],
+        networkPolicies: [],
+      }),
+      mockCollectionRepository()
+    );
+
+    const posture = await collector.collect();
+    expect(posture.privilegedHost.privilegedContainers).toBe(1);
+    expect(posture.networkPolicyCoverage.namespacesTotal).toBe(1);
+    expect(posture.networkPolicyCoverage.namespacesWithNetworkPolicy).toBe(0);
+    expect(posture.nsaCisRollups.hostNamespacesPods).toBe(0);
+    expect(Object.keys(posture.nsaCisRollups)).toHaveLength(6);
+    expect(posture.collectionId).toMatch(/^coll_[a-f0-9]{32}$/);
+  });
+
+  it('collect() rejects when a required list fails mid-tick', async () => {
+    const collector = new SecurityPostureCollector(
+      mockKubernetesClient({
+        podListError: new Error('pods forbidden'),
+        namespaces: [{ metadata: { name: 'default' } }],
+      }),
+      mockCollectionRepository()
+    );
+
+    await expect(collector.collect()).rejects.toThrow(/pods forbidden/i);
+  });
+
+  it('processCollection() persists a validated security-posture payload', async () => {
+    const insertCollection = vi.fn().mockReturnValue(true);
+    const collector = new SecurityPostureCollector(
+      mockKubernetesClient({}),
+      mockCollectionRepository(insertCollection)
+    );
+
+    const posture: SecurityPosture = {
+      timestamp: new Date().toISOString(),
+      collectionId: 'coll_' + 'b'.repeat(32),
+      clusterId: 'cls_' + 'c'.repeat(32),
+      privilegedHost: {
+        privilegedContainers: 1,
+        hostPathVolumes: 0,
+        hostNetworkPods: 0,
+        hostPIDPods: 0,
+        hostIPCPods: 0,
+      },
+      networkPolicyCoverage: {
+        namespacesTotal: 2,
+        namespacesWithNetworkPolicy: 1,
+        coverageRatio: 0.5,
+      },
+      nsaCisRollups: {
+        allowPrivilegeEscalationTrueContainers: 0,
+        runAsNonRootFalseContainers: 1,
+        readOnlyRootFilesystemFalseContainers: 1,
+        capabilitiesNotDroppedAllContainers: 1,
+        automountServiceAccountTokenTruePods: 1,
+        hostNamespacesPods: 0,
+      },
+    };
+
+    await collector.processCollection(posture);
+
+    expect(insertCollection).toHaveBeenCalledTimes(1);
+    const payload = insertCollection.mock.calls[0][0];
+    expect(payload.type).toBe('security-posture');
+    expect(payload.data.collectionId).toBe(posture.collectionId);
+  });
+
+  it('processCollection() throws when persist returns false', async () => {
+    const insertCollection = vi.fn().mockReturnValue(false);
+    const collector = new SecurityPostureCollector(
+      mockKubernetesClient({}),
+      mockCollectionRepository(insertCollection)
+    );
+
+    const posture: SecurityPosture = {
+      timestamp: new Date().toISOString(),
+      collectionId: 'coll_' + 'b'.repeat(32),
+      clusterId: 'cls_' + 'c'.repeat(32),
+      privilegedHost: {
+        privilegedContainers: 0,
+        hostPathVolumes: 0,
+        hostNetworkPods: 0,
+        hostPIDPods: 0,
+        hostIPCPods: 0,
+      },
+      networkPolicyCoverage: {
+        namespacesTotal: 0,
+        namespacesWithNetworkPolicy: 0,
+      },
+      nsaCisRollups: {
+        allowPrivilegeEscalationTrueContainers: 0,
+        runAsNonRootFalseContainers: 0,
+        readOnlyRootFilesystemFalseContainers: 0,
+        capabilitiesNotDroppedAllContainers: 0,
+        automountServiceAccountTokenTruePods: 0,
+        hostNamespacesPods: 0,
+      },
+    };
+
+    await expect(collector.processCollection(posture)).rejects.toThrow(/Failed to persist/i);
+  });
+});

--- a/src/collection/collectors/security-posture.ts
+++ b/src/collection/collectors/security-posture.ts
@@ -1,0 +1,251 @@
+/**
+ * Security posture collector: bounded cluster-API aggregate snapshots on ~24h schedule.
+ */
+
+import { randomBytes } from 'crypto';
+import * as k8s from '@kubernetes/client-node';
+import type { CollectionPayload, SecurityPosture, SecurityPostureNsaCisRollups } from '../types.js';
+import { validateSecurityPosture } from '../validation.js';
+import type { CollectionRepository } from '../../database/collection-repository.js';
+import { persistCollection } from '../persist-collection.js';
+import { KubernetesClient } from '../../kubernetes/client.js';
+import { generateClusterIdForCollection } from '../../cluster/identifier.js';
+import { logger } from '../../logging/logger.js';
+
+export interface SecurityPostureAggregateCounts {
+  privilegedContainers: number;
+  hostPathVolumes: number;
+  hostNetworkPods: number;
+  hostPIDPods: number;
+  hostIPCPods: number;
+  nsaCisRollups: SecurityPostureNsaCisRollups;
+  automountServiceAccountTokenTruePods: number;
+}
+
+function normalizeCapability(cap: string): string {
+  return cap.replace(/^CAP_/i, '').toUpperCase();
+}
+
+function capabilitiesDropIncludesAll(drop: string[] | undefined): boolean {
+  if (!drop || drop.length === 0) {
+    return false;
+  }
+  return drop.some((cap) => normalizeCapability(cap) === 'ALL');
+}
+
+function podContainers(pod: k8s.V1Pod): k8s.V1Container[] {
+  return [
+    ...(pod.spec?.containers ?? []),
+    ...(pod.spec?.initContainers ?? []),
+    ...(pod.spec?.ephemeralContainers ?? []),
+  ];
+}
+
+function isAutomountServiceAccountTokenTrue(pod: k8s.V1Pod): boolean {
+  const value = pod.spec?.automountServiceAccountToken;
+  return value !== false;
+}
+
+/**
+ * Walks pods and returns bounded security-posture aggregate counts.
+ */
+export function aggregateSecurityPostureFromPods(pods: k8s.V1Pod[]): SecurityPostureAggregateCounts {
+  const counts: SecurityPostureAggregateCounts = {
+    privilegedContainers: 0,
+    hostPathVolumes: 0,
+    hostNetworkPods: 0,
+    hostPIDPods: 0,
+    hostIPCPods: 0,
+    automountServiceAccountTokenTruePods: 0,
+    nsaCisRollups: {
+      allowPrivilegeEscalationTrueContainers: 0,
+      runAsNonRootFalseContainers: 0,
+      readOnlyRootFilesystemFalseContainers: 0,
+      capabilitiesNotDroppedAllContainers: 0,
+      automountServiceAccountTokenTruePods: 0,
+      hostNamespacesPods: 0,
+    },
+  };
+
+  for (const pod of pods) {
+    const podSecurityContext = pod.spec?.securityContext;
+
+    if (pod.spec?.hostNetwork === true) {
+      counts.hostNetworkPods++;
+    }
+    if (pod.spec?.hostPID === true) {
+      counts.hostPIDPods++;
+    }
+    if (pod.spec?.hostIPC === true) {
+      counts.hostIPCPods++;
+    }
+    if (pod.spec?.hostPID === true || pod.spec?.hostIPC === true) {
+      counts.nsaCisRollups.hostNamespacesPods++;
+    }
+    if (isAutomountServiceAccountTokenTrue(pod)) {
+      counts.automountServiceAccountTokenTruePods++;
+      counts.nsaCisRollups.automountServiceAccountTokenTruePods++;
+    }
+
+    for (const volume of pod.spec?.volumes ?? []) {
+      if (volume.hostPath) {
+        counts.hostPathVolumes++;
+      }
+    }
+
+    for (const container of podContainers(pod)) {
+      const securityContext = container.securityContext;
+
+      if (securityContext?.privileged === true) {
+        counts.privilegedContainers++;
+      }
+
+      const effectiveAllowPrivilegeEscalation = securityContext?.allowPrivilegeEscalation;
+      if (effectiveAllowPrivilegeEscalation === true) {
+        counts.nsaCisRollups.allowPrivilegeEscalationTrueContainers++;
+      }
+
+      const effectiveRunAsNonRoot = securityContext?.runAsNonRoot ?? podSecurityContext?.runAsNonRoot;
+      if (effectiveRunAsNonRoot !== true) {
+        counts.nsaCisRollups.runAsNonRootFalseContainers++;
+      }
+
+      const effectiveReadOnlyRootFilesystem = securityContext?.readOnlyRootFilesystem;
+      if (effectiveReadOnlyRootFilesystem !== true) {
+        counts.nsaCisRollups.readOnlyRootFilesystemFalseContainers++;
+      }
+
+      const drop = securityContext?.capabilities?.drop;
+      if (!capabilitiesDropIncludesAll(drop)) {
+        counts.nsaCisRollups.capabilitiesNotDroppedAllContainers++;
+      }
+    }
+  }
+
+  return counts;
+}
+
+export function computeNetworkPolicyCoverage(
+  namespaces: k8s.V1Namespace[],
+  networkPolicies: k8s.V1NetworkPolicy[]
+): SecurityPosture['networkPolicyCoverage'] {
+  const namespacesTotal = namespaces.length;
+  const namespaceNames = new Set(
+    namespaces.map((ns) => ns.metadata?.name).filter((name): name is string => Boolean(name))
+  );
+
+  const coveredNamespaces = new Set<string>();
+  for (const policy of networkPolicies) {
+    const ns = policy.metadata?.namespace;
+    if (ns && namespaceNames.has(ns)) {
+      coveredNamespaces.add(ns);
+    }
+  }
+
+  const namespacesWithNetworkPolicy = coveredNamespaces.size;
+  const coverage: SecurityPosture['networkPolicyCoverage'] = {
+    namespacesTotal,
+    namespacesWithNetworkPolicy,
+  };
+
+  if (namespacesTotal > 0) {
+    coverage.coverageRatio = namespacesWithNetworkPolicy / namespacesTotal;
+  }
+
+  return coverage;
+}
+
+export class SecurityPostureCollector {
+  private readonly kubernetesClient: KubernetesClient;
+  private readonly collectionRepository: CollectionRepository;
+
+  constructor(kubernetesClient: KubernetesClient, collectionRepository: CollectionRepository) {
+    this.kubernetesClient = kubernetesClient;
+    this.collectionRepository = collectionRepository;
+  }
+
+  /**
+   * Gathers cluster-API aggregates for a security-posture snapshot.
+   * @throws when any required list/read fails (failed tick; no row persisted)
+   */
+  async collect(): Promise<SecurityPosture> {
+    logger.info('Starting security posture collection');
+
+    const [podList, namespaceList, networkPolicyList] = await Promise.all([
+      this.kubernetesClient.coreApi.listPodForAllNamespaces(),
+      this.kubernetesClient.coreApi.listNamespace(),
+      this.kubernetesClient.networkingApi.listNetworkPolicyForAllNamespaces(),
+    ]);
+
+    const pods = podList.items ?? [];
+    const namespaces = namespaceList.items ?? [];
+    const networkPolicies = networkPolicyList.items ?? [];
+
+    const aggregates = aggregateSecurityPostureFromPods(pods);
+    const networkPolicyCoverage = computeNetworkPolicyCoverage(namespaces, networkPolicies);
+
+    const posture: SecurityPosture = {
+      timestamp: new Date().toISOString(),
+      collectionId: this.generateCollectionId(),
+      clusterId: generateClusterIdForCollection(),
+      privilegedHost: {
+        privilegedContainers: aggregates.privilegedContainers,
+        hostPathVolumes: aggregates.hostPathVolumes,
+        hostNetworkPods: aggregates.hostNetworkPods,
+        hostPIDPods: aggregates.hostPIDPods,
+        hostIPCPods: aggregates.hostIPCPods,
+      },
+      networkPolicyCoverage,
+      nsaCisRollups: aggregates.nsaCisRollups,
+    };
+
+    logger.info('Security posture collected successfully', {
+      collectionId: posture.collectionId,
+      clusterId: posture.clusterId,
+      privilegedContainers: posture.privilegedHost.privilegedContainers,
+      namespacesTotal: posture.networkPolicyCoverage.namespacesTotal,
+      namespacesWithNetworkPolicy: posture.networkPolicyCoverage.namespacesWithNetworkPolicy,
+    });
+
+    return posture;
+  }
+
+  async processCollection(posture: SecurityPosture): Promise<void> {
+    try {
+      const validated = validateSecurityPosture(posture);
+
+      const payload: CollectionPayload = {
+        version: 'v1.0.0',
+        type: 'security-posture',
+        data: validated,
+        sanitization: {
+          rulesApplied: ['bounded-counts', 'closed-nsa-cis-rollups', 'hashed-cluster-id'],
+          timestamp: new Date().toISOString(),
+        },
+      };
+
+      logger.info('Persisting security posture collection', {
+        collectionId: validated.collectionId,
+      });
+      const inserted = persistCollection(this.collectionRepository, payload);
+      if (!inserted) {
+        throw new Error(`Failed to persist security posture collection: ${validated.collectionId}`);
+      }
+
+      logger.info('Security posture collection processed successfully', {
+        collectionId: validated.collectionId,
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error('Failed to process security posture collection', {
+        error: errorMessage,
+        collectionId: posture.collectionId,
+      });
+      throw error;
+    }
+  }
+
+  private generateCollectionId(): string {
+    return `coll_${randomBytes(16).toString('hex')}`;
+  }
+}

--- a/src/collection/validation.ts
+++ b/src/collection/validation.ts
@@ -7,6 +7,8 @@ import type {
   ResourceInventory,
   ResourceConfigurationPatternsData,
   PerformanceMetrics,
+  SecurityPosture,
+  SecurityPostureNsaCisRollups,
 } from './types.js';
 
 /**
@@ -538,6 +540,145 @@ export function validatePerformanceMetrics(data: unknown): PerformanceMetrics {
     source: { available, ...(reason !== undefined ? { reason } : {}) },
     ...(utilization !== undefined ? { utilization } : {}),
     ...(ratios !== undefined ? { ratios } : {}),
+  };
+}
+
+const NSA_CIS_ROLLUP_KEYS = [
+  'allowPrivilegeEscalationTrueContainers',
+  'runAsNonRootFalseContainers',
+  'readOnlyRootFilesystemFalseContainers',
+  'capabilitiesNotDroppedAllContainers',
+  'automountServiceAccountTokenTruePods',
+  'hostNamespacesPods',
+] as const satisfies ReadonlyArray<keyof SecurityPostureNsaCisRollups>;
+
+function validateNsaCisRollups(data: unknown): SecurityPostureNsaCisRollups {
+  const obj = assertObject(data, 'nsaCisRollups');
+  const keys = Object.keys(obj);
+  if (keys.length !== NSA_CIS_ROLLUP_KEYS.length) {
+    throw new ValidationError(
+      'nsaCisRollups',
+      `expected exactly ${NSA_CIS_ROLLUP_KEYS.length} keys, got ${keys.length}`
+    );
+  }
+
+  const rollups = {} as SecurityPostureNsaCisRollups;
+  for (const key of NSA_CIS_ROLLUP_KEYS) {
+    if (!(key in obj)) {
+      throw new ValidationError(`nsaCisRollups.${key}`, 'required key missing');
+    }
+    const value = assertInteger(obj[key], `nsaCisRollups.${key}`);
+    if (value < 0) {
+      throw new ValidationError(`nsaCisRollups.${key}`, `expected integer >= 0, got ${value}`);
+    }
+    rollups[key] = value;
+  }
+
+  for (const key of keys) {
+    if (!(NSA_CIS_ROLLUP_KEYS as readonly string[]).includes(key)) {
+      throw new ValidationError(`nsaCisRollups.${key}`, 'unknown rollup key');
+    }
+  }
+
+  return rollups;
+}
+
+/**
+ * Validates security posture against schema
+ */
+export function validateSecurityPosture(data: unknown): SecurityPosture {
+  const obj = assertObject(data, 'root');
+
+  const timestamp = assertString(obj.timestamp, 'timestamp');
+  assertISO8601Timestamp(timestamp, 'timestamp');
+
+  const collectionId = assertString(obj.collectionId, 'collectionId');
+  assertPattern(collectionId, /^coll_[a-z0-9]{32}$/, 'collectionId', 'collection ID format "coll_[32-char-hash]"');
+
+  const clusterId = assertString(obj.clusterId, 'clusterId');
+  assertPattern(clusterId, /^cls_[a-z0-9]{32}$/, 'clusterId', 'cluster ID format "cls_[32-char-hash]"');
+
+  const privilegedHostObj = assertObject(obj.privilegedHost, 'privilegedHost');
+  const privilegedContainers = assertInteger(
+    privilegedHostObj.privilegedContainers,
+    'privilegedHost.privilegedContainers'
+  );
+  const hostPathVolumes = assertInteger(privilegedHostObj.hostPathVolumes, 'privilegedHost.hostPathVolumes');
+  const hostNetworkPods = assertInteger(privilegedHostObj.hostNetworkPods, 'privilegedHost.hostNetworkPods');
+
+  for (const [field, value] of [
+    ['privilegedHost.privilegedContainers', privilegedContainers],
+    ['privilegedHost.hostPathVolumes', hostPathVolumes],
+    ['privilegedHost.hostNetworkPods', hostNetworkPods],
+  ] as const) {
+    if (value < 0) {
+      throw new ValidationError(field, `expected integer >= 0, got ${value}`);
+    }
+  }
+
+  let hostPIDPods: number | undefined;
+  if (privilegedHostObj.hostPIDPods !== undefined) {
+    hostPIDPods = assertInteger(privilegedHostObj.hostPIDPods, 'privilegedHost.hostPIDPods');
+    if (hostPIDPods < 0) {
+      throw new ValidationError('privilegedHost.hostPIDPods', `expected integer >= 0, got ${hostPIDPods}`);
+    }
+  }
+
+  let hostIPCPods: number | undefined;
+  if (privilegedHostObj.hostIPCPods !== undefined) {
+    hostIPCPods = assertInteger(privilegedHostObj.hostIPCPods, 'privilegedHost.hostIPCPods');
+    if (hostIPCPods < 0) {
+      throw new ValidationError('privilegedHost.hostIPCPods', `expected integer >= 0, got ${hostIPCPods}`);
+    }
+  }
+
+  const networkPolicyCoverageObj = assertObject(obj.networkPolicyCoverage, 'networkPolicyCoverage');
+  const namespacesTotal = assertInteger(
+    networkPolicyCoverageObj.namespacesTotal,
+    'networkPolicyCoverage.namespacesTotal'
+  );
+  const namespacesWithNetworkPolicy = assertInteger(
+    networkPolicyCoverageObj.namespacesWithNetworkPolicy,
+    'networkPolicyCoverage.namespacesWithNetworkPolicy'
+  );
+
+  if (namespacesTotal < 0) {
+    throw new ValidationError('networkPolicyCoverage.namespacesTotal', `expected integer >= 0, got ${namespacesTotal}`);
+  }
+  if (namespacesWithNetworkPolicy < 0) {
+    throw new ValidationError(
+      'networkPolicyCoverage.namespacesWithNetworkPolicy',
+      `expected integer >= 0, got ${namespacesWithNetworkPolicy}`
+    );
+  }
+
+  let coverageRatio: number | undefined;
+  if (networkPolicyCoverageObj.coverageRatio !== undefined) {
+    coverageRatio = assertRatio(
+      networkPolicyCoverageObj.coverageRatio,
+      'networkPolicyCoverage.coverageRatio'
+    );
+  }
+
+  const nsaCisRollups = validateNsaCisRollups(obj.nsaCisRollups);
+
+  return {
+    timestamp,
+    collectionId,
+    clusterId,
+    privilegedHost: {
+      privilegedContainers,
+      hostPathVolumes,
+      hostNetworkPods,
+      ...(hostPIDPods !== undefined ? { hostPIDPods } : {}),
+      ...(hostIPCPods !== undefined ? { hostIPCPods } : {}),
+    },
+    networkPolicyCoverage: {
+      namespacesTotal,
+      namespacesWithNetworkPolicy,
+      ...(coverageRatio !== undefined ? { coverageRatio } : {}),
+    },
+    nsaCisRollups,
   };
 }
 

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -230,3 +230,42 @@ describe('loadConfig — performance metrics / Prometheus', () => {
     await expect(loadConfig()).rejects.toThrow(/PROMETHEUS_TIMEOUT_MS/);
   });
 });
+
+describe('loadConfig — security posture interval', () => {
+  const keys = ['SECURITY_POSTURE_INTERVAL_SECONDS'] as const;
+  const snapshots: Partial<Record<(typeof keys)[number], string | undefined>> = {};
+
+  beforeEach(() => {
+    for (const key of keys) {
+      snapshots[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of keys) {
+      const v = snapshots[key];
+      if (v === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = v;
+      }
+    }
+  });
+
+  it('defaults security posture interval to 86400 seconds', async () => {
+    const config = await loadConfig();
+    expect(config.securityPostureIntervalSeconds).toBe(86400);
+  });
+
+  it('accepts SECURITY_POSTURE_INTERVAL_SECONDS at minimum 3600', async () => {
+    process.env.SECURITY_POSTURE_INTERVAL_SECONDS = '3600';
+    const config = await loadConfig();
+    expect(config.securityPostureIntervalSeconds).toBe(3600);
+  });
+
+  it('rejects security posture interval below minimum', async () => {
+    process.env.SECURITY_POSTURE_INTERVAL_SECONDS = '3599';
+    await expect(loadConfig()).rejects.toThrow(/SECURITY_POSTURE_INTERVAL_SECONDS/);
+  });
+});

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -16,6 +16,8 @@ const RESOURCE_INVENTORY_INTERVAL_MIN_SECONDS = 1800;
 const ARGOCD_APP_STATUS_INTERVAL_MIN_SECONDS = 1800;
 /** Minimum interval for performance metrics collection (5 minutes). */
 const PERFORMANCE_METRICS_INTERVAL_MIN_SECONDS = 300;
+/** Minimum interval for security posture collection (1 hour). */
+const SECURITY_POSTURE_INTERVAL_MIN_SECONDS = 3600;
 
 /**
  * Parses a positive base-10 integer from env or a default string.
@@ -191,6 +193,12 @@ export async function loadConfig(): Promise<Config> {
     '900',
     PERFORMANCE_METRICS_INTERVAL_MIN_SECONDS
   );
+  const securityPostureIntervalSeconds = parsePositiveInt(
+    'SECURITY_POSTURE_INTERVAL_SECONDS',
+    process.env.SECURITY_POSTURE_INTERVAL_SECONDS,
+    '86400',
+    SECURITY_POSTURE_INTERVAL_MIN_SECONDS
+  );
   const prometheus = parsePrometheusConfigFromEnv();
 
   const config: Config = {
@@ -214,6 +222,7 @@ export async function loadConfig(): Promise<Config> {
     aiConformanceIntervalSeconds,
     aiConformanceChecklistSource,
     performanceMetricsIntervalSeconds,
+    securityPostureIntervalSeconds,
     ...(prometheus !== undefined ? { prometheus } : {}),
   };
 
@@ -259,6 +268,12 @@ export async function loadConfig(): Promise<Config> {
       process.env.PERFORMANCE_METRICS_INTERVAL_SECONDS !== undefined,
     prometheusConfigured: config.prometheus !== undefined,
     prometheusBaseUrl: config.prometheus?.baseUrl ?? null,
+  });
+
+  logger.info('Security posture schedule configured', {
+    securityPostureIntervalSeconds: config.securityPostureIntervalSeconds,
+    securityPostureIntervalOverridden:
+      process.env.SECURITY_POSTURE_INTERVAL_SECONDS !== undefined,
   });
 
   return config;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -111,6 +111,12 @@ export interface Config {
   performanceMetricsIntervalSeconds: number;
 
   /**
+   * Security posture collection interval in seconds (always-on cluster-API aggregates).
+   * Default: 86400 (24 hours). Minimum: 3600 (1 hour).
+   */
+  securityPostureIntervalSeconds: number;
+
+  /**
    * Optional Prometheus outbound client. Present only when PROMETHEUS_BASE_URL is non-empty.
    */
   prometheus?: PrometheusClientConfig;

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -14,6 +14,7 @@ import { ClusterMetadataCollector } from './collection/collectors/cluster-metada
 import { ResourceInventoryCollector } from './collection/collectors/resource-inventory.js';
 import { ResourceConfigurationPatternsCollector } from './collection/collectors/resource-configuration-patterns.js';
 import { PerformanceMetricsCollector } from './collection/collectors/performance-metrics.js';
+import { SecurityPostureCollector } from './collection/collectors/security-posture.js';
 import { CollectionRepository } from './database/collection-repository.js';
 import { recordCollection } from './collection/metrics.js';
 import { collectionStatsTracker } from './collection/stats-tracker.js';
@@ -332,6 +333,41 @@ export async function startOperator() {
         }
       }
     );
+
+    try {
+      const securityPostureCollector = new SecurityPostureCollector(
+        kubernetesClient,
+        collectionRepository
+      );
+
+      collectionScheduler.register(
+        'security-posture',
+        config.securityPostureIntervalSeconds,
+        3600,
+        3600,
+        async () => {
+          const startTime = Date.now();
+          try {
+            const posture = await securityPostureCollector.collect();
+            await securityPostureCollector.processCollection(posture);
+
+            const durationSeconds = (Date.now() - startTime) / 1000;
+            recordCollection('security-posture', 'success', durationSeconds);
+            collectionStatsTracker.recordSuccess('security-posture');
+          } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            logger.warn('Security posture collection failed', { error: errorMessage });
+
+            const durationSeconds = (Date.now() - startTime) / 1000;
+            recordCollection('security-posture', 'failed', durationSeconds);
+            collectionStatsTracker.recordFailure('security-posture');
+          }
+        }
+      );
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error('Failed to register security-posture collector', { error: errorMessage });
+    }
 
     if (config.prometheus) {
       try {

--- a/src/status/ai-conformance-summary.test.ts
+++ b/src/status/ai-conformance-summary.test.ts
@@ -33,6 +33,7 @@ const baseConfig: Config = {
   aiConformanceIntervalSeconds: 86400,
   aiConformanceChecklistSource: 'bundled',
   performanceMetricsIntervalSeconds: 900,
+  securityPostureIntervalSeconds: 86400,
 };
 
 describe('ai-conformance status summary', () => {


### PR DESCRIPTION
## Description

Implements the always-on security-posture collector for kube9-operator: cluster-API aggregates on a ~24h schedule, durable SQLite persistence, and collection metrics participation.

Closes #170

## Motivation and Context

Operators need bounded `security-posture` history (privileged/host counts, NetworkPolicy coverage, closed six-key `nsaCisRollups`) without depending on Prometheus or Trivy. Failed mid-tick API reads omit rows and increment failed metrics without affecting operator health.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated
- [x] All new and existing tests pass (`npm run test:unit`)
- [x] Linter passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)

## How to Test this Work

```bash
npm install
npm run test:unit
npm run lint
npm run build
```

Key coverage:
- `SecurityPostureCollector` gather + persist + API failure omit path
- `SECURITY_POSTURE_INTERVAL_SECONDS` default 86400 / min 3600 validation
- Closed six-key `nsaCisRollups` accept/reject via validation and schema tests

## How to Validate this Work

Serve with core collectors; confirm security-posture registers without Prometheus/Trivy. After a successful tick, `query collections list --type security-posture --format json` returns privilegedHost, networkPolicyCoverage, and six rollup keys.

## Additional Notes

Helm wiring for `metrics.intervals.securityPosture` remains in #171 (out of scope here).