### PR TITLE
feat(helm): wire performance and security-posture collector intervals (#171)

### DIFF
--- a/charts/kube9-operator/README.md
+++ b/charts/kube9-operator/README.md
@@ -107,6 +107,8 @@ The following table lists the configurable parameters and their default values:
 | `metrics.intervals.clusterMetadata` | Cluster metadata collection interval (seconds). Default 86400 (24h), minimum 3600 (1h) | `86400` |
 | `metrics.intervals.resourceInventory` | Resource inventory collection interval (seconds). Default 21600 (6h), minimum 1800 (30m) | `21600` |
 | `metrics.intervals.resourceConfigurationPatterns` | Resource configuration patterns collection interval (seconds). Default 43200 (12h), minimum 3600 (1h) | `43200` |
+| `metrics.intervals.performanceMetrics` | Performance metrics collection interval (seconds). Default 900 (15m), minimum 300 (5m). Requires optional Prometheus (`prometheus.baseUrl`) | `900` |
+| `metrics.intervals.securityPosture` | Security posture collection interval (seconds). Default 86400 (24h), minimum 3600 (1h). Cluster API only | `86400` |
 | `events.persistence.enabled` | Enable PersistentVolume for event storage. When false, uses emptyDir (data lost on pod restart) | `true` |
 | `events.persistence.size` | PVC size for event database | `5Gi` |
 | `events.persistence.storageClassName` | Storage class for PVC. Empty uses cluster default | `""` |
@@ -138,6 +140,9 @@ The following table lists the configurable parameters and their default values:
 | `trivy.vulnMaxHigh` | `VULN_MAX_HIGH` | `1000000` |
 | `trivy.vulnMaxMedium` | `VULN_MAX_MEDIUM` | `1000000` |
 | `metrics.intervals.workloadImageScan` | Seconds between workload image collection / scan cycles | `86400` |
+| `prometheus.baseUrl` | Optional Prometheus base URL for performance-metrics collector. Empty = default-off (no outbound Prometheus; pod stays Ready) | `""` |
+| `prometheus.timeoutMs` | `PROMETHEUS_TIMEOUT_MS` — HTTP timeout for Prometheus queries | `30000` |
+| `prometheus.tlsInsecure` | `PROMETHEUS_TLS_INSECURE` — skip TLS verification (labs only) | `false` |
 
 ### Configuration Details
 
@@ -188,11 +193,32 @@ Controls how often the operator collects different types of metrics data. All va
 | `clusterMetadata` | 86400 | 3600 | 24h / 1h |
 | `resourceInventory` | 21600 | 1800 | 6h / 30m |
 | `resourceConfigurationPatterns` | 43200 | 3600 | 12h / 1h |
+| `performanceMetrics` | 900 | 300 | 15m / 5m |
+| `securityPosture` | 86400 | 3600 | 24h / 1h |
+
+**Collection type labels:** Prometheus collection metrics and CLI filters use a closed five-type set: `cluster-metadata`, `resource-inventory`, `resource-configuration-patterns`, `performance-metrics`, `security-posture`. Status ConfigMap `collectionStats` stays aggregate-only (no required per-type status fields).
+
+**Performance vs security posture:**
+
+- **performance-metrics** — optional outbound Prometheus PromQL when `prometheus.baseUrl` is set. Default install (empty URL) does not register performance ticks; readiness does not depend on Prometheus.
+- **security-posture** — cluster API aggregates only (NetworkPolicy, RBAC, etc.). Always registered at the configured interval.
 
 **Usage scenarios:**
 
 - **Production**: Use defaults. Balances freshness with API load and cluster impact.
 - **Testing/debugging**: Override with shorter intervals within the minimums to get faster feedback during development or troubleshooting.
+
+#### Optional Prometheus (`prometheus.*`)
+
+Optional in-cluster Prometheus HTTP client for the **performance-metrics** collector. Mirrors the optional-integration pattern used by `trivy.*` and `argocd.api.*`:
+
+| Value | Default | Env | Notes |
+|-------|---------|-----|-------|
+| `baseUrl` | `""` | `PROMETHEUS_BASE_URL` | Emitted only when non-empty. Empty = default-off; no performance collector ticks. |
+| `timeoutMs` | `30000` | `PROMETHEUS_TIMEOUT_MS` | Minimum 1000 ms. |
+| `tlsInsecure` | `false` | `PROMETHEUS_TLS_INSECURE` | Labs / mis-signed certs only. |
+
+The chart does **not** install Prometheus, create ServiceMonitors for Prometheus ownership, or mount Secrets for Prometheus credentials in v1. Traffic is outbound cluster-internal when configured. Default install stays zero-ingress and reaches Ready without Prometheus.
 
 #### Event Storage and Retention (`events.*`)
 
@@ -214,6 +240,8 @@ The operator stores Kubernetes events in a SQLite database for insights and dash
 **Agent and Desktop query consumers:** [kube9-vscode](https://github.com/alto9/kube9-vscode) and [kube9-desktop](https://github.com/alto9/kube9-desktop) Pro AI agent Tier 2 tools read operator history via `kubectl exec` → `kube9-operator query events list` and `query assessments history` (same RBAC model; no Desktop→operator HTTP). When citing Operator-stored event history, product copy must reflect the **severity-split** defaults (**7** days info/warning, **30** days error/critical), not a single unified day count. Bound queries with `--since` / `--until` (ISO-8601 on the operator CLI) against still-stored rows; pruned, absent, or ephemeral-store gaps are normal.
 
 **Assessment history (agent/Desktop consumers):** Well-Architected check history is available via `kube9-operator query assessments history`. It is a **posture / historical check signal**, not a live incident log stream. Assessment rows are **not** time-pruned by `RetentionCleanup`; they persist until explicit remove or cascade delete of the parent assessment run. A successful query that returns an empty `history` array is a normal evidence gap, not an operator error.
+
+**Collections disk growth:** SQLite `collections` rows (cluster metadata, inventory, configuration patterns, performance metrics, security posture) have **no TTL or count cap** in the chart. Expect PVC growth under frequent append-only collectors, notably ~15m performance-metrics ticks when `prometheus.baseUrl` is set. Size the PVC operationally; there is no chart prune knob in this release.
 
 **Log evidence (explicit non-goal):** This operator does **not** expose `query logs*` (or equivalent) for agent or extension consumers. Pod and workload container logs for debugging agents come from live Kubernetes API reads in the client (Desktop Tier 1), not from operator SQLite history.
 
@@ -631,6 +659,8 @@ Complete reference of all configurable values:
 | `metrics.intervals.clusterMetadata` | Cluster metadata collection interval (seconds). Default 86400 (24h), minimum 3600 (1h) | `86400` |
 | `metrics.intervals.resourceInventory` | Resource inventory collection interval (seconds). Default 21600 (6h), minimum 1800 (30m) | `21600` |
 | `metrics.intervals.resourceConfigurationPatterns` | Resource configuration patterns collection interval (seconds). Default 43200 (12h), minimum 3600 (1h) | `43200` |
+| `metrics.intervals.performanceMetrics` | Performance metrics collection interval (seconds). Default 900 (15m), minimum 300 (5m). Requires optional Prometheus (`prometheus.baseUrl`) | `900` |
+| `metrics.intervals.securityPosture` | Security posture collection interval (seconds). Default 86400 (24h), minimum 3600 (1h). Cluster API only | `86400` |
 | `events.persistence.enabled` | Enable PersistentVolume for event storage. When false, uses emptyDir | `true` |
 | `events.persistence.size` | PVC size for event database | `5Gi` |
 | `events.persistence.storageClassName` | Storage class for PVC. Empty uses cluster default | `""` |
@@ -651,6 +681,9 @@ Complete reference of all configurable values:
 | `argocd.api.token.existingSecretKey` | Key within `existingSecret` holding the bearer token | `token` |
 | `argocd.api.tokenFile` | Advanced: override `ARGOCD_API_TOKEN_FILE` path without chart-managed Secret mount | (unset) |
 | `metrics.intervals.argocdApplicationStatus` | Argo CD Application API collection interval (seconds); minimum 1800 | `3600` |
+| `prometheus.baseUrl` | Optional Prometheus base URL for performance-metrics collector. Empty = default-off | `""` |
+| `prometheus.timeoutMs` | `PROMETHEUS_TIMEOUT_MS` — HTTP timeout for Prometheus queries | `30000` |
+| `prometheus.tlsInsecure` | `PROMETHEUS_TLS_INSECURE` — skip TLS verification (labs only) | `false` |
 
 ## Additional Resources
 

--- a/charts/kube9-operator/performance-metrics-helm.test.ts
+++ b/charts/kube9-operator/performance-metrics-helm.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+
+const chartDir = path.join(process.cwd(), 'charts/kube9-operator');
+
+function renderChart(extraArgs = ''): string | undefined {
+  try {
+    return execSync(
+      `helm template kube9-operator ${chartDir} --namespace kube9-system ${extraArgs}`.trim(),
+      { encoding: 'utf8', timeout: 15_000 }
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+describe('kube9-operator Helm chart performance-metrics and security-posture wiring', () => {
+  it('renders interval env vars on default install', () => {
+    const rendered = renderChart();
+    if (!rendered) {
+      return;
+    }
+
+    expect(rendered).toContain('name: PERFORMANCE_METRICS_INTERVAL_SECONDS');
+    expect(rendered).toContain('value: "900"');
+    expect(rendered).toContain('name: SECURITY_POSTURE_INTERVAL_SECONDS');
+    expect(rendered).toContain('value: "86400"');
+  });
+
+  it('does not emit PROMETHEUS_BASE_URL when prometheus.baseUrl is empty', () => {
+    const rendered = renderChart();
+    if (!rendered) {
+      return;
+    }
+
+    expect(rendered).not.toContain('name: PROMETHEUS_BASE_URL');
+    expect(rendered).toContain('name: PROMETHEUS_TIMEOUT_MS');
+    expect(rendered).toContain('name: PROMETHEUS_TLS_INSECURE');
+  });
+
+  it('emits Prometheus env when prometheus.baseUrl is set', () => {
+    const rendered = renderChart(
+      '--set prometheus.baseUrl=http://prometheus.monitoring.svc:9090'
+    );
+    if (!rendered) {
+      return;
+    }
+
+    expect(rendered).toContain('name: PROMETHEUS_BASE_URL');
+    expect(rendered).toContain('value: "http://prometheus.monitoring.svc:9090"');
+    expect(rendered).toContain('name: PROMETHEUS_TIMEOUT_MS');
+    expect(rendered).toContain('value: "30000"');
+    expect(rendered).toContain('name: PROMETHEUS_TLS_INSECURE');
+    expect(rendered).toContain('value: "false"');
+  });
+
+  it('honors interval overrides via metrics.intervals values', () => {
+    const rendered = renderChart(
+      '--set metrics.intervals.performanceMetrics=600 --set metrics.intervals.securityPosture=7200'
+    );
+    if (!rendered) {
+      return;
+    }
+
+    expect(rendered).toContain('value: "600"');
+    expect(rendered).toContain('value: "7200"');
+  });
+
+  it('documents dual-purpose NetworkPolicy ClusterRole grant', () => {
+    const rendered = renderChart();
+    if (!rendered) {
+      return;
+    }
+
+    expect(rendered).toContain('security-posture NetworkPolicy coverage');
+    expect(rendered).toContain('apiGroups: ["networking.k8s.io"]');
+    expect(rendered).toContain('resources: ["networkpolicies"]');
+  });
+});

--- a/charts/kube9-operator/templates/clusterrole.yaml
+++ b/charts/kube9-operator/templates/clusterrole.yaml
@@ -31,7 +31,7 @@ rules:
 - apiGroups: ["policy"]
   resources: ["poddisruptionbudgets"]
   verbs: ["get", "list", "watch"]
-# Read NetworkPolicies (ai-conformance security.network-policy-default-deny)
+# Read NetworkPolicies (AI conformance security.network-policy-default-deny + security-posture NetworkPolicy coverage)
 - apiGroups: ["networking.k8s.io"]
   resources: ["networkpolicies"]
   verbs: ["get", "list", "watch"]

--- a/charts/kube9-operator/templates/deployment.yaml
+++ b/charts/kube9-operator/templates/deployment.yaml
@@ -52,6 +52,10 @@ spec:
           value: {{ .Values.metrics.intervals.resourceInventory | default 21600 | quote }}
         - name: RESOURCE_CONFIGURATION_PATTERNS_INTERVAL_SECONDS
           value: {{ .Values.metrics.intervals.resourceConfigurationPatterns | default 43200 | quote }}
+        - name: PERFORMANCE_METRICS_INTERVAL_SECONDS
+          value: {{ .Values.metrics.intervals.performanceMetrics | default 900 | quote }}
+        - name: SECURITY_POSTURE_INTERVAL_SECONDS
+          value: {{ .Values.metrics.intervals.securityPosture | default 86400 | quote }}
         # ArgoCD configuration
         - name: ARGOCD_AUTO_DETECT
           value: {{ .Values.argocd.autoDetect | quote }}
@@ -124,6 +128,16 @@ spec:
           value: {{ .Values.trivy.vulnMaxMedium | quote }}
         - name: WORKLOAD_IMAGE_SCAN_INTERVAL_SECONDS
           value: {{ .Values.metrics.intervals.workloadImageScan | default 86400 | quote }}
+        # Optional Prometheus client (performance-metrics collector; outbound only)
+        {{- $prometheus := .Values.prometheus | default dict }}
+        {{- if $prometheus.baseUrl }}
+        - name: PROMETHEUS_BASE_URL
+          value: {{ $prometheus.baseUrl | quote }}
+        {{- end }}
+        - name: PROMETHEUS_TIMEOUT_MS
+          value: {{ $prometheus.timeoutMs | default 30000 | quote }}
+        - name: PROMETHEUS_TLS_INSECURE
+          value: {{ $prometheus.tlsInsecure | default false | quote }}
         # Periodic assessment schedule (see assessment.* in values.yaml)
         {{- $assessment := .Values.assessment | default dict }}
         - name: ASSESSMENT_ENABLED

--- a/charts/kube9-operator/values.schema.json
+++ b/charts/kube9-operator/values.schema.json
@@ -100,9 +100,44 @@
               "description": "Argo CD Application API status collection interval in seconds. Default: 3600 (1 hour). Minimum: 1800 (30 minutes).",
               "minimum": 1800,
               "default": 3600
+            },
+            "performanceMetrics": {
+              "type": "integer",
+              "description": "Performance metrics collection interval in seconds. Default: 900 (15 minutes). Minimum: 300 (5 minutes). Requires optional Prometheus client (prometheus.baseUrl).",
+              "minimum": 300,
+              "default": 900
+            },
+            "securityPosture": {
+              "type": "integer",
+              "description": "Security posture collection interval in seconds. Default: 86400 (24 hours). Minimum: 3600 (1 hour). Cluster API only.",
+              "minimum": 3600,
+              "default": 86400
             }
           },
           "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "prometheus": {
+      "type": "object",
+      "description": "Optional Prometheus HTTP client for performance-metrics collector (outbound; chart does not install Prometheus)",
+      "properties": {
+        "baseUrl": {
+          "type": "string",
+          "default": "",
+          "description": "Prometheus base URL. Empty = default-off (no PROMETHEUS_BASE_URL env; performance collector not registered)."
+        },
+        "timeoutMs": {
+          "type": "integer",
+          "minimum": 1000,
+          "default": 30000,
+          "description": "PROMETHEUS_TIMEOUT_MS — HTTP timeout for Prometheus queries"
+        },
+        "tlsInsecure": {
+          "type": "boolean",
+          "default": false,
+          "description": "PROMETHEUS_TLS_INSECURE — skip TLS verification (labs only)"
         }
       },
       "additionalProperties": false

--- a/charts/kube9-operator/values.yaml
+++ b/charts/kube9-operator/values.yaml
@@ -106,6 +106,19 @@ metrics:
     workloadImageScan: 86400
     # Argo CD Application API collection (default 3600 = 1h, minimum 1800 = 30m)
     argocdApplicationStatus: 3600
+    # Performance metrics collection interval (default 900 = 15m, minimum 300 = 5m)
+    # Requires optional Prometheus client (prometheus.baseUrl); cluster-API only when unset
+    performanceMetrics: 900
+    # Security posture collection interval (default 86400 = 24h, minimum 3600 = 1h)
+    # Uses cluster API only (NetworkPolicy, RBAC, etc.); no Prometheus required
+    securityPosture: 86400
+
+# Optional Prometheus HTTP client for performance-metrics collector (does not install Prometheus)
+prometheus:
+  # baseUrl: "http://prometheus.monitoring.svc:9090"
+  baseUrl: ""
+  timeoutMs: 30000
+  tlsInsecure: false
 
 # Periodic Well-Architected assessment scheduling (operator reads these at startup)
 assessment:

--- a/scripts/test-helm-chart.sh
+++ b/scripts/test-helm-chart.sh
@@ -107,6 +107,52 @@ else
     exit 1
 fi
 
+if echo "$TEMPLATE_OUTPUT" | grep -q "PERFORMANCE_METRICS_INTERVAL_SECONDS"; then
+    success "PERFORMANCE_METRICS_INTERVAL_SECONDS env present on default install"
+else
+    error "PERFORMANCE_METRICS_INTERVAL_SECONDS env missing from default template"
+    exit 1
+fi
+
+if echo "$TEMPLATE_OUTPUT" | grep -q "SECURITY_POSTURE_INTERVAL_SECONDS"; then
+    success "SECURITY_POSTURE_INTERVAL_SECONDS env present on default install"
+else
+    error "SECURITY_POSTURE_INTERVAL_SECONDS env missing from default template"
+    exit 1
+fi
+
+if echo "$TEMPLATE_OUTPUT" | grep -q "PROMETHEUS_BASE_URL"; then
+    error "PROMETHEUS_BASE_URL must not appear when prometheus.baseUrl is empty"
+    exit 1
+else
+    success "PROMETHEUS_BASE_URL correctly absent on default install"
+fi
+
+PROMETHEUS_TEMPLATE=$(helm template "$RELEASE_NAME" "$CHART_DIR" \
+    --namespace "$NAMESPACE" \
+    --set prometheus.baseUrl=http://prometheus.monitoring.svc:9090)
+
+if echo "$PROMETHEUS_TEMPLATE" | grep -q "name: PROMETHEUS_BASE_URL"; then
+    success "PROMETHEUS_BASE_URL env present when prometheus.baseUrl is set"
+else
+    error "PROMETHEUS_BASE_URL env missing when prometheus.baseUrl is set"
+    exit 1
+fi
+
+if echo "$PROMETHEUS_TEMPLATE" | grep -q "name: PROMETHEUS_TIMEOUT_MS"; then
+    success "PROMETHEUS_TIMEOUT_MS env present when prometheus.baseUrl is set"
+else
+    error "PROMETHEUS_TIMEOUT_MS env missing when prometheus.baseUrl is set"
+    exit 1
+fi
+
+if echo "$PROMETHEUS_TEMPLATE" | grep -q "name: PROMETHEUS_TLS_INSECURE"; then
+    success "PROMETHEUS_TLS_INSECURE env present when prometheus.baseUrl is set"
+else
+    error "PROMETHEUS_TLS_INSECURE env missing when prometheus.baseUrl is set"
+    exit 1
+fi
+
 echo ""
 
 # Phase 3: NOTES.txt Validation

--- a/src/collection/metrics.ts
+++ b/src/collection/metrics.ts
@@ -18,7 +18,7 @@ export const register = new Registry();
  * Counter for collection attempts by type and status
  * 
  * Labels:
- * - type: Collection type (e.g., "cluster-metadata", "resource-inventory")
+ * - type: Collection type (cluster-metadata, resource-inventory, resource-configuration-patterns, performance-metrics, security-posture)
  * - status: Collection status ("success" or "failed")
  */
 const collectionTotal = new Counter({
@@ -32,7 +32,7 @@ const collectionTotal = new Counter({
  * Histogram for collection duration in seconds
  * 
  * Labels:
- * - type: Collection type (e.g., "cluster-metadata", "resource-inventory")
+ * - type: Collection type (cluster-metadata, resource-inventory, resource-configuration-patterns, performance-metrics, security-posture)
  * 
  * Buckets: [0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120] seconds
  */
@@ -48,7 +48,7 @@ const collectionDurationSeconds = new Histogram({
  * Gauge for last successful collection timestamp (Unix epoch seconds)
  * 
  * Labels:
- * - type: Collection type (e.g., "cluster-metadata", "resource-inventory")
+ * - type: Collection type (cluster-metadata, resource-inventory, resource-configuration-patterns, performance-metrics, security-posture)
  */
 const collectionLastSuccess = new Gauge({
   name: 'kube9_operator_collection_last_success',
@@ -60,7 +60,7 @@ const collectionLastSuccess = new Gauge({
 /**
  * Records a collection attempt with metrics
  * 
- * @param type - Collection type (e.g., "cluster-metadata", "resource-inventory")
+ * @param type - Collection type (cluster-metadata, resource-inventory, resource-configuration-patterns, performance-metrics, security-posture)
  * @param status - Collection status ("success" or "failed")
  * @param durationSeconds - Duration of the collection operation in seconds
  */


### PR DESCRIPTION
## Description

Wire Helm chart values, Deployment env mapping, schema, README, and harness assertions for the performance-metrics and security-posture collectors added in #169/#170.

## Motivation and Context

Fixes #171

Cluster operators installing via Helm need chart values and RBAC/ops surfaces that expose the peer-locked env contracts for both collectors while keeping default installs zero-ingress and Ready without Prometheus.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated
- [x] All new and existing tests pass (`npm test`)
- [x] Linter passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] Chart unit tests (`npm test -- charts/kube9-operator`)
- [x] Helm harness Phases 1–4 (`./scripts/test-helm-chart.sh`; Phase 5 skipped without kind)

## How to Test this Work

```bash
npm install
npm run test:unit
npm run lint
npm run build
npm test -- charts/kube9-operator
./scripts/test-helm-chart.sh
```

Verify default `helm template` includes `PERFORMANCE_METRICS_INTERVAL_SECONDS` and `SECURITY_POSTURE_INTERVAL_SECONDS`, omits `PROMETHEUS_BASE_URL`, and emits Prometheus env when `--set prometheus.baseUrl=http://prometheus.monitoring.svc:9090`.

## How to Validate this Work

1. Install chart with defaults; operator pod reaches Ready without Prometheus.
2. Confirm README documents interval keys, `prometheus.*`, collections no-TTL / PVC growth note.
3. Confirm ClusterRole NetworkPolicy comment names AI conformance and security-posture coverage (no new rules).

## Additional Notes

- No ClusterRole rule expansion; Prometheus v1 ships URL/timeout/TLS only (no Secret mount).
- Collection metric `type` label docs aligned to closed five-type set.